### PR TITLE
Feature/url rewrite feature toggle

### DIFF
--- a/helm_deploy/prisoner-content-hub-frontend/templates/deployment.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
             - name: ANALYTICS_SITE_ID
               value: {{ .Values.application.config.analyticsSiteId }}
             - name: FEATURE_USE_RELATIVE_URL
-              value: {{ .Values.application.config.useRelativeUrl | quote }}
+              value: {{ .Values.application.config.useRelativeUrlForMedia | quote }}
           ports:
             - name: http
               containerPort: {{ .Values.application.port }}

--- a/helm_deploy/prisoner-content-hub-frontend/templates/deployment.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/templates/deployment.yaml
@@ -73,6 +73,8 @@ spec:
               value: {{ .Values.application.config.analyticsEndpoint }}
             - name: ANALYTICS_SITE_ID
               value: {{ .Values.application.config.analyticsSiteId }}
+            - name: FEATURE_USE_RELATIVE_URL
+              value: {{ .Values.application.config.useRelativeUrl | quote }}
           ports:
             - name: http
               containerPort: {{ .Values.application.port }}

--- a/helm_deploy/prisoner-content-hub-frontend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.yaml
@@ -30,6 +30,7 @@ application:
     establishmentName: berwyn
     nprStream: /npr-stream
     analyticsEndpoint: https://www.google-analytics.com/collect
+    useRelativeUrl: false
   contentConfigMap: prisoner-content-hub-drupal
 
 imagePullSecrets: [] # Are we using ECR?

--- a/helm_deploy/prisoner-content-hub-frontend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.yaml
@@ -30,7 +30,7 @@ application:
     establishmentName: berwyn
     nprStream: /npr-stream
     analyticsEndpoint: https://www.google-analytics.com/collect
-    useRelativeUrl: false
+    useRelativeUrlForMedia: false
   contentConfigMap: prisoner-content-hub-drupal
 
 imagePullSecrets: [] # Are we using ECR?

--- a/server/config.js
+++ b/server/config.js
@@ -84,6 +84,7 @@ module.exports = {
   dev: !isProduction && !isTest,
   test: isTest,
   production: isProduction,
+  useRelativeUrl: getEnv('FEATURE_USE_RELATIVE_URL', 'true') === 'true',
   backendUrl,
   buildInfo: {
     buildNumber: getEnv('BUILD_NUMBER', '9999999'),

--- a/server/utils/adapters.js
+++ b/server/utils/adapters.js
@@ -210,7 +210,7 @@ function pdfResponseFrom(data) {
     id: data.id,
     title: data.title,
     contentType: typeFrom(data.content_type),
-    url: R.path(['media', 'url'], data),
+    url: fixUrlForProduction(R.path(['media', 'url'], data)),
     establishmentIds: R.map(R.prop('target_id'), R.propOr([], 'prisons', data)),
     contentUrl: `/content/${data.id}`,
   };

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -70,10 +70,7 @@ function relativeUrlFrom(url = '', override) {
 }
 
 function fixUrlForProduction(url, config = defaultConfig) {
-  if (config.useRelativeUrl) {
-    return relativeUrlFrom(url);
-  }
-  return url;
+  return config.useRelativeUrl ? relativeUrlFrom(url) : url;
 }
 
 function capitalizeAll(input, separator = ' ') {

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -70,7 +70,7 @@ function relativeUrlFrom(url = '', override) {
 }
 
 function fixUrlForProduction(url, config = defaultConfig) {
-  if (config.production) {
+  if (config.useRelativeUrl) {
     return relativeUrlFrom(url);
   }
   return url;

--- a/test/resources/featuredItems.json
+++ b/test/resources/featuredItems.json
@@ -43,7 +43,7 @@
       "summary": "Featured Item Summary",
       "image": {
         "alt": "Featured Item",
-        "url": "http://foo.bar/images/foo.jpg"
+        "url": "/images/foo.jpg"
       },
       "contentType": "landing_page",
       "contentUrl": "/content/1234",
@@ -97,7 +97,7 @@
       "summary": "Featured Item Summary",
       "image": {
         "alt": "Featured Item",
-        "url": "http://foo.bar/images/foo.jpg"
+        "url": "/images/foo.jpg"
       },
       "contentType": "moj_video_item",
       "contentUrl": "/content/1234",
@@ -151,7 +151,7 @@
       "summary": "Featured Item Summary",
       "image": {
         "alt": "Featured Item",
-        "url": "http://foo.bar/images/foo.jpg"
+        "url": "/images/foo.jpg"
       },
       "contentType": "moj_video_item",
       "contentUrl": "/content/1234",

--- a/test/resources/flatPageContent.json
+++ b/test/resources/flatPageContent.json
@@ -4,7 +4,7 @@
   "id": 3456,
   "image": {
     "alt": "foo alt",
-    "url": "http://foo.image.png"
+    "url": "http://foo.bar/image/foo.png"
   },
   "description": {
     "value": "<h2>foo text</h2>",

--- a/test/resources/terms.json
+++ b/test/resources/terms.json
@@ -10,7 +10,7 @@
   "summary": "Foo Term summary",
   "image": {
     "alt": "Foo Term",
-    "url": "http://foo.bar/term/"
+    "url": "http://foo.bar/images/foo.jpg"
   },
   "video": null,
   "audio": {

--- a/test/utils/adapters.spec.js
+++ b/test/utils/adapters.spec.js
@@ -151,14 +151,14 @@ function radioContent() {
       summary: 'hello world',
     },
     contentType: 'radio',
-    media: 'http://foo.bar.com/audio.mp3',
+    media: '/audio.mp3',
     episode: 1,
     season: 1,
     episodeId: 1001,
     seriesId: 665,
     image: {
       alt: 'Foo Bar',
-      url: 'http://foo.bar.com/image.png',
+      url: '/image.png',
     },
     secondaryTags: [646],
     categories: [646],
@@ -179,13 +179,13 @@ function videoContent() {
       summary: 'hello world',
     },
     contentType: 'video',
-    media: 'http://foo.bar.com/video.mp4',
+    media: '/video.mp4',
     episode: 2,
     season: 1,
     seriesId: 665,
     image: {
       alt: 'Foo Bar',
-      url: 'http://foo.bar.com/image.png',
+      url: '/image.png',
     },
     secondaryTags: [],
     categories: [],
@@ -207,7 +207,7 @@ function flatPageContent() {
     },
     image: {
       alt: 'foo alt',
-      url: 'http://foo.image.png',
+      url: '/image/foo.png',
     },
     standFirst: 'foo stand first',
     establishmentIds: [],
@@ -232,9 +232,9 @@ function seasonContent() {
       id: '3456',
       image: {
         alt: '',
-        url: 'http://foo.bar/images/foo.jpg',
+        url: '/images/foo.jpg',
       },
-      media: 'http://foo.bar/audio/foo.mp3',
+      media: '/audio/foo.mp3',
       season: '1',
       seriesId: 660,
       secondaryTags: [646],
@@ -256,9 +256,9 @@ function seasonContent() {
       id: '3457',
       image: {
         alt: '',
-        url: 'http://foo.bar/images/bar.jpg',
+        url: '/images/bar.jpg',
       },
-      media: 'http://foo.bar/audio/bar.mp3',
+      media: '/audio/bar.mp3',
       season: '1',
       seriesId: 660,
       secondaryTags: [761],
@@ -283,7 +283,7 @@ function landingPageContent() {
       summary: 'Landing page item summary',
     },
     image: {
-      url: 'http://foo.bar/image/foo.jpg',
+      url: '/image/foo.jpg',
       alt: 'foo image',
     },
   };
@@ -297,7 +297,7 @@ function relatedContent() {
       contentType: 'video',
       summary: 'Item summary 1',
       image: {
-        url: 'http://foo.bar/image/foo.jpg',
+        url: '/image/foo.jpg',
         alt: 'Video Item 1 alt',
       },
       contentUrl: '/content/3456',
@@ -310,7 +310,7 @@ function relatedContent() {
       contentType: 'video',
       summary: 'Item summary 2',
       image: {
-        url: 'http://foo.bar/image/bar.jpg',
+        url: '/image/bar.jpg',
         alt: 'Video Item 2 alt',
       },
       contentUrl: '/content/3457',
@@ -325,7 +325,7 @@ function pdfContent() {
     id: '3456',
     title: 'Food and catering',
     contentType: 'pdf',
-    url: 'http://foo.bar/content/foo.pdf',
+    url: '/content/foo.pdf',
     establishmentIds: [],
     contentUrl: '/content/3456',
   };
@@ -338,7 +338,7 @@ function featuredItem() {
     summary: 'Featured video summary',
     image: {
       alt: 'Featured Video 1',
-      url: 'http://foo.bar/images/foo.jpg',
+      url: '/images/foo.jpg',
     },
     contentType: 'video',
     contentUrl: '/content/3456',
@@ -352,7 +352,7 @@ function featuredSeries() {
     summary: 'Featured item summary',
     image: {
       alt: 'Featured Item 1',
-      url: 'http://foo.bar/images/foo.jpg',
+      url: '/images/foo.jpg',
     },
     contentType: 'series',
     contentUrl: '/tags/678',
@@ -362,7 +362,7 @@ function featuredSeries() {
 function termContent() {
   return {
     audio: {
-      url: 'http://foo.bar/audio/foo.mp3',
+      url: '/audio/foo.mp3',
       programmeCode: 'xyz',
     },
     description: {
@@ -373,12 +373,12 @@ function termContent() {
     id: '678',
     image: {
       alt: 'Foo Term',
-      url: 'http://foo.bar/term/',
+      url: '/images/foo.jpg',
     },
     name: 'Foo term',
     contentType: 'series',
     video: {
-      url: undefined,
+      url: '',
     },
   };
 }


### PR DESCRIPTION
Updated URL rewrites for media items to be behind a feature toggle, reasons for this are;

- Preserve default behaviours already present in Azure environments
- Allow Cloud Platform environment to be configured to use absolute URLS