### PR TITLE
Remove 'staging' from Cookham Wood release name in Cloud Platform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,7 @@ jobs:
       - release_to_namespace:
           environment: "staging"
           establishment: "cookhamwood"
-          releaseName: "prisoner-content-hub-staging-cookhamwood"
+          releaseName: "prisoner-content-hub-cookhamwood"
 
 workflows:
   version: 2


### PR DESCRIPTION
Before this change, our deployment set looks like this:
```
kubectl -n prisoner-content-hub-staging get deployments
NAME                                       READY   UP-TO-DATE   AVAILABLE   AGE
aws-es-proxy                               1/1     1            1           46h
prisoner-content-hub-backend               0/1     1            0           11h
prisoner-content-hub-staging-cookhamwood   0/0     0            0           16h
```

This PR renames the Cookham Wood release, removing `staging`, in order to make it consistent with the other deployments