### PR TITLE
Cloud Platform development preview build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,27 +288,7 @@ workflows:
     jobs:
       - test_branch:
           <<: *feature_branch
-      - approve_preview_build:
-          <<: *feature_branch
-          type: approval
-      - preview_build:
-          <<: *feature_branch
-          requires:
-            - test_branch
-            - approve_preview_build
-      - preview_build_deploy_azure_dev:
-          <<: *feature_branch
-          requires:
-            - preview_build
-      - approve_preview_build_deploy_azure_staging:
-          <<: *feature_branch
-          type: approval
-          requires:
-            - preview_build_deploy_azure_dev
-      - preview_build_deploy_azure_staging:
-          <<: *feature_branch
-          requires:
-            - approve_preview_build_deploy_azure_staging
+
       - build_frontend:
           <<: *main_branch
       # - run_e2e_test:
@@ -316,6 +296,9 @@ workflows:
       #     requires:
       #       - build_frontend
 
+      #
+      # Deploy to Cloud Platform
+      #
       - approve_deploy_cloud_platform_dev_preview:
           <<: *feature_branch
           type: approval
@@ -344,10 +327,37 @@ workflows:
           requires:
             - approve_deploy_cloud_platform_production
 
+      #
+      # Deploy to Azure
+      #
+      - approve_preview_build:
+          <<: *feature_branch
+          type: approval
+      - preview_build:
+          <<: *feature_branch
+          requires:
+            - test_branch
+            - approve_preview_build
+      - preview_build_deploy_azure_dev:
+          <<: *feature_branch
+          requires:
+            - preview_build
+
+      - approve_preview_build_deploy_azure_staging:
+          <<: *feature_branch
+          type: approval
+          requires:
+            - preview_build_deploy_azure_dev
+      - preview_build_deploy_azure_staging:
+          <<: *feature_branch
+          requires:
+            - approve_preview_build_deploy_azure_staging
+
       - deploy_azure_dev:
           <<: *main_branch
           requires:
             - build_frontend
+
       - approve_deploy_azure_staging:
           <<: *main_branch
           type: approval
@@ -357,6 +367,7 @@ workflows:
           <<: *main_branch
           requires:
             - approve_deploy_azure_staging
+
       - approve_deploy_azure_production:
           <<: *main_branch
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,6 +274,14 @@ jobs:
           establishment: "cookhamwood"
           releaseName: "prisoner-content-hub-cookhamwood"
 
+  deploy_cloud_platform_dev_preview:
+    <<: *defaults
+    steps:
+      - release_to_namespace:
+          environment: "development"
+          establishment: "cookhamwood"
+          releaseName: "prisoner-content-hub-cookhamwood"
+
 workflows:
   version: 2
   build-test-deploy:
@@ -307,11 +315,24 @@ workflows:
       #     <<: *main_branch
       #     requires:
       #       - build_frontend
+
+      - approve_deploy_cloud_platform_dev_preview:
+          <<: *feature_branch
+          type: approval
+          requires:
+            - build_frontend
+      - deploy_cloud_platform_dev_preview:
+          <<: *feature_branch
+          context: prisoner-content-hub-development
+          requires:
+            - approve_deploy_cloud_platform_dev_preview
+
       - deploy_cloud_platform_staging:
           <<: *main_branch
           context: prisoner-content-hub-staging
           requires:
             - build_frontend
+
       - approve_deploy_cloud_platform_production:
           <<: *main_branch
           type: approval
@@ -322,6 +343,7 @@ workflows:
           context: prisoner-content-hub-prod
           requires:
             - approve_deploy_cloud_platform_production
+
       - deploy_azure_dev:
           <<: *main_branch
           requires:


### PR DESCRIPTION
This PR:

- Adds a gated deployment in the development namespace
- Moves the Azure build steps around so they're all together

You can step through the commits to see the above more clearly split.

Intent:

- To allow us to trivially deploy into the development environment for any branch.

This will overwrite any existing deployment, so there's a couple of caveats:

1. Development can enter a broken state by moving back and forth with backend releases. If/when this happens, we'll restore a known good copy of the database.
2. There's only one active deployment, so this approach won't work well for pull requests, where we often have many. This can easily be solved for the frontend, but for Drupal it's a bit trickier to spin up ephemeral databases.

### Dependencies

This PR depends on:

- [x] A corresponding CMS deployment (https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/45)
- [ ] Seed the initial database for the environment
- [ ] Either the above being released first, or the health check being refactored to _not_ include dependent services
- [x] Adding the Cloud Platform credentials to a CircleCI context for `prisoner-content-hub-development`, and updating our docs around that.