### PR TITLE
Add custom hostnames

### DIFF
--- a/helm_deploy/prisoner-content-hub-frontend/templates/ingress.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/templates/ingress.yaml
@@ -11,13 +11,32 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.tlsEnabled }}
   tls:
-    - hosts:
-        - {{ include "prisoner-content-hub-frontend.hostName" . }}
+  {{- range .Values.ingress.hosts }}
+  - hosts:
+    - {{ .host }}
+    {{ if .cert_secret }}secretName: {{ .cert_secret }}{{ end }}
   {{- end }}
   rules:
-    - host: {{ include "prisoner-content-hub-frontend.hostName" . }}
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+
+  {{- range .Values.ingress.hosts }}
+  - hosts:
+    - {{ .host }}
+    {{ if .cert_secret }}secretName: {{ .cert_secret }}{{ end }}
+  {{- end }}
+
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
       http:
         paths:
           - path: {{ .Values.ingress.path }}

--- a/helm_deploy/prisoner-content-hub-frontend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.development.yaml
@@ -5,10 +5,11 @@ application:
     feedbackEndpoint: /prod-feedback/_doc
     enableFeatureToggles: true
     enablePrisonSwitch: true
-    mockAuth: true
     analyticsSiteId: UA-152065860-4
 
 ingress:
   enabled: true
   tlsEnabled: true
-  hostName: prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk
+  hosts:
+    - host: prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk
+  path: /

--- a/helm_deploy/prisoner-content-hub-frontend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.production.yaml
@@ -8,4 +8,9 @@ application:
 ingress:
   enabled: true
   tlsEnabled: true
-  hostName: prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
+  hosts:
+    - host: prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
+    - host: cookhamwood.prisoner.service.justice.gov.uk
+      cert_secret: prisoner-content-hub-frontend-certificate
+  path: /
+

--- a/helm_deploy/prisoner-content-hub-frontend/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.staging.yaml
@@ -8,4 +8,6 @@ application:
 ingress:
   enabled: true
   tlsEnabled: true
-  hostName: prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+  hosts:
+    - host: prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+  path: /


### PR DESCRIPTION
This PR:

- Adds a custom hostname for the frontend
- Refactors the ingress slightly to allow multiple hostnames

We've only added Cookham Wood, but this opens the door to use a single deployment with one hostname per prison