### PR TITLE
fix copy/pasta error and enable TLS by default

### DIFF
--- a/helm_deploy/prisoner-content-hub-frontend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.production.yaml
@@ -10,7 +10,7 @@ ingress:
   tlsEnabled: true
   hosts:
     - host: prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
-    - host: cookhamwood.prisoner.service.justice.gov.uk
+    - host: cookhamwood.content-hub.prisoner.service.justice.gov.uk
       cert_secret: prisoner-content-hub-frontend-certificate
   path: /
 


### PR DESCRIPTION
This PR 
- removes some duplicates config in the ingress which I missed
- defaults the ingress to enabled to simplify config (we enable TLS/ingress in all our CP environments)