### PR TITLE
Use host prefix/suffix to build frontend hostname

### DIFF
--- a/helm_deploy/prisoner-content-hub-frontend/templates/_helpers.tpl
+++ b/helm_deploy/prisoner-content-hub-frontend/templates/_helpers.tpl
@@ -66,13 +66,6 @@ Create a feedback URL
 {{- end }}
 
 {{/*
-Create concatenated hostname
-*/}}
-{{- define "prisoner-content-hub-frontend.hostName" -}}
-{{- printf "%s-%s" .Values.ingress.domainPrefix .Values.ingress.hostName }}
-{{- end }}
-
-{{/*
 Create external Kubernetes hostname
 */}}
 {{- define "prisoner-content-hub-frontend.externalHost" -}}
@@ -80,5 +73,5 @@ Create external Kubernetes hostname
 {{- if .Values.ingress.tlsEnabled }}
 {{- $protocol = "https" }}
 {{- end }}
-{{- printf "%s://%s" $protocol  (include "prisoner-content-hub-frontend.hostName" .) }}
+{{- printf "%s://%s%s" $protocol .Values.ingress.domainPrefix (index .Values.ingress.hosts 0).suffix }}
 {{- end }}

--- a/helm_deploy/prisoner-content-hub-frontend/templates/ingress.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/templates/ingress.yaml
@@ -12,14 +12,15 @@ metadata:
   {{- end }}
 spec:
   tls:
+  {{- $domainPrefix := .Values.ingress.domainPrefix -}}
   {{- range .Values.ingress.hosts }}
   - hosts:
-    - {{ .host }}
+    - {{ $domainPrefix }}{{ .suffix }}
     {{ if .cert_secret }}secretName: {{ .cert_secret }}{{ end }}
   {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ .host }}
+    - host: {{ $domainPrefix }}{{ .suffix }}
       http:
         paths:
           - path: "/"

--- a/helm_deploy/prisoner-content-hub-frontend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.development.yaml
@@ -11,5 +11,4 @@ ingress:
   enabled: true
   tlsEnabled: true
   hosts:
-    - host: prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk
-  path: /
+    - suffix: prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-frontend/values.local.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.local.yaml
@@ -12,4 +12,5 @@ application:
 ingress:
   enabled: false
   tlsEnabled: false
-  hostName: pfs-hub.local
+  hosts:
+    - suffix: pfs-hub.local

--- a/helm_deploy/prisoner-content-hub-frontend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.production.yaml
@@ -9,8 +9,6 @@ ingress:
   enabled: true
   tlsEnabled: true
   hosts:
-    - host: prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
-    - host: cookhamwood.content-hub.prisoner.service.justice.gov.uk
+    - suffix: .content-hub.prisoner.service.justice.gov.uk
       cert_secret: prisoner-content-hub-frontend-certificate
-  path: /
-
+    - suffix: -prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-frontend/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.staging.yaml
@@ -9,5 +9,4 @@ ingress:
   enabled: true
   tlsEnabled: true
   hosts:
-    - host: prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk
-  path: /
+    - suffix: prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
This PR:

- Refactors the ingress to correctly build the hostname from an establishment prefix and one or more environment suffixes
- Removes the hostname helper as it's only used once in another helper.
- Removes redundant `path` entries.

Intent

Before now we've built domain names using `-` for the prefix. Our naming scheme in production is `<establishment>.content-hub.service.justice.gov.uk`, so we need to support both.

An ingress definition in Helm would now look like

```
# In the establishment values file
ingress:
  domainPrefix: cookhamwood

# In the environment values file
ingress:
  hosts:
    - suffix: .content-hub.prisoner.service.justice.gov.uk
      cert_secret: prisoner-content-hub-frontend-certificate
    - suffix: -prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
```