### PR TITLE
Remove azure CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,50 +103,7 @@ jobs:
       - run:
           name: Run Unit and Integration tests
           command: npm run lint && npm run test
-  preview_build:
-    <<: *defaults
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-      - run:
-          name: Build frontend Docker image
-          command: |
-            BUILD_NUMBER="$CIRCLE_BUILD_NUM" \
-            GIT_REF="$CIRCLE_SHA1" \
-            GIT_DATE="$(git log --format=%cd -n1 --date=iso $CIRCLE_SHA1)" \
-            make build
-      - save_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-          paths:
-            - ./node_modules
-      - run:
-          name: Push frontend Docker image
-          command: make push-preview
-      - add_ssh_keys:
-          fingerprints:
-            - "0a:04:a1:27:17:3e:3d:8a:20:91:79:a1:9e:af:85:6c"
-      - run:
-          name: Save build number (for deployment)
-          command: |
-            mkdir -p /tmp/build-info
-            echo preview > /tmp/build-info/version-to-deploy.txt
-      - persist_to_workspace:
-          root: /tmp/build-info
-          paths:
-            - version-to-deploy.txt
-  preview_build_deploy_azure_dev:
-    <<: *default_machine
-    steps:
-      - deploy_to_environment:
-          to: hub-dev
-  preview_build_deploy_azure_staging:
-    <<: *default_machine
-    steps:
-      - deploy_to_environment:
-          to: hub-stage
+
   build_frontend:
     <<: *defaults
     steps:
@@ -230,17 +187,6 @@ jobs:
   #         path: ./cypress/videos
   #     - store_artifacts:
   #         path: ./cypress/screenshots
-  deploy_azure_dev:
-    <<: *default_machine
-    steps:
-      - deploy_to_environment:
-          to: hub-dev
-
-  deploy_azure_staging:
-    <<: *default_machine
-    steps:
-      - deploy_to_environment:
-          to: hub-stage
 
   deploy_azure_production:
     <<: *default_machine
@@ -256,7 +202,6 @@ jobs:
             export VERSION_TO_DEPLOY="$(cat /tmp/build-info/version-to-deploy.txt)" && \
             ssh -t ciuser@pfs-management-bastion-1.uksouth.cloudapp.azure.com ssh -t ciuser@hub-wayland-prod.pfs-management.com "sudo /etc/docker-decomposed-secrets.sh -v ${VERSION_TO_DEPLOY}" && \
             ssh -t ciuser@pfs-management-bastion-1.uksouth.cloudapp.azure.com ssh -t ciuser@hub-berwyn-prod.pfs-management.com "sudo /etc/docker-decomposed-secrets.sh -v ${VERSION_TO_DEPLOY}"
-            # ssh -t ciuser@pfs-management-bastion-1.uksouth.cloudapp.azure.com ssh -t ciuser@hub-cookhamwood-prod.pfs-management.com "sudo /etc/docker-decomposed-secrets.sh -v ${VERSION_TO_DEPLOY}"
 
   deploy_cloud_platform_production:
     <<: *defaults
@@ -354,49 +299,12 @@ workflows:
       #
       # Deploy to Azure
       #
-      - approve_preview_build:
-          <<: *feature_branch
-          type: approval
-      - preview_build:
-          <<: *feature_branch
-          requires:
-            - test_branch
-            - approve_preview_build
-      - preview_build_deploy_azure_dev:
-          <<: *feature_branch
-          requires:
-            - preview_build
-
-      - approve_preview_build_deploy_azure_staging:
-          <<: *feature_branch
-          type: approval
-          requires:
-            - preview_build_deploy_azure_dev
-      - preview_build_deploy_azure_staging:
-          <<: *feature_branch
-          requires:
-            - approve_preview_build_deploy_azure_staging
-
-      - deploy_azure_dev:
-          <<: *main_branch
-          requires:
-            - build_frontend
-
-      - approve_deploy_azure_staging:
-          <<: *main_branch
-          type: approval
-          requires:
-            - deploy_azure_dev
-      - deploy_azure_staging:
-          <<: *main_branch
-          requires:
-            - approve_deploy_azure_staging
-
       - approve_deploy_azure_production:
           <<: *main_branch
           type: approval
           requires:
-            - deploy_azure_staging
+            - deploy_cloud_platform_production
+
       - deploy_azure_production:
           <<: *main_branch
           requires:


### PR DESCRIPTION
Following the call with Rich, here's a PR to remove the CI deploy to the Azure for all but Wayland and Berwyn production

There are some downsides to this PR – we won't have a non-production environment to recreate issues we see in Wayland and Berwyn. 