### PR TITLE
Refactor health check endpoints

### DIFF
--- a/helm_deploy/prisoner-content-hub-frontend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.yaml
@@ -14,11 +14,11 @@ image:
 application:
   port: 3000
   liveness:
-    endpoint: /games/smashout
+    endpoint: /health/liveness
     delaySeconds: 10
     timeoutSeconds: 5
   readiness:
-    endpoint: /health
+    endpoint: /health/readiness
     delaySeconds: 10
     timeoutSeconds: 5
   config:

--- a/server/routes/health.js
+++ b/server/routes/health.js
@@ -4,7 +4,9 @@ const { path } = require('ramda');
 const createHealthRouter = ({ healthService }) => {
   const router = express.Router();
 
-  router.get('/', async (req, res, next) => {
+  router.get('/liveness', (_, res) => res.json({ status: 'OK' }));
+
+  router.get('/readiness', async (req, res, next) => {
     try {
       const healthStatus = await healthService.status();
       const buildInfo = path(['app', 'locals', 'config', 'buildInfo'], req);

--- a/test/routes/health.spec.js
+++ b/test/routes/health.spec.js
@@ -3,7 +3,33 @@ const request = require('supertest');
 const { createHealthRouter } = require('../../server/routes/health');
 const { setupBasicApp } = require('../test-helpers');
 
-describe('/health', () => {
+describe('GET /health/liveness', () => {
+  it('returns the health status of the application', () => {
+    const healthService = {};
+    const router = createHealthRouter({ healthService });
+    const app = setupBasicApp({
+      buildInfo: {
+        buildNumber: 'foo-number',
+        gitRef: 'foo-ref',
+        gitDate: 'foo-date',
+      },
+    });
+
+    app.use('/health', router);
+
+    return request(app)
+      .get('/health/liveness')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .then(res => {
+        expect(res.body).eql({
+          status: 'OK',
+        });
+      });
+  });
+});
+
+describe('GET /health/readiness', () => {
   it('returns the health status of the application', () => {
     const healthService = {
       status: sinon.stub().returns({
@@ -25,7 +51,7 @@ describe('/health', () => {
     app.use('/health', router);
 
     return request(app)
-      .get('/health')
+      .get('/health/readiness')
       .expect(200)
       .expect('Content-Type', /json/)
       .then(res => {

--- a/test/services/healthService.spec.js
+++ b/test/services/healthService.spec.js
@@ -27,7 +27,7 @@ describe('HealthService', () => {
         .returns({
           backend: {
             timestamp: 1564392127,
-            'Drupal Version': '8.7.3',
+            'Drupal Version': '8.9.1',
           },
           db: {
             database: 'mysql',


### PR DESCRIPTION
- Split health endpoints to supply liveness and readiness
- Refactor naming of things in the health service
- Update Helm values to use new liveness and readiness probes