### PR TITLE
Fix staging URLs

### DIFF
--- a/helm_deploy/prisoner-content-hub-frontend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.development.yaml
@@ -8,7 +8,5 @@ application:
     analyticsSiteId: UA-152065860-4
 
 ingress:
-  enabled: true
-  tlsEnabled: true
   hosts:
-    - suffix: prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk
+    - suffix: -prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-frontend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.production.yaml
@@ -6,8 +6,6 @@ application:
     analyticsSiteId: UA-152065860-4
 
 ingress:
-  enabled: true
-  tlsEnabled: true
   hosts:
     - suffix: .content-hub.prisoner.service.justice.gov.uk
       cert_secret: prisoner-content-hub-frontend-certificate

--- a/helm_deploy/prisoner-content-hub-frontend/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.staging.yaml
@@ -6,7 +6,5 @@ application:
     analyticsSiteId: UA-152065860-4
 
 ingress:
-  enabled: true
-  tlsEnabled: true
   hosts:
-    - suffix: prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+    - suffix: -prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-frontend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.yaml
@@ -54,8 +54,8 @@ service:
   port: 80
 
 ingress:
-  enabled: false
-  tlsEnabled: false
+  enabled: true
+  tlsEnabled: true
   path: /
   annotations:
     kubernetes.io/ingress.class: "nginx"


### PR DESCRIPTION
### Expected behaviour

The staging environment is available on the following URLs:
- https://berwyn-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk
- https://berwyn-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk
- https://berwyn-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk

### Actual behaviour

The staging environment is available on the following URLs (note the missing `-` between the prison name and `prisoner`):
- https://berwynprisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk
- https://berwynprisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk
- https://berwynprisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk

This issue doesn't affect the CMS, which is available at https://cms-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk

### This PR:
- fixes staging URLs by add '-' between the prefix and suffix. 
- removes redundancy by enabling ingress/TLS by default (it's explicitly disabled in `values.local` already.

