### PR TITLE
Add Sentry exception logging, to centralise and alert on Node exceptions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,7 @@ commands:
               --values ~/git/helm_deploy/prisoner-content-hub-frontend/values.establishment-<< parameters.establishment >>.yaml \
               --values ~/git/helm_deploy/prisoner-content-hub-frontend/values.<< parameters.environment >>.yaml \
               --set application.contentConfigMap="${HELM_BACKEND_RELEASE_NAME}" \
+              --set application.sentry_dsn="${FRONTEND_SENTRY_DSN}" \
               --set nomisApiToken="${SECRET_NOMIS_API_TOKEN}" \
               --set nomisApiEndpoint="${SECRET_NOMIS_API_ENDPOINT}" \
               --set image.tag=${VERSION_TO_DEPLOY}

--- a/helm_deploy/prisoner-content-hub-frontend/secrets.example.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/secrets.example.yaml
@@ -1,2 +1,4 @@
 nomisApiToken: Token
 nomisApiEndpoint: http://foo.bar
+application:
+  sentry_dsn: todo_set_this

--- a/helm_deploy/prisoner-content-hub-frontend/templates/deployment.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/templates/deployment.yaml
@@ -75,6 +75,8 @@ spec:
               value: {{ .Values.application.config.analyticsSiteId }}
             - name: FEATURE_USE_RELATIVE_URL
               value: {{ .Values.application.config.useRelativeUrlForMedia | quote }}
+            - name: SENTRY_DSN
+              value: {{ .Values.application.sentry_dsn }}
           ports:
             - name: http
               containerPort: {{ .Values.application.port }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -360,6 +360,129 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@sentry/apm": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@sentry/apm/-/apm-5.20.1.tgz",
+      "integrity": "sha512-oqfyYqRR1CaM/U5qZg3KY9MxCe4OWYs3uiOvVGMOHCyx50dYsDZziM5DDVUvi6pOuokLCNbyXO9xGROSmploBQ==",
+      "requires": {
+        "@sentry/browser": "5.20.1",
+        "@sentry/hub": "5.20.1",
+        "@sentry/minimal": "5.20.1",
+        "@sentry/types": "5.20.1",
+        "@sentry/utils": "5.20.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/browser": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.20.1.tgz",
+      "integrity": "sha512-ClykuvrEsMKgAvifx5VHzRjchwYbJFX8YiIicYx+Wr3MXL2jLG6OEfHHJwJeyBL2C3vxd5O0KPK3pGMR9wPMLA==",
+      "requires": {
+        "@sentry/core": "5.20.1",
+        "@sentry/types": "5.20.1",
+        "@sentry/utils": "5.20.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.20.1.tgz",
+      "integrity": "sha512-gG622/UY2TePruF6iUzgVrbIX5vN8w2cjlWFo1Est8MvCfQsz8agGaLMCAyl5hCGJ6K2qTUZDOlbCNIKoMclxg==",
+      "requires": {
+        "@sentry/hub": "5.20.1",
+        "@sentry/minimal": "5.20.1",
+        "@sentry/types": "5.20.1",
+        "@sentry/utils": "5.20.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.20.1.tgz",
+      "integrity": "sha512-Nv5BXf14BEc08acDguW6eSqkAJLVf8wki283FczEvTsQZZuSBHM9cJ5Hnehr6n+mr8wWpYLgUUYM0oXXigUmzQ==",
+      "requires": {
+        "@sentry/types": "5.20.1",
+        "@sentry/utils": "5.20.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.20.1.tgz",
+      "integrity": "sha512-2PeJKDTHNsUd1jtSLQBJ6oRI+xrIJrYDQmsyK/qs9D7HqHfs+zNAMUjYseiVeSAFGas5IcNSuZbPRV4BnuoZ0w==",
+      "requires": {
+        "@sentry/hub": "5.20.1",
+        "@sentry/types": "5.20.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.20.1.tgz",
+      "integrity": "sha512-43YFDnD7Rv+vGHV+Fmb3LaSSWrFzsPmFRu3wmf9eYMgWiuDks6c6/kWRCgkqX9Np9ImC89wcTZs/V6S4MlOm4g==",
+      "requires": {
+        "@sentry/apm": "5.20.1",
+        "@sentry/core": "5.20.1",
+        "@sentry/hub": "5.20.1",
+        "@sentry/types": "5.20.1",
+        "@sentry/utils": "5.20.1",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
+          "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@sentry/types": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.20.1.tgz",
+      "integrity": "sha512-OU+i/lcjGpDJv0XkNpsKrI2r1VPp8qX0H6Knq8NuZrlZe3AbvO3jRJJK0pH14xFv8Xok5jbZZpKKoQLxYfxqsw=="
+    },
+    "@sentry/utils": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.20.1.tgz",
+      "integrity": "sha512-dhK6IdO6g7Q2CoxCbB+q8gwUapDUH5VjraFg0UBzgkrtNhtHLylqmwx0sWQvXCcp14Q/3MuzEbb4euvoh8o8oA==",
+      "requires": {
+        "@sentry/types": "5.20.1",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
@@ -4951,6 +5074,11 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "macos-release": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     }
   },
   "dependencies": {
+    "@sentry/node": "^5.20.1",
     "axios": "0.19.2",
     "body-parser": "^1.19.0",
     "bunyan-request-logger": "^2.1.0",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,14 @@
 require('dotenv').config();
 
+const Sentry = require('@sentry/node');
+const { getEnv } = require('./utils/index');
+
+// Set up Sentry before (almost) everything else, so we can
+// capture any exceptions during startup
+Sentry.init({
+  dsn: getEnv('SENTRY_DSN', ''),
+});
+
 const app = require('./server/index');
 const { logger } = require('./server/utils/logger');
 


### PR DESCRIPTION
### Changes

Cloud Platform recently set up a Sentry organisation on a paid plan. [Sentry](https://sentry.io/for/node/) allows us to collect, track and notify us about code-level exceptions and events with stack-traces. 

This PR adds Sentry exception collection to the Node frontend. 

The `FRONTEND_SENTRY_DSN` has been added to CircleCI in development/staging/production, so exceptions should start appearing in the [dashboard](https://sentry.io/organizations/ministryofjustice/issues/?project=5377056).

We can test this by triggering an exception in a Kubernetes pod or locally (or just deliberately shipping unstable code 🤪). We should definitely validate that this happens as we expect in Cloud Platform.

### Intent

This will help us catch exceptions and errors early on, and goes hand-in-hand with the alerting & monitoring work we've got going on.