### PR TITLE
Add establishment name to the 'release to env' step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ commands:
               --namespace=${KUBE_NAMESPACE}
             kubectl config use-context ${KUBE_CLUSTER_NAME}
       - run:
-          name: Release to << parameters.environment >>
+          name: Release to << parameters.environment >> (<< parameters.establishment >>)
           command: |
             VERSION_TO_DEPLOY=$(cat /tmp/build-info/version-to-deploy.txt)
             helm upgrade << parameters.releaseName >> ~/git/helm_deploy/prisoner-content-hub-frontend \


### PR DESCRIPTION
- Use parameters.establishment to give a clearer release step in CircleCI