### PR TITLE
Remove duplicated kops/kubectl/helm installs in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,13 @@ orbs:
   helm: circleci/helm@1.0.0
 
 commands:
+  set_up_helm:
+    description: "Set up Kubernetes/Helm"
+    steps:
+      - kubernetes/install
+      - helm/install-helm-client:
+          version: v3.2.1
+
   release_to_namespace:
     description: "Release with Helm"
     parameters:
@@ -36,9 +43,6 @@ commands:
       releaseName:
         type: string
     steps:
-      - kubernetes/install
-      - helm/install-helm-client:
-          version: v3.2.1
       - checkout:
           path: ~/git
       - attach_workspace:
@@ -171,6 +175,7 @@ jobs:
   deploy_cloud_platform_production:
     <<: *defaults
     steps:
+      - set_up_helm
       - release_to_namespace:
           environment: "production"
           establishment: "berwyn"
@@ -187,6 +192,7 @@ jobs:
   deploy_cloud_platform_staging:
     <<: *defaults
     steps:
+      - set_up_helm
       - release_to_namespace:
           environment: "staging"
           establishment: "berwyn"
@@ -203,6 +209,7 @@ jobs:
   deploy_cloud_platform_development_preview:
     <<: *defaults
     steps:
+      - set_up_helm
       - release_to_namespace:
           environment: "development"
           establishment: "berwyn"


### PR DESCRIPTION
Looking at a recent build, we can see a few dependencies are duplicated for every namespace we deploy to:
<img width="495" alt="Screenshot 2020-08-12 at 13 17 44" src="https://user-images.githubusercontent.com/464482/90013996-3926a980-dc9e-11ea-8ba2-c41cd573fbe0.png">

This PR removes the duplicated install of KOPS, kubectl, and helm, shifting them into a single step that gets executed at the beginning of the job.

We may be able to optimise this further, for example I _believe_ the checkout in line 36 could be refactored into a single `checkout` step (e.g. L101).