### PR TITLE
Parameterise CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,57 +172,48 @@ jobs:
 
   deploy_cloud_platform_production:
     <<: *defaults
+    parameters:
+      environment:
+        type: string
+      establishment:
+        type: string
     steps:
       - set_up_helm
       - checkout
       - release_to_namespace:
-          environment: "production"
-          establishment: "berwyn"
-          releaseName: "prisoner-content-hub-berwyn"
-      - release_to_namespace:
-          environment: "production"
-          establishment: "cookhamwood"
-          releaseName: "prisoner-content-hub-cookhamwood"
-      - release_to_namespace:
-          environment: "production"
-          establishment: "wayland"
-          releaseName: "prisoner-content-hub-wayland"
+          environment: "<< parameters.environment >>"
+          establishment: "<< parameters.establishment >>"
+          releaseName: "prisoner-content-hub-<< parameters.establishment >>"
 
   deploy_cloud_platform_staging:
     <<: *defaults
+    parameters:
+      environment:
+        type: string
+      establishment:
+        type: string
     steps:
       - set_up_helm
       - checkout
       - release_to_namespace:
-          environment: "staging"
-          establishment: "berwyn"
-          releaseName: "prisoner-content-hub-berwyn"
-      - release_to_namespace:
-          environment: "staging"
-          establishment: "cookhamwood"
-          releaseName: "prisoner-content-hub-cookhamwood"
-      - release_to_namespace:
-          environment: "staging"
-          establishment: "wayland"
-          releaseName: "prisoner-content-hub-wayland"
+          environment: "<< parameters.environment >>"
+          establishment: "<< parameters.establishment >>"
+          releaseName: "prisoner-content-hub-<< parameters.establishment >>"
 
   deploy_cloud_platform_development_preview:
     <<: *defaults
+    parameters:
+      environment:
+        type: string
+      establishment:
+        type: string
     steps:
       - set_up_helm
       - checkout
       - release_to_namespace:
-          environment: "development"
-          establishment: "berwyn"
-          releaseName: "prisoner-content-hub-berwyn"
-      - release_to_namespace:
-          environment: "development"
-          establishment: "cookhamwood"
-          releaseName: "prisoner-content-hub-cookhamwood"
-      - release_to_namespace:
-          environment: "development"
-          establishment: "wayland"
-          releaseName: "prisoner-content-hub-wayland"
+          environment: "<< parameters.environment >>"
+          establishment: "<< parameters.establishment >>"
+          releaseName: "prisoner-content-hub-<< parameters.establishment >>"
 
 workflows:
   version: 2
@@ -242,6 +233,10 @@ workflows:
       - deploy_cloud_platform_development_preview:
           <<: *feature_branch
           context: prisoner-content-hub-development
+          matrix:
+            parameters:
+              environment: "development"
+              establishment: ["berwyn", "cookhamwood", "wayland"]
           requires:
             - build_preview
 
@@ -253,6 +248,10 @@ workflows:
       - deploy_cloud_platform_staging:
           <<: *main_branch
           context: prisoner-content-hub-staging
+          matrix:
+            parameters:
+              environment: "development"
+              establishment: ["berwyn", "cookhamwood", "wayland"]
           requires:
             - build_production
 
@@ -265,5 +264,9 @@ workflows:
       - deploy_cloud_platform_production:
           <<: *main_branch
           context: prisoner-content-hub-prod
+          matrix:
+            parameters:
+              environment: "development"
+              establishment: ["berwyn", "cookhamwood", "wayland"]
           requires:
             - approve_deploy_production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,11 +63,11 @@ commands:
           name: Release to << parameters.environment >> (<< parameters.establishment >>)
           command: |
             VERSION_TO_DEPLOY=$(cat /tmp/build-info/version-to-deploy.txt)
-            helm upgrade << parameters.releaseName >> ~/git/helm_deploy/prisoner-content-hub-frontend \
+            helm upgrade << parameters.releaseName >> ./helm_deploy/prisoner-content-hub-frontend \
               --install --wait --force --reset-values --timeout 360s \
               --namespace=${KUBE_NAMESPACE} \
-              --values ~/git/helm_deploy/prisoner-content-hub-frontend/values.establishment-<< parameters.establishment >>.yaml \
-              --values ~/git/helm_deploy/prisoner-content-hub-frontend/values.<< parameters.environment >>.yaml \
+              --values ./helm_deploy/prisoner-content-hub-frontend/values.establishment-<< parameters.establishment >>.yaml \
+              --values ./helm_deploy/prisoner-content-hub-frontend/values.<< parameters.environment >>.yaml \
               --set application.contentConfigMapName="${HELM_BACKEND_RELEASE_NAME}" \
               --set application.nprConfigMapName="${HELM_NPR_CONFIG_MAP_NAME}" \
               --set application.sentry_dsn="${FRONTEND_SENTRY_DSN}" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,6 @@ workflows:
 
       - deploy_cloud_platform:
           <<: *feature_branch
-          name: deploy_dev_preview
           context: prisoner-content-hub-development
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,6 +221,7 @@ workflows:
           name: deploy_staging
           context: prisoner-content-hub-staging
           matrix:
+            alias: deploy_to_staging
             parameters:
               environment: ["staging"]
               establishment: ["berwyn", "cookhamwood", "wayland"]
@@ -231,7 +232,7 @@ workflows:
           <<: *main_branch
           type: approval
           requires:
-            - deploy_staging
+            - deploy_to_staging
 
       - deploy_cloud_platform:
           <<: *main_branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,37 +170,7 @@ jobs:
           paths:
             - version-to-deploy.txt
 
-  deploy_cloud_platform_production:
-    <<: *defaults
-    parameters:
-      environment:
-        type: string
-      establishment:
-        type: string
-    steps:
-      - set_up_helm
-      - checkout
-      - release_to_namespace:
-          environment: "<< parameters.environment >>"
-          establishment: "<< parameters.establishment >>"
-          releaseName: "prisoner-content-hub-<< parameters.establishment >>"
-
-  deploy_cloud_platform_staging:
-    <<: *defaults
-    parameters:
-      environment:
-        type: string
-      establishment:
-        type: string
-    steps:
-      - set_up_helm
-      - checkout
-      - release_to_namespace:
-          environment: "<< parameters.environment >>"
-          establishment: "<< parameters.establishment >>"
-          releaseName: "prisoner-content-hub-<< parameters.establishment >>"
-
-  deploy_cloud_platform_development_preview:
+  deploy_cloud_platform:
     <<: *defaults
     parameters:
       environment:
@@ -230,7 +200,7 @@ workflows:
           requires:
             - approve_preview_build
 
-      - deploy_cloud_platform_development_preview:
+      - deploy_cloud_platform:
           <<: *feature_branch
           context: prisoner-content-hub-development
           matrix:
@@ -245,12 +215,12 @@ workflows:
           requires:
             - run_unit_and_integration_tests
 
-      - deploy_cloud_platform_staging:
+      - deploy_cloud_platform:
           <<: *main_branch
           context: prisoner-content-hub-staging
           matrix:
             parameters:
-              environment: ["development"]
+              environment: ["staging"]
               establishment: ["berwyn", "cookhamwood", "wayland"]
           requires:
             - build_production
@@ -261,12 +231,12 @@ workflows:
           requires:
             - deploy_cloud_platform_staging
 
-      - deploy_cloud_platform_production:
+      - deploy_cloud_platform:
           <<: *main_branch
           context: prisoner-content-hub-prod
           matrix:
             parameters:
-              environment: ["development"]
+              environment: ["production"]
               establishment: ["berwyn", "cookhamwood", "wayland"]
           requires:
             - approve_deploy_production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,7 @@ workflows:
           context: prisoner-content-hub-development
           matrix:
             parameters:
-              environment: "development"
+              environment: ["development"]
               establishment: ["berwyn", "cookhamwood", "wayland"]
           requires:
             - build_preview
@@ -250,7 +250,7 @@ workflows:
           context: prisoner-content-hub-staging
           matrix:
             parameters:
-              environment: "development"
+              environment: ["development"]
               establishment: ["berwyn", "cookhamwood", "wayland"]
           requires:
             - build_production
@@ -266,7 +266,7 @@ workflows:
           context: prisoner-content-hub-prod
           matrix:
             parameters:
-              environment: "development"
+              environment: ["development"]
               establishment: ["berwyn", "cookhamwood", "wayland"]
           requires:
             - approve_deploy_production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,6 +202,7 @@ workflows:
 
       - deploy_cloud_platform:
           <<: *feature_branch
+          name: deploy_dev_preview
           context: prisoner-content-hub-development
           matrix:
             parameters:
@@ -217,6 +218,7 @@ workflows:
 
       - deploy_cloud_platform:
           <<: *main_branch
+          name: deploy_staging
           context: prisoner-content-hub-staging
           matrix:
             parameters:
@@ -229,10 +231,11 @@ workflows:
           <<: *main_branch
           type: approval
           requires:
-            - deploy_cloud_platform_staging
+            - deploy_staging
 
       - deploy_cloud_platform:
           <<: *main_branch
+          name: deploy_production
           context: prisoner-content-hub-prod
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,6 @@ workflows:
 
       - deploy_cloud_platform:
           <<: *main_branch
-          name: deploy_staging
           context: prisoner-content-hub-staging
           matrix:
             alias: deploy_to_staging
@@ -235,7 +234,6 @@ workflows:
 
       - deploy_cloud_platform:
           <<: *main_branch
-          name: deploy_production
           context: prisoner-content-hub-prod
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,8 +178,8 @@ jobs:
       establishment:
         type: string
     steps:
-      - set_up_helm
       - checkout
+      - set_up_helm
       - release_to_namespace:
           environment: "<< parameters.environment >>"
           establishment: "<< parameters.establishment >>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,6 @@ commands:
       releaseName:
         type: string
     steps:
-      - checkout:
-          path: ~/git
       - attach_workspace:
           at: /tmp/build-info
       - run:
@@ -176,6 +174,7 @@ jobs:
     <<: *defaults
     steps:
       - set_up_helm
+      - checkout
       - release_to_namespace:
           environment: "production"
           establishment: "berwyn"
@@ -193,6 +192,7 @@ jobs:
     <<: *defaults
     steps:
       - set_up_helm
+      - checkout
       - release_to_namespace:
           environment: "staging"
           establishment: "berwyn"
@@ -210,6 +210,7 @@ jobs:
     <<: *defaults
     steps:
       - set_up_helm
+      - checkout
       - release_to_namespace:
           environment: "development"
           establishment: "berwyn"


### PR DESCRIPTION
This is a bit of an exploration. The PR:

- Refactors code checkout to occur in the job step
- Uses relative paths to remove the need for a custom checkout location
- [more controversially] uses `matrix` parameterisation to deduplicate the release steps. 

The result (after a bit of jigerry-pokery) is the following, where the job name becomes more meaningful in the UI:

<img width="1025" alt="Screenshot 2020-08-12 at 15 48 22" src="https://user-images.githubusercontent.com/464482/90029965-6467c380-dcb3-11ea-9e00-2ff3a77b7901.png">
