### PR TITLE
Use namespace-specific nginx for non-production environments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,3 @@ Mocha and Chai are used for unit and integration tests
 Cypress is used for E2E testing
 
     npm run test:e2e:dev
-

--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ Mocha and Chai are used for unit and integration tests
 Cypress is used for E2E testing
 
     npm run test:e2e:dev
+

--- a/helm_deploy/prisoner-content-hub-frontend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.development.yaml
@@ -13,5 +13,7 @@ application:
     enablePersonalInformation: true
 
 ingress:
+  annotations:
+    kubernetes.io/ingress.class: prisoner-content-hub-development
   hosts:
     - suffix: -prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-frontend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.production.yaml
@@ -5,6 +5,8 @@ application:
     feedbackEndpoint: /prod-feedback/_doc
 
 ingress:
+  annotations:
+    kubernetes.io/ingress.class: nginx
   hosts:
     - suffix: .content-hub.prisoner.service.justice.gov.uk
       cert_secret: prisoner-content-hub-frontend-certificate

--- a/helm_deploy/prisoner-content-hub-frontend/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.staging.yaml
@@ -8,5 +8,7 @@ application:
     enablePersonalInformation: true
 
 ingress:
+  annotations:
+    kubernetes.io/ingress.class: prisoner-content-hub-staging
   hosts:
     - suffix: -prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-frontend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.yaml
@@ -61,7 +61,6 @@ ingress:
   tlsEnabled: true
   path: /
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     # nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     # nginx.ingress.kubernetes.io/modsecurity-snippet: |
     #   Include /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf


### PR DESCRIPTION
For https://trello.com/c/9w8hYZJQ/1380-add-annotation-to-ingress-controllers.

This PR updates the kubernetes ingress annotation following https://mojdt.slack.com/archives/CH6D099DF/p1598372708002900.

This only applies to non-production environments initially. Once we're ready to roll it out across the board we should probably refactor this to remove the environment-specific annotations into something like:

```
{{- $namespace_name := .Release.Namespace }}
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:

  ... removed for brevity

  {{- with .Values.ingress.annotations }}
  annotations:
    kubernetes.io/ingress.class: {{ $namespace_name }}
    {{- toYaml . | nindent 4 }}
  {{- end }}
```
