### PR TITLE
Make landing page content variables sensible

### DIFF
--- a/server/repositories/categoryFeaturedContent.js
+++ b/server/repositories/categoryFeaturedContent.js
@@ -5,7 +5,7 @@ const config = require('../config');
 
 const { featuredContentResponseFrom } = require('../utils/adapters');
 
-function hubCategoryFeaturedContentRepository(httpClient) {
+function categoryFeaturedContentRepository(httpClient) {
   async function contentFor({ categoryId, establishmentId, number = 8 } = {}) {
     const endpoint = `${config.api.hubCategory}/featured`;
     const query = {
@@ -16,7 +16,7 @@ function hubCategoryFeaturedContentRepository(httpClient) {
 
     if (!categoryId) {
       logger.error(
-        `HubCategoryFeaturedContentRepository (contentFor) - No Category ID passed`,
+        `CategoryFeaturedContentRepository (contentFor) - No Category ID passed`,
       );
       return [];
     }
@@ -36,5 +36,5 @@ function hubCategoryFeaturedContentRepository(httpClient) {
 }
 
 module.exports = {
-  categoryFeaturedContentRepository: hubCategoryFeaturedContentRepository,
+  categoryFeaturedContentRepository,
 };

--- a/server/services/hubContent.js
+++ b/server/services/hubContent.js
@@ -127,7 +127,10 @@ function createHubContentService({
     return {
       ...data,
       featuredContent,
-      relatedContent: { contentType: 'default', data: categoryFeaturedContent },
+      categoryFeaturedContent: {
+        contentType: 'default',
+        data: categoryFeaturedContent,
+      },
       categoryMenu,
     };
   }

--- a/server/views/pages/category.html
+++ b/server/views/pages/category.html
@@ -95,8 +95,8 @@
   <div class="govuk-body categories-container">
     <h2>Featured</h2>
     <div class="category-content">
-      {{ contentTileLarge({content: data.relatedContent.data[0], imageAlign: 'right'}) }}
-      {% for tile in data.relatedContent.data %}
+      {{ contentTileLarge({content: data.categoryFeaturedContent.data[0], imageAlign: 'right'}) }}
+      {% for tile in data.categoryFeaturedContent.data %}
         {% if loop.index === 1 or loop.index === 5 %}
           <div class="category-content__three-items">
           {% endif %}
@@ -107,7 +107,7 @@
           </div>
         {% endif %}
       {% endfor %}
-      {% if data.relatedContent.data.length !== 4 and data.relatedContent.data.length !== 7 and data.relatedContent.data.length < 8 %}
+      {% if data.categoryFeaturedContent.data.length !== 4 and data.categoryFeaturedContent.data.length !== 7 and data.categoryFeaturedContent.data.length < 8 %}
       </div>
     {% endif %}
   </div>

--- a/test/repositories/categoryFeaturedContentRepository.spec.js
+++ b/test/repositories/categoryFeaturedContentRepository.spec.js
@@ -2,7 +2,7 @@ const {
   categoryFeaturedContentRepository,
 } = require('../../server/repositories/categoryFeaturedContent');
 
-describe('hubCategoryFeaturedContentRepository', () => {
+describe('CategoryFeaturedContentRepository', () => {
   describe('#contentFor', () => {
     describe('When content is returned from the endpoint', () => {
       it('returns a featured content', async () => {

--- a/test/routes/content.spec.js
+++ b/test/routes/content.spec.js
@@ -393,7 +393,7 @@ describe('GET /content/:id', () => {
           url: '',
         },
       },
-      relatedContent: {
+      categoryFeaturedContent: {
         contentType: 'foo',
         data: [
           {

--- a/test/services/hubContentService.spec.js
+++ b/test/services/hubContentService.spec.js
@@ -166,7 +166,7 @@ describe('#hubContentService', () => {
         content.featuredContentId,
       );
       expect(result).to.have.property('featuredContent', 'fooBar');
-      expect(result).to.have.property('relatedContent');
+      expect(result).to.have.property('categoryFeaturedContent');
       expect(result).to.have.property('categoryMenu', 'categoryMenu');
     });
 


### PR DESCRIPTION
- Renamed relatedContent to categoryFeaturedContent to stop conflicts and misunderstanding