### PR TITLE
Revert ingress class to 'nginx' 

### DIFF
--- a/helm_deploy/prisoner-content-hub-frontend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.development.yaml
@@ -11,6 +11,6 @@ application:
 
 ingress:
   annotations:
-    kubernetes.io/ingress.class: prisoner-content-hub-development
+    kubernetes.io/ingress.class: nginx
   hosts:
     - suffix: -prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-frontend/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.staging.yaml
@@ -8,6 +8,6 @@ application:
 
 ingress:
   annotations:
-    kubernetes.io/ingress.class: prisoner-content-hub-staging
+    kubernetes.io/ingress.class: nginx
   hosts:
     - suffix: -prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
Following the ingress configuration rollback in Cloud Platform, we need to revert our ingress class back to `nginx`.

See https://mojdt.slack.com/archives/C69NWE339/p1601994739044500?thread_ts=1601994124.044000&cid=C69NWE339