### PR TITLE
Fix missing query parameter when calling the Term endpoint

### DIFF
--- a/server/repositories/hubContent.js
+++ b/server/repositories/hubContent.js
@@ -37,17 +37,23 @@ const hubContentRepository = httpClient => {
 
   async function termFor(id, establishmentId) {
     const endpoint = `${config.api.hubTerm}/${id}`;
+
     if (!id) {
       logger.error(`HubContentRepository (termFor) - No ID passed`);
       return null;
     }
-    const response = await httpClient.get(endpoint, {
+
+    const query = {
       _prison: establishmentId,
-    });
+    };
+
+    const response = await httpClient.get(endpoint, { query });
+
     if (isEmptyResponse(response)) {
       logger.error(`HubContentRepository (termFor) - Empty response`);
       return null;
     }
+
     return termResponseFrom(response);
   }
 


### PR DESCRIPTION
The fix is this

```
const response = await httpClient.get(endpoint, { query });
```

Originally we were passing the query as the second parameter, which is wrong, it should be wrapped in an object

So `{ _prison: 123 }` becomes `{ query: { _prison: 123 } }`