### PR TITLE
Add validation for returnUrl in auth flow

### DIFF
--- a/server/auth/__tests__/middleware.spec.js
+++ b/server/auth/__tests__/middleware.spec.js
@@ -3,7 +3,7 @@ const {
   createSignInCallbackMiddleware,
   createSignOutMiddleware,
   isPrisonerId,
-  getReturnUrl,
+  getSafeReturnUrl,
 } = require('../middleware');
 
 const AZURE_AD_OAUTH2_STRATEGY = 'azure_ad_oauth2';
@@ -273,22 +273,26 @@ describe('AuthMiddleware', () => {
     });
   });
 
-  describe('getReturnUrl', () => {
+  describe('getSafeReturnUrl', () => {
     it('should return the default when the URL is absolute or protocol-relative', () => {
-      expect(getReturnUrl({ returnUrl: 'http://foo.bar/baz' })).toBe('/');
-      expect(getReturnUrl({ returnUrl: 'https://foo.bar/baz' })).toBe('/');
-      expect(getReturnUrl({ returnUrl: 'http://foo.bar' })).toBe('/');
-      expect(getReturnUrl({ returnUrl: 'https://foo.bar' })).toBe('/');
-      expect(getReturnUrl({ returnUrl: '//foo.bar' })).toBe('/');
+      expect(getSafeReturnUrl({ returnUrl: 'http://foo.bar/baz' })).toBe('/');
+      expect(getSafeReturnUrl({ returnUrl: 'https://foo.bar/baz' })).toBe('/');
+      expect(getSafeReturnUrl({ returnUrl: 'http://foo.bar' })).toBe('/');
+      expect(getSafeReturnUrl({ returnUrl: 'https://foo.bar' })).toBe('/');
+      expect(getSafeReturnUrl({ returnUrl: '//foo.bar' })).toBe('/');
     });
 
     it('should return the URL when the URL is relative', () => {
-      expect(getReturnUrl({ returnUrl: '/foo' })).toBe('/foo');
-      expect(getReturnUrl({ returnUrl: '/foo/bar' })).toBe('/foo/bar');
+      expect(getSafeReturnUrl({ returnUrl: '/foo' })).toBe('/foo');
+      expect(getSafeReturnUrl({ returnUrl: '/foo/bar' })).toBe('/foo/bar');
     });
 
     it('should default to home if no URL is passed', () => {
-      expect(getReturnUrl()).toBe('/');
+      expect(getSafeReturnUrl()).toBe('/');
+    });
+
+    it('should default to home if argument is not a string', () => {
+      expect(getSafeReturnUrl({ returnUrl: ['foo', 'bar'] })).toBe('/');
     });
   });
 });

--- a/server/auth/middleware.js
+++ b/server/auth/middleware.js
@@ -2,9 +2,14 @@
 const _passport = require('passport');
 const { path } = require('ramda');
 
+const getReturnUrl = ({ returnUrl = '/' } = {}) =>
+  returnUrl.indexOf('://') > 0 || returnUrl.indexOf('//') === 0
+    ? '/'
+    : returnUrl;
+
 const createSignInMiddleware = (passport = _passport) =>
   function signIn(req, res, next) {
-    req.session.returnUrl = req.query.returnUrl || '/';
+    req.session.returnUrl = getReturnUrl(req.query);
     passport.authenticate('azure_ad_oauth2')(req, res, next);
   };
 
@@ -93,7 +98,7 @@ const createSignOutMiddleware = ({ logger, analyticsService }) =>
       sessionId: path(['session', 'id'], req),
       userAgent: path(['body', 'userAgent'], req),
     });
-    res.redirect(req.query.returnUrl || '/');
+    res.redirect(getReturnUrl(req.query));
   };
 
 module.exports = {
@@ -101,5 +106,6 @@ module.exports = {
   createSignInCallbackMiddleware,
   createSignOutMiddleware,
   isPrisonerId,
+  getReturnUrl,
   _authenticate,
 };

--- a/server/auth/middleware.js
+++ b/server/auth/middleware.js
@@ -3,7 +3,9 @@ const _passport = require('passport');
 const { path } = require('ramda');
 
 const getReturnUrl = ({ returnUrl = '/' } = {}) =>
-  returnUrl.indexOf('://') > 0 || returnUrl.indexOf('//') === 0
+  // type-check to mitigate "type confusion through parameter tampering", where an attacker
+  // coerces the param to an array to bypass the indexOf checks
+  typeof returnUrl !== 'string' || returnUrl.indexOf('://') > 0 || returnUrl.indexOf('//') === 0
     ? '/'
     : returnUrl;
 

--- a/server/auth/middleware.js
+++ b/server/auth/middleware.js
@@ -2,16 +2,18 @@
 const _passport = require('passport');
 const { path } = require('ramda');
 
-const getReturnUrl = ({ returnUrl = '/' } = {}) =>
+const getSafeReturnUrl = ({ returnUrl = '/' } = {}) =>
   // type-check to mitigate "type confusion through parameter tampering", where an attacker
   // coerces the param to an array to bypass the indexOf checks
-  typeof returnUrl !== 'string' || returnUrl.indexOf('://') > 0 || returnUrl.indexOf('//') === 0
+  typeof returnUrl !== 'string' ||
+  returnUrl.indexOf('://') > 0 ||
+  returnUrl.indexOf('//') === 0
     ? '/'
     : returnUrl;
 
 const createSignInMiddleware = (passport = _passport) =>
   function signIn(req, res, next) {
-    req.session.returnUrl = getReturnUrl(req.query);
+    req.session.returnUrl = getSafeReturnUrl(req.query);
     passport.authenticate('azure_ad_oauth2')(req, res, next);
   };
 
@@ -100,7 +102,7 @@ const createSignOutMiddleware = ({ logger, analyticsService }) =>
       sessionId: path(['session', 'id'], req),
       userAgent: path(['body', 'userAgent'], req),
     });
-    res.redirect(getReturnUrl(req.query));
+    res.redirect(getSafeReturnUrl(req.query));
   };
 
 module.exports = {
@@ -108,6 +110,6 @@ module.exports = {
   createSignInCallbackMiddleware,
   createSignOutMiddleware,
   isPrisonerId,
-  getReturnUrl,
+  getSafeReturnUrl,
   _authenticate,
 };


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/XSUYKalD/1773-server-side-url-redirect-security-warning

> If this is an issue, do we have steps to reproduce?

- Alter the `returnURL` parameter when logging in to be absolute
- The application should not redirect to the absolute URL but the homepage

### Intent

> What changes are introduced by this PR that correspond to the above card?

Add validation for `returnUrl` parameter in the authentication middleware
- Redirect to the `returnUrl` if it is relative
- Redirect to the homepage if `returnUrl` is absolute or protocol-relative

### Considerations

> Is there any additional information that would help when reviewing this PR?

N/A

> Are there any steps required when merging/deploying this PR?

N/A

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
