### PR TITLE
Ensures tests are run for each non-main branch. Build before approval step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,14 +190,14 @@ workflows:
     jobs:
       - run_unit_and_integration_tests
 
+      - build_preview:
+          <<: *feature_branch
+
       - approve_preview_build:
           <<: *feature_branch
           type: approval
-
-      - build_preview:
-          <<: *feature_branch
           requires:
-            - approve_preview_build
+            - build_preview
 
       - deploy_cloud_platform:
           <<: *feature_branch
@@ -206,7 +206,7 @@ workflows:
             parameters:
               environment: ["development"]
           requires:
-            - build_preview
+            - approve_preview_build
 
       - build_production:
           <<: *main_branch


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/Stp7gjlf/1832-development-branches-arent-built-tested-in-circleci

> If this is an issue, do we have steps to reproduce?
✔ we can see no tests are run in the CircleCI dashboard

### Intent

> What changes are introduced by this PR that correspond to the above card?
This PR flips the approval step for development environment deployments so the build happens first.

This _might_ be better if we split it into two different workflows, so we get a checkmark next to the tests rather than a "pending" because the approval step hasn't been used.

> Would this PR benefit from screenshots?

### Considerations

> Is there any additional information that would help when reviewing this PR?
Check the CircleCI builds for this branch 

> Are there any steps required when merging/deploying this PR?
No

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change **N/A**
- [ ] Documentation has been updated where appropriate **N/A**
- [ ] Tested in Development **N/A**
