### PR TITLE
Add code to filter when calls to the Term API return 404

### DIFF
--- a/server/services/__tests__/hubContentService.spec.js
+++ b/server/services/__tests__/hubContentService.spec.js
@@ -35,6 +35,26 @@ describe('#hubContentService', () => {
       });
     });
 
+    it('should handle when unable to find a Term', async () => {
+      const contentRepository = {
+        contentFor: jest.fn().mockReturnValue({
+          title: 'foo',
+          href: 'www.foo.com',
+          type: 'foo',
+          secondaryTags: [12],
+          categories: [13],
+          description: { raw: '' },
+        }),
+        termFor: jest.fn().mockReturnValue(null),
+      };
+      const service = createHubContentService({ contentRepository });
+      const result = await service.contentFor('contentId');
+
+      expect(result.tags.length).toEqual(0);
+      expect(result.secondaryTagNames.length).toEqual(0);
+      expect(result.categoryNames.length).toEqual(0);
+    });
+
     ['radio', 'video'].forEach(contentType => {
       it(`returns ${contentType} show content`, async () => {
         const contentRepository = {

--- a/server/services/hubContent.js
+++ b/server/services/hubContent.js
@@ -18,7 +18,9 @@ function createHubContentService({
         tag => contentRepository.termFor(tag, establishmentId),
         secondaryTags,
       );
-      const tags = await Promise.all(tagsPromises);
+      const tags = (await Promise.all(tagsPromises)).filter(
+        secondaryTag => secondaryTag !== null,
+      ); // Filter out Terms that returned 404;
 
       content.tags = tags;
       content.secondaryTagNames = tags
@@ -34,7 +36,9 @@ function createHubContentService({
         categories,
       );
 
-      const categoryNames = await Promise.all(categoriesPromises);
+      const categoryNames = (await Promise.all(categoriesPromises)).filter(
+        category => category !== null,
+      ); // Filter out Categories that returned 404;
 
       content.categoryNames = categoryNames
         .map(category => category.name)


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/hwdHR1OQ/1873-content-pages-fail-to-load-when-the-term-api-returns-404

> If this is an issue, do we have steps to reproduce?

- Access `/content/3840` in Wayland

### Intent

> What changes are introduced by this PR that correspond to the above card?

We add `.filter` to the resolved `Promise.all` when retrieving terms for content

> Would this PR benefit from screenshots?

N/A

### Considerations

> Is there any additional information that would help when reviewing this PR?

This is not the ideal fix for this issue, ideally we should return these terms alongside the content. This is a quick fix for brevity.

> Are there any steps required when merging/deploying this PR?

N/A

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
