### PR TITLE
Update Cypress configuration to run locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ Jest is used for unit and integration tests
 
     npm run test
 
+### Running the E2E tests
+
 Cypress is used for E2E testing
 
+**Prerequisites**
+
+- Backing services will need to be run in Docker-Compose using the `prisoner-content-hub` repository
+- Your `/etc/hosts` will need to be configured such that `127.0.0.1 localhost` includes
+  - `wayland.prisoner-content-hub.local`
+  - `berwyn.prisoner-content-hub.local`
+  - `cookhamwood.prisoner-content-hub.local`
+
+To launch the application and open the Cypress test runner
+
     npm run test:e2e:dev
+
+To launch the application and run the Cypress tests
+
+    npm run test:e2e:run

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:3000",
+  "baseUrl": "http://wayland.prisoner-content-hub.local:3000",
   "integrationFolder": "cypress/e2e",
   "viewportWidth": 1280,
   "viewportHeight": 768,

--- a/cypress/e2e/homepage.spec.js
+++ b/cypress/e2e/homepage.spec.js
@@ -1,7 +1,7 @@
 describe('Homepage', () => {
   describe('Cookham Wood', () => {
     beforeEach(() => {
-      cy.visit('/?prison=cookhamwood');
+      cy.visit('http://cookhamwood.prisoner-content-hub.local:3000/');
     });
 
     describe('Navigation', () => {
@@ -29,7 +29,7 @@ describe('Homepage', () => {
   });
   describe('Berwyn', () => {
     beforeEach(() => {
-      cy.visit('/?prison=berwyn');
+      cy.visit('http://berwyn.prisoner-content-hub.local:3000/');
     });
 
     describe('Navigation', () => {
@@ -58,7 +58,7 @@ describe('Homepage', () => {
 
   describe('Wayland', () => {
     beforeEach(() => {
-      cy.visit('/?prison=wayland');
+      cy.visit('http://wayland.prisoner-content-hub.local:3000/');
     });
 
     describe('Navigation', () => {});


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/2Rg3lbdM/1894-get-e2e-tests-running-locally

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

- Update Cypress base URL to allow for inferring prison from hostname
- Update home page tests to use absolute URLs for testing multiple sites
- Update documentation for running E2E tests

> Would this PR benefit from screenshots?

N/A

### Considerations

> Is there any additional information that would help when reviewing this PR?

This PR is to get our existing E2E tests running in Cypress locally

> Are there any steps required when merging/deploying this PR?

N/A

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
