### PR TITLE
Add feature toggle for mocking auth

### DIFF
--- a/helm_deploy/prisoner-content-hub-frontend/templates/deployment.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/templates/deployment.yaml
@@ -92,6 +92,8 @@ spec:
               value: {{ .Values.application.sentry_dsn }}
             - name: ENABLE_REDIS_CACHE
               value: {{ .Values.application.config.enableRedisCache | quote }}
+            - name: ENABLE_MOCK_AUTH
+              value: "false"
             - name: CACHE_SECRET
               valueFrom:
                 secretKeyRef:

--- a/server/config.js
+++ b/server/config.js
@@ -138,6 +138,7 @@ module.exports = {
     personalInformation:
       getEnv('ENABLE_PERSONAL_INFORMATION', 'false') === 'true',
     useRedisCache: getEnv('ENABLE_REDIS_CACHE', 'true') === 'true',
+    useMockAuth: getEnv('ENABLE_MOCK_AUTH', 'false') === 'true',
     showStackTraces:
       getEnv('ENABLE_STACK_TRACES_ON_ERROR_PAGES', 'false') === 'true',
   },


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/7XkW9uMD/1931-how-do-we-test-sign-in-out-e2e

### Intent

> What changes are introduced by this PR that correspond to the above card?

- Create mock auth middleware
- Add feature toggle `ENABLE_MOCK_AUTH`

So.....

- Clicking sign-in/out with mocking enabled will use a "test" user

### Considerations

> Is there any additional information that would help when reviewing this PR?

Turns out mocking getting our AzureAD SSO set up with Cypress is difficult, especially with our current setup and how we intend to run these tests.
To ensure we're not blocked on this work, and until we have a better solution, there's this PR ☝️ 

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
