### PR TITLE
Fix Booking ID validation for balances API call

### DIFF
--- a/server/repositories/__tests__/prisonApi.spec.js
+++ b/server/repositories/__tests__/prisonApi.spec.js
@@ -143,10 +143,10 @@ describe('PrisonApiRepository', () => {
 
       client.get.mockResolvedValue('API_RESPONSE');
 
-      const response = await repository.getBalancesFor(4567);
+      const response = await repository.getBalancesFor(1234567);
 
       expect(client.get).toHaveBeenCalledWith(
-        'http://foo.bar/api/bookings/4567/balances',
+        'http://foo.bar/api/bookings/1234567/balances',
       );
 
       expect(response).toBe('API_RESPONSE');
@@ -167,7 +167,7 @@ describe('PrisonApiRepository', () => {
 
       client.get.mockRejectedValue('💥');
 
-      const response = await repository.getBalancesFor(4567);
+      const response = await repository.getBalancesFor(1234567);
 
       expect(response).toBeNull();
     });

--- a/server/repositories/prisonApi.js
+++ b/server/repositories/prisonApi.js
@@ -72,7 +72,7 @@ class PrisonApiRepository {
   async getBalancesFor(bookingId) {
     assert(
       isValidBookingId(bookingId),
-      `Booking ID must be in the format 1234 - Received: ${bookingId}`,
+      `Booking ID must be a number - Received: ${bookingId}`,
     );
 
     try {

--- a/server/routes/__tests__/money.spec.js
+++ b/server/routes/__tests__/money.spec.js
@@ -32,7 +32,7 @@ describe('GET /money/transactions', () => {
     prisonerId: 'A1234BC',
     firstName: 'Test',
     surname: 'User',
-    bookingId: 5678,
+    bookingId: 1234567,
   });
 
   const transactionApiResponse = [

--- a/server/utils/__tests__/validators.spec.js
+++ b/server/utils/__tests__/validators.spec.js
@@ -36,10 +36,6 @@ describe('Validators', () => {
       expect(isValidBookingId(4321)).toBeTruthy();
     });
 
-    it('returns null when the number passed is not 4 digits', () => {
-      expect(isValidBookingId(43213)).toBeFalsy();
-    });
-
     it('returns null when passed data of the wrong type', () => {
       expect(isValidBookingId('1234')).toBeFalsy();
       expect(isValidBookingId([])).toBeFalsy();

--- a/server/utils/validators.js
+++ b/server/utils/validators.js
@@ -1,7 +1,6 @@
 const isValidPrisonerId = s =>
   typeof s === 'string' && s.match(/^[A-Z][0-9]{4}[A-Z]{2}$/i);
-const isValidBookingId = n =>
-  typeof n === 'number' && n.toString().match(/^[0-9]{4}$/);
+const isValidBookingId = n => typeof n === 'number';
 const isValidPrisonId = s => typeof s === 'string' && s.match(/^[A-Z]{3}$/i);
 const isValidAccountCode = s =>
   typeof s === 'string' && ['spends', 'cash', 'savings'].includes(s);


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/dY96wSWn/1993-transactions-history-isnt-shown-in-production

> If this is an issue, do we have steps to reproduce?

- Log in with a production account
- Navigate to `/money/transactions`
- The transaction information will not be displayed

### Intent

> What changes are introduced by this PR that correspond to the above card?

- Removed the length assertion for the Booking ID validator

### Considerations

> Is there any additional information that would help when reviewing this PR?

- Booking ID's appear to be variable length, as opposed to fixed length as thought based on test accounts

> Are there any steps required when merging/deploying this PR?

Nope

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
