### PR TITLE
Add sentry capture exception when getting transactions

### DIFF
--- a/server/repositories/__tests__/prisonApi.spec.js
+++ b/server/repositories/__tests__/prisonApi.spec.js
@@ -1,4 +1,7 @@
+const Sentry = require('@sentry/node');
 const { PrisonApiRepository } = require('../prisonApi');
+
+jest.mock('@sentry/node');
 
 describe('PrisonApiRepository', () => {
   const client = { get: jest.fn() };
@@ -107,6 +110,7 @@ describe('PrisonApiRepository', () => {
         new Date('2020-01-31'),
       );
 
+      expect(Sentry.captureException).toHaveBeenCalledWith('💥');
       expect(response).toBeNull();
     });
   });
@@ -133,6 +137,7 @@ describe('PrisonApiRepository', () => {
 
       const response = await repository.getPrisonDetails();
 
+      expect(Sentry.captureException).toHaveBeenCalledWith('💥');
       expect(response).toStrictEqual([]);
     });
   });
@@ -169,6 +174,7 @@ describe('PrisonApiRepository', () => {
 
       const response = await repository.getBalancesFor(1234567);
 
+      expect(Sentry.captureException).toHaveBeenCalledWith('💥');
       expect(response).toBeNull();
     });
   });

--- a/server/repositories/prisonApi.js
+++ b/server/repositories/prisonApi.js
@@ -1,6 +1,8 @@
 const querystring = require('querystring');
 const assert = require('assert');
 const { formatISO } = require('date-fns');
+const Sentry = require('@sentry/node');
+
 const { logger } = require('../utils/logger');
 const {
   isValidPrisonerId,
@@ -45,6 +47,7 @@ class PrisonApiRepository {
 
       return response;
     } catch (e) {
+      Sentry.captureException(e);
       logger.error(
         `PrisonApiRepository (getTransactionsFor) - Failed: ${e.message} - User: ${prisonerId}`,
       );
@@ -61,6 +64,7 @@ class PrisonApiRepository {
 
       return response;
     } catch (e) {
+      Sentry.captureException(e);
       logger.error(
         `PrisonApiRepository (getPrisonDetailsFor) - Failed: ${e.message}`,
       );
@@ -82,6 +86,7 @@ class PrisonApiRepository {
 
       return response;
     } catch (e) {
+      Sentry.captureException(e);
       logger.error(
         `PrisonApiRepository (getBalancesFor) - Failed: ${e.message} - Booking ID: ${bookingId}`,
       );

--- a/server/services/__tests__/prisonerInformation.spec.js
+++ b/server/services/__tests__/prisonerInformation.spec.js
@@ -1,5 +1,8 @@
+const Sentry = require('@sentry/node');
 const { PrisonerInformationService } = require('../prisonerInformation');
 const { User } = require('../../auth/user');
+
+jest.mock('@sentry/node');
 
 describe('PrisonerInformation', () => {
   let prisonApiRepository = {};
@@ -299,6 +302,7 @@ describe('PrisonerInformation', () => {
         new Date('2021-01-01'),
       );
 
+      expect(Sentry.captureException).toHaveBeenCalledWith('💥');
       expect(result).toBeNull();
     });
 
@@ -318,6 +322,7 @@ describe('PrisonerInformation', () => {
         new Date('2021-01-01'),
       );
 
+      expect(Sentry.captureException).toHaveBeenCalledWith('💥');
       expect(result).toBeNull();
     });
 
@@ -337,6 +342,7 @@ describe('PrisonerInformation', () => {
         new Date('2021-01-01'),
       );
 
+      expect(Sentry.captureException).toHaveBeenCalledWith('💥');
       expect(result).toBeNull();
     });
   });

--- a/server/services/prisonerInformation.js
+++ b/server/services/prisonerInformation.js
@@ -1,3 +1,5 @@
+const Sentry = require('@sentry/node');
+
 const { logger } = require('../utils/logger');
 
 function createPrisonMapFrom(prisonDetailsResponse) {
@@ -66,6 +68,7 @@ class PrisonerInformationService {
         balances,
       };
     } catch (e) {
+      Sentry.captureException(e);
       logger.error(
         `PrisonerInformationService (getTransactionInformationFor) - Failed: ${e.message}`,
       );


### PR DESCRIPTION
### Context

https://trello.com/c/c6JWJSeX/1994-5xx-responses-from-frontend-dont-raise-sentry-alerts

### Intent

To capture transaction exceptions in Sentry

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
