### PR TITLE
🧹 Remove NPM verify from Dockerfile, tests are run in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,6 @@ ENV BUILD_NUMBER=${BUILD_NUMBER}
 ENV GIT_REF=${GIT_REF}
 ENV GIT_DATE=${GIT_DATE}
 
-# Run application verification
-RUN npm run verify
-
 RUN apk del git
 
 EXPOSE 3000


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
No

### Intent

This PR removes the test step from the Dockerfile, because we run tests as part of CI. 
