### PR TITLE
Add additional logic when formatting transactions to split batch payments

### DIFF
--- a/server/routes/__tests__/formatters.spec.js
+++ b/server/routes/__tests__/formatters.spec.js
@@ -13,6 +13,55 @@ describe('Responses', () => {
         postingType: 'DR',
         prison: 'HMP Test',
         currentBalance: 12345,
+        relatedOffenderTransactions: [],
+      },
+    ];
+
+    const relatedTransactions = [
+      {
+        entryDate: '2021-03-09',
+        transactionType: 'TELE',
+        entryDescription: 'Television',
+        currency: 'GBP',
+        penceAmount: 50,
+        accountType: 'SPND',
+        postingType: 'DR',
+        prison: 'HMP Test',
+        currentBalance: 12295,
+        relatedOffenderTransactions: [],
+      },
+      {
+        entryDate: '2021-03-08',
+        transactionType: 'A_EARN',
+        entryDescription: 'Payroll',
+        currency: 'GBP',
+        penceAmount: 100,
+        accountType: 'SPND',
+        postingType: 'CR',
+        prison: 'HMP Test',
+        currentBalance: 12345,
+        relatedOffenderTransactions: [
+          {
+            transactionEntrySequence: 1,
+            calendarDate: '2021-03-08',
+            payTypeCode: 'TST2',
+            eventId: null,
+            payAmount: 50,
+            pieceWork: 0,
+            bonusPay: 0,
+            paymentDescription: 'Test 2',
+          },
+          {
+            transactionEntrySequence: 1,
+            calendarDate: '2021-03-08',
+            payTypeCode: 'TST',
+            eventId: null,
+            payAmount: 50,
+            pieceWork: 0,
+            bonusPay: 0,
+            paymentDescription: 'Test 1',
+          },
+        ],
       },
     ];
 
@@ -41,15 +90,16 @@ describe('Responses', () => {
         balances: balancesApiResponse,
       });
 
-      expect(formatted.transactions.length).toBe(1);
-      expect(formatted.transactions[0]).toEqual({
-        balance: '£123.45',
-        moneyIn: '£0.50',
-        moneyOut: null,
-        paymentDate: '23 February 2021',
-        paymentDescription: 'Television',
-        prison: 'HMP Test',
-      });
+      expect(formatted.transactions).toEqual([
+        {
+          balance: '£123.45',
+          moneyIn: '£0.50',
+          moneyOut: null,
+          paymentDate: '23 February 2021',
+          paymentDescription: 'Television',
+          prison: 'HMP Test',
+        },
+      ]);
     });
 
     it('formats negative transactions when present', () => {
@@ -70,31 +120,50 @@ describe('Responses', () => {
         balances: balancesApiResponse,
       });
 
-      expect(formatted.transactions.length).toBe(1);
-      expect(formatted.transactions[0]).toEqual({
-        balance: '£123.45',
-        moneyIn: null,
-        moneyOut: '-£0.50',
-        paymentDate: '23 February 2021',
-        paymentDescription: 'Television',
-        prison: 'HMP Test',
-      });
+      expect(formatted.transactions).toEqual([
+        {
+          balance: '£123.45',
+          moneyIn: null,
+          moneyOut: '-£0.50',
+          paymentDate: '23 February 2021',
+          paymentDescription: 'Television',
+          prison: 'HMP Test',
+        },
+      ]);
     });
-    it('formats negative transactions when present', () => {
+
+    it('formats related transactions when present', () => {
       const formatted = formatTransactionPageData('spends', {
-        transactions: transactionApiResponse,
+        transactions: relatedTransactions,
         balances: balancesApiResponse,
       });
 
-      expect(formatted.transactions.length).toBe(1);
-      expect(formatted.transactions[0]).toEqual({
-        balance: '£123.45',
-        moneyIn: null,
-        moneyOut: '-£0.50',
-        paymentDate: '23 February 2021',
-        paymentDescription: 'Television',
-        prison: 'HMP Test',
-      });
+      expect(formatted.transactions).toEqual([
+        {
+          balance: '£122.95',
+          moneyIn: null,
+          moneyOut: '-£0.50',
+          paymentDate: '9 March 2021',
+          paymentDescription: 'Television',
+          prison: 'HMP Test',
+        },
+        {
+          balance: '£123.45',
+          moneyIn: '£0.50',
+          moneyOut: null,
+          paymentDate: '8 March 2021',
+          paymentDescription: 'Test 2 from 8 March 2021',
+          prison: 'HMP Test',
+        },
+        {
+          balance: '£122.95',
+          moneyIn: '£0.50',
+          moneyOut: null,
+          paymentDate: '8 March 2021',
+          paymentDescription: 'Test 1 from 8 March 2021',
+          prison: 'HMP Test',
+        },
+      ]);
     });
 
     it('returns an error notification when present for transactions', () => {

--- a/server/routes/__tests__/formatters.spec.js
+++ b/server/routes/__tests__/formatters.spec.js
@@ -43,7 +43,7 @@ describe('Responses', () => {
         relatedOffenderTransactions: [
           {
             transactionEntrySequence: 1,
-            calendarDate: '2021-03-08',
+            calendarDate: '2021-03-07',
             payTypeCode: 'TST2',
             eventId: null,
             payAmount: 50,
@@ -152,7 +152,7 @@ describe('Responses', () => {
           moneyIn: '£0.50',
           moneyOut: null,
           paymentDate: '8 March 2021',
-          paymentDescription: 'Test 2 from 8 March 2021',
+          paymentDescription: 'Test 1 from 8 March 2021',
           prison: 'HMP Test',
         },
         {
@@ -160,7 +160,7 @@ describe('Responses', () => {
           moneyIn: '£0.50',
           moneyOut: null,
           paymentDate: '8 March 2021',
-          paymentDescription: 'Test 1 from 8 March 2021',
+          paymentDescription: 'Test 2 from 7 March 2021',
           prison: 'HMP Test',
         },
       ]);

--- a/server/routes/formatters.js
+++ b/server/routes/formatters.js
@@ -1,5 +1,6 @@
+const { parseISO } = require('date-fns');
 const { formatBalanceOrDefault } = require('../utils/string');
-const { formatDateOrDefault } = require('../utils/date');
+const { formatDateOrDefault, sortByDateTime } = require('../utils/date');
 
 function formatTransaction(transaction) {
   return {
@@ -37,16 +38,89 @@ function formatBalance(accountType, balances) {
   };
 }
 
+function flattenTransactions(transactions) {
+  const batchTransactionsOnly = transaction =>
+    Array.isArray(transaction.relatedOffenderTransactions) &&
+    transaction.relatedOffenderTransactions.length;
+
+  const sortByRecentEntryDateThenByRecentCalendarDate = (
+    transaction1,
+    transaction2,
+  ) => {
+    if (transaction1.entryDate && transaction2.entryDate)
+      return (
+        parseISO(transaction2.entryDate).valueOf() -
+        parseISO(transaction1.entryDate).valueOf()
+      );
+    if (transaction1.entryDate) return -1;
+    if (transaction2.entryDate) return 1;
+
+    if (transaction1.calendarDate && transaction2.calendarDate)
+      return (
+        parseISO(transaction2.calendarDate).valueOf() -
+        parseISO(transaction1.calendarDate).valueOf()
+      );
+    if (transaction1.calendarDate) return -1;
+    if (transaction2.calendarDate) return 1;
+
+    return 0;
+  };
+  const sortByOldestCalendarDate = (transaction1, transaction2) =>
+    sortByDateTime(transaction1.calendarDate, transaction2.calendarDate);
+
+  const relatedTransactions = transactions
+    .filter(batchTransactionsOnly)
+    .sort(sortByOldestCalendarDate)
+    .flatMap(batchTransaction => {
+      const related = batchTransaction.relatedOffenderTransactions.map(
+        relatedTransaction => ({
+          entryDate: batchTransaction.entryDate,
+          penceAmount: relatedTransaction.payAmount,
+          entryDescription: `${
+            relatedTransaction.paymentDescription
+          } from ${formatDateOrDefault(
+            '',
+            'd MMMM yyyy',
+            relatedTransaction.calendarDate,
+          )}`,
+          postingType: 'CR',
+          currency: batchTransaction.currency,
+          prison: batchTransaction.prison,
+        }),
+      );
+
+      let adjustedBalance = batchTransaction.currentBalance;
+
+      return related.map(current => {
+        const withBalance = {
+          ...current,
+          currentBalance: adjustedBalance,
+        };
+        adjustedBalance -= current.penceAmount;
+        return withBalance;
+      });
+    });
+
+  const transactionsExcludingRelated = transactions.filter(
+    transaction => !batchTransactionsOnly(transaction),
+  );
+
+  return [...transactionsExcludingRelated, ...relatedTransactions].sort(
+    sortByRecentEntryDateThenByRecentCalendarDate,
+  );
+}
+
 function formatTransactionPageData(accountType, transactionsData) {
   if (transactionsData) {
     const { balances, transactions } = transactionsData;
+
     return {
       balance: balances.error
         ? { error: balances.error }
         : formatBalance(accountType, balances),
       transactions: transactions.error
         ? { error: transactions.error }
-        : transactions.map(formatTransaction),
+        : flattenTransactions(transactions).map(formatTransaction),
     };
   }
 

--- a/server/routes/formatters.js
+++ b/server/routes/formatters.js
@@ -47,33 +47,32 @@ function flattenTransactions(transactions) {
     transaction1,
     transaction2,
   ) => {
-    if (transaction1.entryDate && transaction2.entryDate)
-      return (
-        parseISO(transaction2.entryDate).valueOf() -
-        parseISO(transaction1.entryDate).valueOf()
-      );
-    if (transaction1.entryDate) return -1;
-    if (transaction2.entryDate) return 1;
+    const diff =
+      parseISO(transaction2.entryDate).valueOf() -
+      parseISO(transaction1.entryDate).valueOf();
 
-    if (transaction1.calendarDate && transaction2.calendarDate)
+    if (diff !== 0) {
+      return diff;
+    }
+
+    if (transaction1.calendarDate && transaction2.calendarDate) {
       return (
         parseISO(transaction2.calendarDate).valueOf() -
         parseISO(transaction1.calendarDate).valueOf()
       );
-    if (transaction1.calendarDate) return -1;
-    if (transaction2.calendarDate) return 1;
+    }
 
     return 0;
   };
   const sortByOldestCalendarDate = (transaction1, transaction2) =>
-    sortByDateTime(transaction1.calendarDate, transaction2.calendarDate);
+    sortByDateTime(transaction2.calendarDate, transaction1.calendarDate);
 
   const relatedTransactions = transactions
     .filter(batchTransactionsOnly)
-    .sort(sortByOldestCalendarDate)
     .flatMap(batchTransaction => {
-      const related = batchTransaction.relatedOffenderTransactions.map(
-        relatedTransaction => ({
+      const related = batchTransaction.relatedOffenderTransactions
+        .sort(sortByOldestCalendarDate)
+        .map(relatedTransaction => ({
           entryDate: batchTransaction.entryDate,
           penceAmount: relatedTransaction.payAmount,
           entryDescription: `${
@@ -86,8 +85,7 @@ function flattenTransactions(transactions) {
           postingType: 'CR',
           currency: batchTransaction.currency,
           prison: batchTransaction.prison,
-        }),
-      );
+        }));
 
       let adjustedBalance = batchTransaction.currentBalance;
 

--- a/server/utils/date.js
+++ b/server/utils/date.js
@@ -16,7 +16,16 @@ const formatTimeBetweenOrDefault = (placeHolder, start, finish) => {
     : formatDistance(parseISO(start), new Date());
 };
 
+const sortByDateTime = (firstDate, secondDate) => {
+  if (firstDate && secondDate)
+    return parseISO(firstDate).valueOf() - parseISO(secondDate).valueOf();
+  if (firstDate) return -1;
+  if (secondDate) return 1;
+  return 0;
+};
+
 module.exports = {
   formatDateOrDefault,
   formatTimeBetweenOrDefault,
+  sortByDateTime,
 };


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/yqqUn6b5/1996-add-additional-logic-to-split-out-batch-payments-for-transactions

### Intent

> What changes are introduced by this PR that correspond to the above card?

- Split batch Payroll payments out, displaying the individual related transactions

> Would this PR benefit from screenshots?

<img width="1495" alt="Screenshot 2021-03-09 at 16 00 12" src="https://user-images.githubusercontent.com/20080441/110655024-95ab6200-81b6-11eb-9021-7b46a1ba2c5a.png">

### Considerations

> Is there any additional information that would help when reviewing this PR?

Original code from Prisoner Staff Hub for reference:
`https://github.com/ministryofjustice/prisonstaffhub/blob/main/backend/controllers/prisonerProfile/prisonerFinances/prisonerSpends.js`

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
