### PR TITLE
Add date selection to the transactions page

### DIFF
--- a/assets/sass/components/_personalised.scss
+++ b/assets/sass/components/_personalised.scss
@@ -163,3 +163,28 @@
     width: 29.3%;
   }
 }
+
+.transactions__selection_wrapper {
+  background: govuk-colour('light-grey');
+  padding: govuk-spacing(3);
+  margin-bottom: govuk-spacing(5);
+}
+
+.transactions__selection__form {
+  display: flex;
+  flex-flow: row wrap;
+
+  & .govuk-form-group {
+    margin-right: 15px;
+  }
+
+  & * {
+    width: auto;
+    margin-bottom: 0;
+  }
+
+  & button {
+    align-self: flex-end;
+    margin-bottom: 2px;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3328,9 +3328,9 @@
       }
     },
     "@hapi/hoek": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
-      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw==",
       "dev": true
     },
     "@hapi/topo": {
@@ -3624,6 +3624,17 @@
         "jest-message-util": "^26.6.2",
         "jest-mock": "^26.6.2",
         "jest-util": "^26.6.2"
+      },
+      "dependencies": {
+        "@sinonjs/fake-timers": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+          "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        }
       }
     },
     "@jest/globals": {
@@ -3999,9 +4010,9 @@
       }
     },
     "@sideway/address": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.0.tgz",
-      "integrity": "sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.1.tgz",
+      "integrity": "sha512-+I5aaQr3m0OAmMr7RQ3fR9zx55sejEYR2BFJaxL+zT3VM2611X0SHvPWIbAUBZVTn/YzYKbV8gJ2oT/QELknfQ==",
       "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.0"
@@ -4026,18 +4037,18 @@
       "dev": true
     },
     "@sinonjs/commons": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
-      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
+      "integrity": "sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
-      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.0.2.tgz",
+      "integrity": "sha512-dF84L5YC90gIOegPDCYymPIsDmwMWWSh7BwfDXQYePi8lVIEp7IZ1UVGkME8FjXOsDPxan12x4aaK+Lo6wVh9A==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
@@ -11623,9 +11634,9 @@
       }
     },
     "joi": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.3.0.tgz",
-      "integrity": "sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.0.tgz",
+      "integrity": "sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==",
       "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.0",
@@ -15817,9 +15828,9 @@
       }
     },
     "start-server-and-test": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.11.6.tgz",
-      "integrity": "sha512-+0T83W/R7CVgIE2HJcrpJDleLt7Skc2Xj8jWWsItRGdpZwenAv0YtIpBEKoL64pwUtPAPoHuYUtvWUOfCRoVjg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.12.0.tgz",
+      "integrity": "sha512-y3M/PLUPkPBsgKoengMIMQeceT8uOnOc4bkdor/RSCK9Ih/j8z4WthSCrAboXLjgtJJWOporAiEQsnYox+THXg==",
       "dev": true,
       "requires": {
         "bluebird": "3.7.2",
@@ -15828,7 +15839,7 @@
         "execa": "3.4.0",
         "lazy-ass": "1.6.0",
         "ps-tree": "1.2.0",
-        "wait-on": "5.2.0"
+        "wait-on": "5.2.1"
       },
       "dependencies": {
         "cross-spawn": {
@@ -17315,51 +17326,16 @@
       }
     },
     "wait-on": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-5.2.0.tgz",
-      "integrity": "sha512-U1D9PBgGw2XFc6iZqn45VBubw02VsLwnZWteQ1au4hUVHasTZuFSKRzlTB2dqgLhji16YVI8fgpEpwUdCr8B6g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-5.2.1.tgz",
+      "integrity": "sha512-H2F986kNWMU9hKlI9l/ppO6tN8ZSJd35yBljMLa1/vjzWP++Qh6aXyt77/u7ySJFZQqBtQxnvm/xgG48AObXcw==",
       "dev": true,
       "requires": {
-        "axios": "^0.19.2",
-        "joi": "^17.1.1",
-        "lodash": "^4.17.19",
+        "axios": "^0.21.1",
+        "joi": "^17.3.0",
+        "lodash": "^4.17.20",
         "minimist": "^1.2.5",
-        "rxjs": "^6.5.5"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.19.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-          "dev": true,
-          "requires": {
-            "follow-redirects": "1.5.10"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "dev": true,
-          "requires": {
-            "debug": "=3.1.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
+        "rxjs": "^6.6.3"
       }
     },
     "walker": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "nodemon": "^2.0.6",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",
-    "start-server-and-test": "^1.11.6",
+    "@sinonjs/fake-timers": "^7.0.2",
+    "start-server-and-test": "^1.12.0",
     "supertest": "^6.0.1"
   }
 }

--- a/server/utils/__tests__/date.spec.js
+++ b/server/utils/__tests__/date.spec.js
@@ -1,6 +1,14 @@
-const { formatDateOrDefault, formatTimeBetweenOrDefault } = require('../date');
+const {
+  formatDateOrDefault,
+  formatTimeBetweenOrDefault,
+  getDateSelection,
+} = require('../date');
 
 describe('DateUtils', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   describe('formatDateOrDefault', () => {
     it('should format a valid date', () => {
       const formatted = formatDateOrDefault(
@@ -47,13 +55,86 @@ describe('DateUtils', () => {
 
       const formatted = formatTimeBetweenOrDefault('PLACEHOLDER', '2020-08-01');
       expect(formatted).toMatch(/1 month/i);
-
-      // clock.restore();
     });
 
     it('should return a placeholder when no start date provided', () => {
       const formatted = formatTimeBetweenOrDefault('PLACEHOLDER', undefined);
       expect(formatted).toBe('PLACEHOLDER');
     });
+  });
+});
+
+describe('getDateSelectionFrom', () => {
+  it('defaults to generating the previous 12 months from today', () => {
+    jest
+      .useFakeTimers('modern')
+      .setSystemTime(new Date('2021-03-10T12:00:00').getTime());
+
+    const dateRange = getDateSelection();
+    expect(dateRange).toEqual([
+      { text: 'March 2021', value: '2021-03-01' },
+      { text: 'February 2021', value: '2021-02-01' },
+      { text: 'January 2021', value: '2021-01-01' },
+      { text: 'December 2020', value: '2020-12-01' },
+      { text: 'November 2020', value: '2020-11-01' },
+      { text: 'October 2020', value: '2020-10-01' },
+      { text: 'September 2020', value: '2020-09-01' },
+      { text: 'August 2020', value: '2020-08-01' },
+      { text: 'July 2020', value: '2020-07-01' },
+      { text: 'June 2020', value: '2020-06-01' },
+      { text: 'May 2020', value: '2020-05-01' },
+      { text: 'April 2020', value: '2020-04-01' },
+    ]);
+  });
+
+  it('allows you to specify the date', () => {
+    const dateRange = getDateSelection(new Date('2021-02-18'));
+    expect(dateRange).toEqual([
+      { text: 'February 2021', value: '2021-02-01' },
+      { text: 'January 2021', value: '2021-01-01' },
+      { text: 'December 2020', value: '2020-12-01' },
+      { text: 'November 2020', value: '2020-11-01' },
+      { text: 'October 2020', value: '2020-10-01' },
+      { text: 'September 2020', value: '2020-09-01' },
+      { text: 'August 2020', value: '2020-08-01' },
+      { text: 'July 2020', value: '2020-07-01' },
+      { text: 'June 2020', value: '2020-06-01' },
+      { text: 'May 2020', value: '2020-05-01' },
+      { text: 'April 2020', value: '2020-04-01' },
+      { text: 'March 2020', value: '2020-03-01' },
+    ]);
+  });
+
+  it('allows you to specify the selected date', () => {
+    const dateRange = getDateSelection(
+      new Date('2021-02-18'),
+      new Date('2021-01-27'),
+    );
+    expect(dateRange).toEqual([
+      { text: 'February 2021', value: '2021-02-01' },
+      { text: 'January 2021', value: '2021-01-01', selected: true },
+      { text: 'December 2020', value: '2020-12-01' },
+      { text: 'November 2020', value: '2020-11-01' },
+      { text: 'October 2020', value: '2020-10-01' },
+      { text: 'September 2020', value: '2020-09-01' },
+      { text: 'August 2020', value: '2020-08-01' },
+      { text: 'July 2020', value: '2020-07-01' },
+      { text: 'June 2020', value: '2020-06-01' },
+      { text: 'May 2020', value: '2020-05-01' },
+      { text: 'April 2020', value: '2020-04-01' },
+      { text: 'March 2020', value: '2020-03-01' },
+    ]);
+  });
+
+  it('allows you to specify the size of the date range', () => {
+    const dateRange = getDateSelection(new Date('2021-02-18'), null, 6);
+    expect(dateRange).toEqual([
+      { text: 'February 2021', value: '2021-02-01' },
+      { text: 'January 2021', value: '2021-01-01' },
+      { text: 'December 2020', value: '2020-12-01' },
+      { text: 'November 2020', value: '2020-11-01' },
+      { text: 'October 2020', value: '2020-10-01' },
+      { text: 'September 2020', value: '2020-09-01' },
+    ]);
   });
 });

--- a/server/utils/date.js
+++ b/server/utils/date.js
@@ -1,4 +1,12 @@
-const { parseISO, format, isValid, formatDistance } = require('date-fns');
+const {
+  parseISO,
+  format,
+  isValid,
+  formatDistance,
+  startOfMonth,
+  subMonths,
+  formatISO,
+} = require('date-fns');
 
 const formatDateOrDefault = (placeHolder = '', dateFormat, date) => {
   if (!isValid(new Date(date))) {
@@ -16,7 +24,32 @@ const formatTimeBetweenOrDefault = (placeHolder, start, finish) => {
     : formatDistance(parseISO(start), new Date());
 };
 
+const getDateSelection = (date = new Date(), selectedDate, amount = 12) => {
+  const startDate = startOfMonth(date);
+  const dateRange = [];
+
+  for (let offset = 0; offset < amount; offset += 1) {
+    const current = subMonths(startDate, offset);
+    const element = {
+      text: format(current, 'MMMM yyyy'),
+      value: formatISO(current, { representation: 'date' }),
+    };
+
+    if (
+      selectedDate &&
+      startOfMonth(selectedDate).valueOf() === current.valueOf()
+    ) {
+      element.selected = true;
+    }
+
+    dateRange.push(element);
+  }
+
+  return dateRange;
+};
+
 module.exports = {
   formatDateOrDefault,
   formatTimeBetweenOrDefault,
+  getDateSelection,
 };

--- a/server/views/components/personal-transactions/template.njk
+++ b/server/views/components/personal-transactions/template.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% if not isLoggedIn %}
   <h2 class="govuk-heading-m">You are signed out</h2>
@@ -43,6 +44,26 @@
           <a href="/content/8534" class="govuk-link">Read more about what the information on this page means</a>.
         </div>
       </details>
+      {% from "govuk/components/select/macro.njk" import govukSelect %}
+      <div class="transactions__selection_wrapper">
+        <h3 class="govuk-heading-m">View by</h3>
+        <form method="GET">
+          <div class="transactions__selection__form">
+            <input type="hidden" name="accountType" value="{{ params.selected }}"/>
+            {{ govukSelect({
+              id: "selected-date",
+              name: "selectedDate",
+              label: {
+                text: "Date"
+              },
+              items: params.dateSelection
+            }) }}
+            {{ govukButton({
+              text: "View"
+            }) }}
+          </div>
+        </form>
+      </div>
       <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">

--- a/server/views/pages/transactions.html
+++ b/server/views/pages/transactions.html
@@ -55,6 +55,8 @@
         balance: prisonerInformation.balance,
         selected: prisonerInformation.selected,
         accountTypes: prisonerInformation.accountTypes,
+        selectedDate: prisonerInformation.selectedDate,
+        dateSelection: prisonerInformation.dateSelection,
         authReturnUrl: config.returnUrl
     }, config.userName) }}
 


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/HNOkkbXj/1933-i-would-like-to-select-the-date-range-transaction-history

### Intent

> What changes are introduced by this PR that correspond to the above card?

- Add date selection for viewing transactions

> Would this PR benefit from screenshots?

![image](https://user-images.githubusercontent.com/20080441/110947405-03cb6280-8338-11eb-964e-faa70bdcf81b.png)

![image](https://user-images.githubusercontent.com/20080441/110947417-0928ad00-8338-11eb-9911-c383fc3136b6.png)

### Considerations

> Is there any additional information that would help when reviewing this PR?

There was an issue with using `Jest.useFakeTimers` with async functions, I've used `@sinonjs/fake-timers` for testing and added comments to explain the usage

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
