### PR TITLE
Add Sentry alerting on failure to authenticate

### DIFF
--- a/server/auth/middleware.js
+++ b/server/auth/middleware.js
@@ -1,4 +1,5 @@
-// eslint-disable-next-line no-underscore-dangle
+/* eslint no-underscore-dangle: ["error", { "allow": ["_passport"] }] */
+const Sentry = require('@sentry/node');
 const _passport = require('passport');
 const { path } = require('ramda');
 const { User } = require('./user');
@@ -18,13 +19,14 @@ const createSignInMiddleware = (passport = _passport) =>
     passport.authenticate('azure_ad_oauth2')(req, res, next);
   };
 
-// eslint-disable-next-line no-underscore-dangle
+/* eslint no-underscore-dangle: ["error", { "allow": ["_passport", "_authenticate"] }] */
 const _authenticate = (req, res, next) =>
   new Promise((resolve, reject) => {
     _passport.authenticate('azure_ad_oauth2', (err, user) => {
       if (err) {
         reject(err);
       }
+
       req.logIn(user, loginErr =>
         loginErr ? reject(loginErr) : resolve(user),
       );
@@ -101,6 +103,7 @@ const createSignInCallbackMiddleware = ({
 
       return res.redirect(req.session.returnUrl);
     } catch (e) {
+      Sentry.captureException(e);
       logger.error(
         `SignInCallbackMiddleware (signInCallback) - Failed: ${e.message}`,
       );


### PR DESCRIPTION
### Context
Does this issue have a Trello card?

https://trello.com/c/c6JWJSeX

### Intent
What changes are introduced by this PR that correspond to the above card?

Enable Sentry on middleware failure to authenticate

### Considerations
Is there any additional information that would help when reviewing this PR?

Eslint flagged no-underscore-dangle - commented code to ensure that the relevant variables are ignored

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
