### PR TITLE
Feature/add damage obligations route and template

### DIFF
--- a/server/routes/__tests__/formatters.spec.js
+++ b/server/routes/__tests__/formatters.spec.js
@@ -72,6 +72,7 @@ describe('Responses', () => {
       spends: 123.45,
       cash: 456.78,
       savings: 890.12,
+      damageObligations: 50,
       currency: 'GBP',
     };
 
@@ -196,6 +197,27 @@ describe('Responses', () => {
 
       expect(formatted.balance).not.toHaveProperty('amount');
       expect(formatted.balance.error).toBe('💥');
+    });
+
+    it('sets the flag to display the damage obligations tab when there is money owed', () => {
+      const formatted = formatTransactionPageData('spends', {
+        transactions: transactionApiResponse,
+        balances: balancesApiResponse,
+      });
+
+      expect(formatted.shouldShowDamageObligationsTab).toBe(true);
+    });
+
+    it('sets the flag to not display the damage obligations tab when there is no money owed', () => {
+      const formatted = formatTransactionPageData('spends', {
+        transactions: transactionApiResponse,
+        balances: {
+          ...balancesApiResponse,
+          damageObligations: 0.0,
+        },
+      });
+
+      expect(formatted.shouldShowDamageObligationsTab).toBe(false);
     });
   });
 

--- a/server/routes/__tests__/formatters.spec.js
+++ b/server/routes/__tests__/formatters.spec.js
@@ -1,4 +1,7 @@
-const { formatTransactionPageData } = require('../formatters');
+const {
+  formatTransactionPageData,
+  formatDamageObligations,
+} = require('../formatters');
 
 describe('Responses', () => {
   describe('formatTransactionPageData', () => {
@@ -193,6 +196,122 @@ describe('Responses', () => {
 
       expect(formatted.balance).not.toHaveProperty('amount');
       expect(formatted.balance.error).toBe('💥');
+    });
+  });
+
+  describe('formatDamageObligations', () => {
+    const damageObligations = [
+      {
+        amountPaid: 25,
+        amountToPay: 50,
+        comment: 'Some description',
+        currency: 'GBP',
+        endDateTime: '2021-03-15T11:49:58.502Z',
+        id: 3,
+        offenderNo: 'A1234BC',
+        prison: 'Test (HMP)',
+        referenceNumber: '841177/1, A841821/1, 842371',
+        startDateTime: '2021-03-15T11:49:58.502Z',
+        status: 'ACTIVE',
+      },
+      {
+        amountPaid: 25,
+        amountToPay: 50,
+        comment: 'Some description',
+        currency: 'GBP',
+        endDateTime: '2021-02-15T11:49:58.502Z',
+        id: 2,
+        offenderNo: 'A1234BC',
+        prison: 'Test (HMP)',
+        referenceNumber: '841187/1, A842821/1, 843371',
+        startDateTime: '2020-02-15T11:49:58.502Z',
+        status: 'ACTIVE',
+      },
+    ];
+
+    it('formats damage obligations data when present', () => {
+      const formatted = formatDamageObligations(damageObligations);
+
+      expect(formatted.rows).toEqual([
+        {
+          adjudicationNumber: '841177/1, A841821/1, 842371',
+          timePeriod: '15 March 2021 to 15 March 2021',
+          totalAmount: '£50.00',
+          amountPaid: '£25.00',
+          amountOwed: '£25.00',
+          prison: 'Test (HMP)',
+          description: 'Some description',
+        },
+        {
+          adjudicationNumber: '841187/1, A842821/1, 843371',
+          timePeriod: '15 February 2020 to 15 February 2021',
+          totalAmount: '£50.00',
+          amountPaid: '£25.00',
+          amountOwed: '£25.00',
+          prison: 'Test (HMP)',
+          description: 'Some description',
+        },
+      ]);
+    });
+
+    it('filters out non-active damage obligations', () => {
+      const withPaidObligations = [
+        ...damageObligations,
+        {
+          amountPaid: 90,
+          amountToPay: 90,
+          comment: 'Some description',
+          currency: 'GBP',
+          endDateTime: '2021-01-15T11:49:58.502Z',
+          id: 1,
+          offenderNo: 'A1234BC',
+          prison: 'Test (HMP)',
+          referenceNumber: '841184/1, A848821/1, 849371',
+          startDateTime: '2021-01-15T11:49:58.502Z',
+          status: 'PAID',
+        },
+      ];
+
+      const formatted = formatDamageObligations(withPaidObligations);
+
+      expect(formatted.rows).toEqual([
+        {
+          adjudicationNumber: '841177/1, A841821/1, 842371',
+          timePeriod: '15 March 2021 to 15 March 2021',
+          totalAmount: '£50.00',
+          amountPaid: '£25.00',
+          amountOwed: '£25.00',
+          prison: 'Test (HMP)',
+          description: 'Some description',
+        },
+        {
+          adjudicationNumber: '841187/1, A842821/1, 843371',
+          timePeriod: '15 February 2020 to 15 February 2021',
+          totalAmount: '£50.00',
+          amountPaid: '£25.00',
+          amountOwed: '£25.00',
+          prison: 'Test (HMP)',
+          description: 'Some description',
+        },
+      ]);
+    });
+
+    it('creates a total for the outstanding damage obligation amount', () => {
+      const formatted = formatDamageObligations(damageObligations);
+
+      expect(formatted.totalRemainingAmount).toEqual('£50.00');
+    });
+
+    it('creates a total when there are no damage obligations', () => {
+      const formatted = formatDamageObligations([]);
+
+      expect(formatted.totalRemainingAmount).toEqual('£0.00');
+    });
+
+    it('returns the error notification when present', () => {
+      const formatted = formatDamageObligations({ error: '💥' });
+
+      expect(formatted.error).toEqual('💥');
     });
   });
 });

--- a/server/routes/__tests__/money.spec.js
+++ b/server/routes/__tests__/money.spec.js
@@ -15,7 +15,7 @@ const {
   consoleLogError,
 } = require('../../../test/test-helpers');
 
-describe('GET /money/transactions', () => {
+describe('Prisoner Money', () => {
   let app;
   const client = { get: jest.fn() };
 
@@ -45,14 +45,14 @@ describe('GET /money/transactions', () => {
       penceAmount: 50,
       accountType: 'SPND',
       postingType: 'DR',
-      agencyId: 'prison',
+      agencyId: 'TST',
       currentBalance: -443,
     },
   ];
 
   const agencyApiResponse = [
     {
-      agencyId: 'prison',
+      agencyId: 'TST',
       description: 'TEST (HMP)',
       formattedDescription: 'Test (HMP)',
     },
@@ -63,6 +63,50 @@ describe('GET /money/transactions', () => {
     cash: 456.78,
     savings: 890.12,
     currency: 'GBP',
+  };
+
+  const damageObligationsApiResponse = {
+    damageObligations: [
+      {
+        amountPaid: 10,
+        amountToPay: 50,
+        comment: 'Damages to canteen furniture',
+        currency: 'GBP',
+        endDateTime: '2021-03-15T11:49:58.502Z',
+        id: 3,
+        offenderNo: 'A1234BC',
+        prisonId: 'TST',
+        referenceNumber: '841177/1, A841821/1, 842371',
+        startDateTime: '2021-03-15T11:49:58.502Z',
+        status: 'ACTIVE',
+      },
+      {
+        amountPaid: 1570,
+        amountToPay: 2000,
+        comment: 'Some description',
+        currency: 'GBP',
+        endDateTime: '2021-02-15T11:49:58.502Z',
+        id: 2,
+        offenderNo: 'A1234BC',
+        prisonId: 'TST',
+        referenceNumber: '841187/1, A842821/1, 843371',
+        startDateTime: '2020-02-15T11:49:58.502Z',
+        status: 'ACTIVE',
+      },
+      {
+        amountPaid: 90,
+        amountToPay: 90,
+        comment: 'Some description',
+        currency: 'GBP',
+        endDateTime: '2021-01-15T11:49:58.502Z',
+        id: 1,
+        offenderNo: 'A1234BC',
+        prisonId: 'TST',
+        referenceNumber: '841184/1, A848821/1, 849371',
+        startDateTime: '2021-01-15T11:49:58.502Z',
+        status: 'PAID',
+      },
+    ],
   };
 
   const fourOhFour = createAxiosRequestError('🤷‍♂️', null, 404);
@@ -78,361 +122,475 @@ describe('GET /money/transactions', () => {
     app = setupBasicApp();
   });
 
-  it('prompts the user to sign in when they are signed out', async () => {
-    app.use('/money', moneyRouter);
+  describe('GET /money/transactions', () => {
+    it('prompts the user to sign in when they are signed out', async () => {
+      app.use('/money', moneyRouter);
 
-    await request(app)
-      .get('/money/transactions')
-      .expect(200)
-      .then(response => {
-        const $ = cheerio.load(response.text);
-        expect($('.govuk-body').text()).toMatch(/sign in/im);
+      await request(app)
+        .get('/money/transactions')
+        .expect(200)
+        .then(response => {
+          const $ = cheerio.load(response.text);
+          expect($('.govuk-body').text()).toMatch(/sign in/im);
+        });
+    });
+
+    it('displays the transactions when the user is signed in', async () => {
+      client.get.mockImplementation(requestUrl => {
+        if (requestUrl.match(/\/transaction-history/i)) {
+          return Promise.resolve(transactionApiResponse);
+        }
+        if (requestUrl.match(/\/agencies\/prison/i)) {
+          return Promise.resolve(agencyApiResponse);
+        }
+        if (requestUrl.match(/\/balances/i)) {
+          return Promise.resolve(balancesApiResponse);
+        }
+        return Promise.reject(fourOhFour);
       });
+
+      app.use(setMockUser);
+      app.use('/money', moneyRouter);
+      app.use(consoleLogError);
+
+      await request(app)
+        .get('/money/transactions')
+        .expect(200)
+        .then(response => {
+          const $ = cheerio.load(response.text);
+          // We should default to the spends account
+          const selectedTab = $('.govuk-tabs__list-item--selected').text();
+          expect(selectedTab).toContain('Spends');
+          // We should be presented the balance
+          const selectedPanel = $('.govuk-tabs__panel').text();
+          expect(selectedPanel).toContain('£123.45');
+          // We should be presented with the transactions
+          const firstTableRow = $('.govuk-table__body .govuk-table__row')
+            .first()
+            .text();
+          expect(firstTableRow).toContain('23 February 2021');
+          expect(firstTableRow).toContain('£0.50');
+          expect(firstTableRow).toContain('-£4.43');
+          expect(firstTableRow).toContain('Test (HMP)');
+        });
+    });
+
+    it('gracefully handles when there are no transactions to display', async () => {
+      client.get.mockImplementation(requestUrl => {
+        if (requestUrl.match(/\/transaction-history/i)) {
+          return Promise.resolve([]);
+        }
+        if (requestUrl.match(/\/balances/i)) {
+          return Promise.resolve(balancesApiResponse);
+        }
+        return Promise.reject(fourOhFour);
+      });
+
+      app.use(setMockUser);
+      app.use('/money', moneyRouter);
+      app.use(consoleLogError);
+
+      await request(app)
+        .get('/money/transactions')
+        .expect(200)
+        .then(response => {
+          const $ = cheerio.load(response.text);
+          // We should default to the spends account
+          const selectedTab = $('.govuk-tabs__list-item--selected').text();
+          expect(selectedTab).toContain('Spends');
+          // We should be presented the balance
+          const selectedPanel = $('.govuk-tabs__panel').text();
+          expect(selectedPanel).toContain('£123.45');
+        });
+    });
+
+    it('allow tabs to be selected', async () => {
+      client.get.mockImplementation(requestUrl => {
+        if (requestUrl.match(/\/transaction-history/i)) {
+          return Promise.resolve([]);
+        }
+        if (requestUrl.match(/\/balances/i)) {
+          return Promise.resolve(balancesApiResponse);
+        }
+        return Promise.reject(fourOhFour);
+      });
+
+      app.use(setMockUser);
+      app.use('/money', moneyRouter);
+      app.use(consoleLogError);
+
+      await request(app)
+        .get('/money/transactions?accountType=private')
+        .expect(200)
+        .then(response => {
+          const $ = cheerio.load(response.text);
+          // We should be on the private account
+          const selectedTab = $('.govuk-tabs__list-item--selected').text();
+          expect(selectedTab).toContain('Private');
+          // We should be presented the balance
+          const selectedPanel = $('.govuk-tabs__panel').text();
+          expect(selectedPanel).toContain('£456.78');
+        });
+    });
+
+    it('default to "spends" when the selected tab is not valid', async () => {
+      client.get.mockImplementation(requestUrl => {
+        if (requestUrl.match(/\/transaction-history/i)) {
+          return [];
+        }
+        if (requestUrl.match(/\/balances/i)) {
+          return Promise.resolve(balancesApiResponse);
+        }
+        return Promise.reject(fourOhFour);
+      });
+
+      app.use(setMockUser);
+      app.use('/money', moneyRouter);
+      app.use(consoleLogError);
+
+      await request(app)
+        .get('/money/transactions?accountType=potato')
+        .expect(200)
+        .then(response => {
+          const $ = cheerio.load(response.text);
+          // We should default to the spends account
+          const selectedTab = $('.govuk-tabs__list-item--selected').text();
+          expect(selectedTab).toContain('Spends');
+          // We should be presented the balance
+          const selectedPanel = $('.govuk-tabs__panel').text();
+          expect(selectedPanel).toContain('£123.45');
+        });
+    });
+
+    it('notifies the user when unable to fetch transaction data', async () => {
+      client.get.mockImplementation(requestUrl => {
+        if (requestUrl.match(/\/transaction-history/i)) {
+          return Promise.reject(fiveOhThree);
+        }
+        if (requestUrl.match(/\/balances/i)) {
+          return Promise.resolve(balancesApiResponse);
+        }
+        return Promise.reject(fourOhFour);
+      });
+
+      app.use(setMockUser);
+      app.use('/money', moneyRouter);
+      app.use(consoleLogError);
+
+      await request(app)
+        .get('/money/transactions')
+        .expect(200)
+        .then(response => {
+          const $ = cheerio.load(response.text);
+          // We should default to the spends account
+          const selectedTab = $('.govuk-tabs__list-item--selected').text();
+          expect(selectedTab).toContain('Spends');
+          // We should still be presented the balance
+          const selectedPanel = $('.govuk-tabs__panel').text();
+          expect(selectedPanel).toContain('£123.45');
+          // We should be presented with a notification that we are unable to show transactions...
+          expect(selectedPanel).toMatch(/not able to show your transactions/im);
+          // ...and allow the user to try again
+          expect($('.govuk-tabs__panel a').text()).toMatch(/try again/im);
+        });
+    });
+
+    it('handles failures to the agency API gracefully', async () => {
+      client.get.mockImplementation(requestUrl => {
+        if (requestUrl.match(/\/transaction-history/i)) {
+          return Promise.resolve(transactionApiResponse);
+        }
+        if (requestUrl.match(/\/agencies\/prison/i)) {
+          return Promise.reject(fiveOhThree);
+        }
+        if (requestUrl.match(/\/balances/i)) {
+          return Promise.resolve(balancesApiResponse);
+        }
+        return Promise.reject(fourOhFour);
+      });
+
+      app.use(setMockUser);
+      app.use('/money', moneyRouter);
+      app.use(consoleLogError);
+
+      await request(app)
+        .get('/money/transactions')
+        .expect(200)
+        .then(response => {
+          const $ = cheerio.load(response.text);
+          // We should default to the spends account
+          const selectedTab = $('.govuk-tabs__list-item--selected').text();
+          expect(selectedTab).toContain('Spends');
+          const firstTableRow = $('.govuk-table__body .govuk-table__row')
+            .first()
+            .text();
+          expect(firstTableRow).toContain('23 February 2021');
+          expect(firstTableRow).toContain('£0.50');
+          expect(firstTableRow).toContain('-£4.43');
+          expect(firstTableRow).toContain('TST');
+        });
+    });
+
+    it('notifies the user when unable to fetch balance data', async () => {
+      client.get.mockImplementation(requestUrl => {
+        if (requestUrl.match(/\/transaction-history/i)) {
+          return Promise.resolve(transactionApiResponse);
+        }
+        if (requestUrl.match(/\/agencies\/prison/i)) {
+          return Promise.resolve(agencyApiResponse);
+        }
+        if (requestUrl.match(/\/balances/i)) {
+          return Promise.reject(fiveOhThree);
+        }
+        return Promise.reject(fourOhFour);
+      });
+
+      app.use(setMockUser);
+      app.use('/money', moneyRouter);
+      app.use(consoleLogError);
+
+      await request(app)
+        .get('/money/transactions')
+        .expect(200)
+        .then(response => {
+          const $ = cheerio.load(response.text);
+          // We should default to the spends account
+          const selectedTab = $('.govuk-tabs__list-item--selected').text();
+          expect(selectedTab).toContain('Spends');
+          // We should be presented with a notification that we are unable to show the balance...
+          const selectedPanel = $('.govuk-tabs__panel').text();
+          expect(selectedPanel).toMatch(/are not able to show your balance/im);
+          // ...and allow the user to try again...
+          expect($('.govuk-tabs__panel a').text()).toMatch(/try again/im);
+          // ..but should still be presented with the transactions
+          const firstTableRow = $('.govuk-table__body .govuk-table__row')
+            .first()
+            .text();
+          expect(firstTableRow).toContain('23 February 2021');
+          expect(firstTableRow).toContain('£0.50');
+          expect(firstTableRow).toContain('-£4.43');
+          expect(firstTableRow).toContain('Test (HMP)');
+        });
+    });
+
+    it('allows the user to specify the month for transactions by passing a date', async () => {
+      const mockPrisonerInformationService = {
+        getTransactionInformationFor: jest.fn(() => ({
+          transactions: transactionApiResponse,
+          balances: balancesApiResponse,
+        })),
+      };
+
+      const mockedMoneyRouter = createMoneyRouter({
+        hubContentService: {},
+        offenderService: {},
+        prisonerInformationService: mockPrisonerInformationService,
+      });
+
+      app.use(setMockUser);
+      app.use('/money', mockedMoneyRouter);
+      app.use(consoleLogError);
+
+      await request(app)
+        .get('/money/transactions?selectedDate=2021-01-01')
+        .expect(200)
+        .then(() => {
+          expect(
+            mockPrisonerInformationService.getTransactionInformationFor,
+          ).toHaveBeenCalledWith(
+            testUser,
+            'spends',
+            new Date('2021-01-01T00:00:00.000Z'),
+            new Date('2021-01-31T23:59:59.999Z'),
+          );
+        });
+    });
+
+    it('defaults to the current month when passed an invalid date', async () => {
+      // Ideally we would use Jest's inbuilt methods for faking the clock, however we are using
+      // Sinon's FakeTimer here because Jest's implementation does not appear to work with Async functions.
+
+      // TODO: Remove @Sinon/fake-timers and use the Jest inbuilt method when the issue is resolved
+      // jest
+      //   .useFakeTimers('modern')
+      //   .setSystemTime(new Date('2021-03-10T12:00:00.000Z').getTime());
+
+      const clock = FakeTimers.install({
+        now: new Date('2021-03-10T12:00:00.000Z'),
+      });
+
+      const mockPrisonerInformationService = {
+        getTransactionInformationFor: jest.fn(() => ({
+          transactions: transactionApiResponse,
+          balances: balancesApiResponse,
+        })),
+      };
+
+      const mockedMoneyRouter = createMoneyRouter({
+        hubContentService: {},
+        offenderService: {},
+        prisonerInformationService: mockPrisonerInformationService,
+      });
+
+      app.use(setMockUser);
+      app.use('/money', mockedMoneyRouter);
+      app.use(consoleLogError);
+
+      await request(app)
+        .get('/money/transactions?selectedDate=potato')
+        .expect(200)
+        .then(() => {
+          expect(
+            mockPrisonerInformationService.getTransactionInformationFor,
+          ).toHaveBeenCalledWith(
+            testUser,
+            'spends',
+            new Date('2021-03-01T00:00:00.000Z'),
+            new Date('2021-03-10T12:00:00.000Z'),
+          );
+        });
+
+      await request(app)
+        .get('/money/transactions?selectedDate=')
+        .expect(200)
+        .then(() => {
+          expect(
+            mockPrisonerInformationService.getTransactionInformationFor,
+          ).toHaveBeenCalledWith(
+            testUser,
+            'spends',
+            new Date('2021-03-01T00:00:00.000Z'),
+            new Date('2021-03-10T12:00:00.000Z'),
+          );
+        });
+
+      await request(app)
+        .get('/money/transactions?selectedDate=2021-02-31')
+        .expect(200)
+        .then(() => {
+          expect(
+            mockPrisonerInformationService.getTransactionInformationFor,
+          ).toHaveBeenCalledWith(
+            testUser,
+            'spends',
+            new Date('2021-03-01T00:00:00.000Z'),
+            new Date('2021-03-10T12:00:00.000Z'),
+          );
+        });
+
+      clock.uninstall();
+    });
   });
 
-  it('displays the transactions when the user is signed in', async () => {
-    client.get.mockImplementation(requestUrl => {
-      if (requestUrl.match(/\/transaction-history/i)) {
-        return Promise.resolve(transactionApiResponse);
-      }
-      if (requestUrl.match(/\/agencies\/prison/i)) {
-        return Promise.resolve(agencyApiResponse);
-      }
-      if (requestUrl.match(/\/balances/i)) {
-        return Promise.resolve(balancesApiResponse);
-      }
-      return Promise.reject(fourOhFour);
+  describe('GET /money/damage-obligations', () => {
+    it('prompts the user to sign in when they are signed out', async () => {
+      app.use('/money', moneyRouter);
+
+      await request(app)
+        .get('/money/damage-obligations')
+        .expect(200)
+        .then(response => {
+          const $ = cheerio.load(response.text);
+          expect($('.govuk-body').text()).toMatch(/sign in/im);
+        });
     });
 
-    app.use(setMockUser);
-    app.use('/money', moneyRouter);
-    app.use(consoleLogError);
-
-    await request(app)
-      .get('/money/transactions')
-      .expect(200)
-      .then(response => {
-        const $ = cheerio.load(response.text);
-        // We should default to the spends account
-        const selectedTab = $('.govuk-tabs__list-item--selected').text();
-        expect(selectedTab).toContain('Spends');
-        // We should be presented the balance
-        const selectedPanel = $('.govuk-tabs__panel').text();
-        expect(selectedPanel).toContain('£123.45');
-        // We should be presented with the transactions
-        const firstTableRow = $('.govuk-table__body .govuk-table__row')
-          .first()
-          .text();
-        expect(firstTableRow).toContain('23 February 2021');
-        expect(firstTableRow).toContain('£0.50');
-        expect(firstTableRow).toContain('-£4.43');
-        expect(firstTableRow).toContain('Test (HMP)');
+    it('displays damage obligations when the user is signed in', async () => {
+      client.get.mockImplementation(requestUrl => {
+        if (requestUrl.match(/\/damage-obligations/i)) {
+          return Promise.resolve(damageObligationsApiResponse);
+        }
+        if (requestUrl.match(/\/agencies\/prison/i)) {
+          return Promise.resolve(agencyApiResponse);
+        }
+        return Promise.reject(fourOhFour);
       });
-  });
 
-  it('gracefully handles when there are no transactions to display', async () => {
-    client.get.mockImplementation(requestUrl => {
-      if (requestUrl.match(/\/transaction-history/i)) {
-        return Promise.resolve([]);
-      }
-      if (requestUrl.match(/\/balances/i)) {
-        return Promise.resolve(balancesApiResponse);
-      }
-      return Promise.reject(fourOhFour);
+      app.use(setMockUser);
+      app.use('/money', moneyRouter);
+      app.use(consoleLogError);
+
+      await request(app)
+        .get('/money/damage-obligations')
+        .expect(200)
+        .then(response => {
+          const $ = cheerio.load(response.text);
+          // We should have the damage obligations tab selected
+          const selectedTab = $('.govuk-tabs__list-item--selected').text();
+          expect(selectedTab).toContain('Damage obligations');
+          // We should be presented the total amount for damage obligations
+          const selectedPanel = $('.govuk-tabs__panel').text();
+          expect(selectedPanel).toContain('£470.00');
+          // We should be presented with the damage obligation data
+          const table = $('.govuk-table__body .govuk-table__row');
+          expect(table.length).toEqual(2);
+          const firstTableRow = table.first().text();
+          expect(firstTableRow).toContain('841177/1, A841821/1, 842371');
+          expect(firstTableRow).toContain('15 March 2021 to 15 March 2021');
+          expect(firstTableRow).toContain('£50.00');
+          expect(firstTableRow).toContain('£10.00');
+          expect(firstTableRow).toContain('£40.00');
+          expect(firstTableRow).toContain('Test (HMP)');
+          expect(firstTableRow).toContain('Damages to canteen furniture');
+        });
     });
-
-    app.use(setMockUser);
-    app.use('/money', moneyRouter);
-    app.use(consoleLogError);
-
-    await request(app)
-      .get('/money/transactions')
-      .expect(200)
-      .then(response => {
-        const $ = cheerio.load(response.text);
-        // We should default to the spends account
-        const selectedTab = $('.govuk-tabs__list-item--selected').text();
-        expect(selectedTab).toContain('Spends');
-        // We should be presented the balance
-        const selectedPanel = $('.govuk-tabs__panel').text();
-        expect(selectedPanel).toContain('£123.45');
+    it('gracefully handles when there are no damage obligations to display', async () => {
+      client.get.mockImplementation(requestUrl => {
+        if (requestUrl.match(/\/damage-obligations/i)) {
+          return Promise.resolve({ damageObligations: [] });
+        }
+        if (requestUrl.match(/\/agencies\/prison/i)) {
+          return Promise.resolve(agencyApiResponse);
+        }
+        return Promise.reject(fourOhFour);
       });
-  });
 
-  it('allow tabs to be selected', async () => {
-    client.get.mockImplementation(requestUrl => {
-      if (requestUrl.match(/\/transaction-history/i)) {
-        return Promise.resolve([]);
-      }
-      if (requestUrl.match(/\/balances/i)) {
-        return Promise.resolve(balancesApiResponse);
-      }
-      return Promise.reject(fourOhFour);
+      app.use(setMockUser);
+      app.use('/money', moneyRouter);
+      app.use(consoleLogError);
+
+      await request(app)
+        .get('/money/damage-obligations')
+        .expect(200)
+        .then(response => {
+          const $ = cheerio.load(response.text);
+          // We should have the damage obligations tab selected
+          const selectedTab = $('.govuk-tabs__list-item--selected').text();
+          expect(selectedTab).toContain('Damage obligations');
+          // We should be presented the total amount for damage obligations
+          const selectedPanel = $('.govuk-tabs__panel').text();
+          expect(selectedPanel).toContain('£0.00');
+        });
     });
-
-    app.use(setMockUser);
-    app.use('/money', moneyRouter);
-    app.use(consoleLogError);
-
-    await request(app)
-      .get('/money/transactions?accountType=private')
-      .expect(200)
-      .then(response => {
-        const $ = cheerio.load(response.text);
-        // We should be on the private account
-        const selectedTab = $('.govuk-tabs__list-item--selected').text();
-        expect(selectedTab).toContain('Private');
-        // We should be presented the balance
-        const selectedPanel = $('.govuk-tabs__panel').text();
-        expect(selectedPanel).toContain('£456.78');
+    it('notifies the user when unable to fetch damage obligations', async () => {
+      client.get.mockImplementation(requestUrl => {
+        if (requestUrl.match(/\/damage-obligations/i)) {
+          return Promise.reject(fiveOhThree);
+        }
+        if (requestUrl.match(/\/agencies\/prison/i)) {
+          return Promise.resolve(agencyApiResponse);
+        }
+        return Promise.reject(fourOhFour);
       });
-  });
 
-  it('default to "spends" when the selected tab is not valid', async () => {
-    client.get.mockImplementation(requestUrl => {
-      if (requestUrl.match(/\/transaction-history/i)) {
-        return [];
-      }
-      if (requestUrl.match(/\/balances/i)) {
-        return Promise.resolve(balancesApiResponse);
-      }
-      return Promise.reject(fourOhFour);
+      app.use(setMockUser);
+      app.use('/money', moneyRouter);
+      app.use(consoleLogError);
+
+      await request(app)
+        .get('/money/damage-obligations')
+        .expect(200)
+        .then(response => {
+          const $ = cheerio.load(response.text);
+          // We should have the damage obligations tab selected
+          const selectedTab = $('.govuk-tabs__list-item--selected').text();
+          expect(selectedTab).toContain('Damage obligations');
+          const selectedPanel = $('.govuk-tabs__panel').text();
+          // We should be presented with a notification that we are unable to show transactions...
+          expect(selectedPanel).toMatch(
+            /not able to show your damage obligations/im,
+          );
+        });
     });
-
-    app.use(setMockUser);
-    app.use('/money', moneyRouter);
-    app.use(consoleLogError);
-
-    await request(app)
-      .get('/money/transactions?accountType=potato')
-      .expect(200)
-      .then(response => {
-        const $ = cheerio.load(response.text);
-        // We should default to the spends account
-        const selectedTab = $('.govuk-tabs__list-item--selected').text();
-        expect(selectedTab).toContain('Spends');
-        // We should be presented the balance
-        const selectedPanel = $('.govuk-tabs__panel').text();
-        expect(selectedPanel).toContain('£123.45');
-      });
-  });
-
-  it('notifies the user when unable to fetch transaction data', async () => {
-    client.get.mockImplementation(requestUrl => {
-      if (requestUrl.match(/\/transaction-history/i)) {
-        return Promise.reject(fiveOhThree);
-      }
-      if (requestUrl.match(/\/balances/i)) {
-        return Promise.resolve(balancesApiResponse);
-      }
-      return Promise.reject(fourOhFour);
-    });
-
-    app.use(setMockUser);
-    app.use('/money', moneyRouter);
-    app.use(consoleLogError);
-
-    await request(app)
-      .get('/money/transactions')
-      .expect(200)
-      .then(response => {
-        const $ = cheerio.load(response.text);
-        // We should default to the spends account
-        const selectedTab = $('.govuk-tabs__list-item--selected').text();
-        expect(selectedTab).toContain('Spends');
-        // We should still be presented the balance
-        const selectedPanel = $('.govuk-tabs__panel').text();
-        expect(selectedPanel).toContain('£123.45');
-        // We should be presented with a notification that we are unable to show transactions...
-        expect(selectedPanel).toMatch(/not able to show your transactions/im);
-        // ...and allow the user to try again
-        expect($('.govuk-tabs__panel a').text()).toMatch(/try again/im);
-      });
-  });
-
-  it('handles failures to the agency API gracefully', async () => {
-    client.get.mockImplementation(requestUrl => {
-      if (requestUrl.match(/\/transaction-history/i)) {
-        return Promise.resolve(transactionApiResponse);
-      }
-      if (requestUrl.match(/\/agencies\/prison/i)) {
-        return Promise.reject(fiveOhThree);
-      }
-      if (requestUrl.match(/\/balances/i)) {
-        return Promise.resolve(balancesApiResponse);
-      }
-      return Promise.reject(fourOhFour);
-    });
-
-    app.use(setMockUser);
-    app.use('/money', moneyRouter);
-    app.use(consoleLogError);
-
-    await request(app)
-      .get('/money/transactions')
-      .expect(200)
-      .then(response => {
-        const $ = cheerio.load(response.text);
-        // We should default to the spends account
-        const selectedTab = $('.govuk-tabs__list-item--selected').text();
-        expect(selectedTab).toContain('Spends');
-        const firstTableRow = $('.govuk-table__body .govuk-table__row')
-          .first()
-          .text();
-        expect(firstTableRow).toContain('23 February 2021');
-        expect(firstTableRow).toContain('£0.50');
-        expect(firstTableRow).toContain('-£4.43');
-        expect(firstTableRow).toContain('prison');
-      });
-  });
-
-  it('notifies the user when unable to fetch balance data', async () => {
-    client.get.mockImplementation(requestUrl => {
-      if (requestUrl.match(/\/transaction-history/i)) {
-        return Promise.resolve(transactionApiResponse);
-      }
-      if (requestUrl.match(/\/agencies\/prison/i)) {
-        return Promise.resolve(agencyApiResponse);
-      }
-      if (requestUrl.match(/\/balances/i)) {
-        return Promise.reject(fiveOhThree);
-      }
-      return Promise.reject(fourOhFour);
-    });
-
-    app.use(setMockUser);
-    app.use('/money', moneyRouter);
-    app.use(consoleLogError);
-
-    await request(app)
-      .get('/money/transactions')
-      .expect(200)
-      .then(response => {
-        const $ = cheerio.load(response.text);
-        // We should default to the spends account
-        const selectedTab = $('.govuk-tabs__list-item--selected').text();
-        expect(selectedTab).toContain('Spends');
-        // We should be presented with a notification that we are unable to show the balance...
-        const selectedPanel = $('.govuk-tabs__panel').text();
-        expect(selectedPanel).toMatch(/are not able to show your balance/im);
-        // ...and allow the user to try again...
-        expect($('.govuk-tabs__panel a').text()).toMatch(/try again/im);
-        // ..but should still be presented with the transactions
-        const firstTableRow = $('.govuk-table__body .govuk-table__row')
-          .first()
-          .text();
-        expect(firstTableRow).toContain('23 February 2021');
-        expect(firstTableRow).toContain('£0.50');
-        expect(firstTableRow).toContain('-£4.43');
-        expect(firstTableRow).toContain('Test (HMP)');
-      });
-  });
-
-  it('allows the user to specify the month for transactions by passing a date', async () => {
-    const mockPrisonerInformationService = {
-      getTransactionInformationFor: jest.fn(() => ({
-        transactions: transactionApiResponse,
-        balances: balancesApiResponse,
-      })),
-    };
-
-    const mockedMoneyRouter = createMoneyRouter({
-      hubContentService: {},
-      offenderService: {},
-      prisonerInformationService: mockPrisonerInformationService,
-    });
-
-    app.use(setMockUser);
-    app.use('/money', mockedMoneyRouter);
-    app.use(consoleLogError);
-
-    await request(app)
-      .get('/money/transactions?selectedDate=2021-01-01')
-      .expect(200)
-      .then(() => {
-        expect(
-          mockPrisonerInformationService.getTransactionInformationFor,
-        ).toHaveBeenCalledWith(
-          testUser,
-          'spends',
-          new Date('2021-01-01T00:00:00.000Z'),
-          new Date('2021-01-31T23:59:59.999Z'),
-        );
-      });
-  });
-
-  it('defaults to the current month when passed an invalid date', async () => {
-    // Ideally we would use Jest's inbuilt methods for faking the clock, however we are using
-    // Sinon's FakeTimer here because Jest's implementation does not appear to work with Async functions.
-
-    // TODO: Remove @Sinon/fake-timers and use the Jest inbuilt method when the issue is resolved
-    // jest
-    //   .useFakeTimers('modern')
-    //   .setSystemTime(new Date('2021-03-10T12:00:00.000Z').getTime());
-
-    const clock = FakeTimers.install({
-      now: new Date('2021-03-10T12:00:00.000Z'),
-    });
-
-    const mockPrisonerInformationService = {
-      getTransactionInformationFor: jest.fn(() => ({
-        transactions: transactionApiResponse,
-        balances: balancesApiResponse,
-      })),
-    };
-
-    const mockedMoneyRouter = createMoneyRouter({
-      hubContentService: {},
-      offenderService: {},
-      prisonerInformationService: mockPrisonerInformationService,
-    });
-
-    app.use(setMockUser);
-    app.use('/money', mockedMoneyRouter);
-    app.use(consoleLogError);
-
-    await request(app)
-      .get('/money/transactions?selectedDate=potato')
-      .expect(200)
-      .then(() => {
-        expect(
-          mockPrisonerInformationService.getTransactionInformationFor,
-        ).toHaveBeenCalledWith(
-          testUser,
-          'spends',
-          new Date('2021-03-01T00:00:00.000Z'),
-          new Date('2021-03-10T12:00:00.000Z'),
-        );
-      });
-
-    await request(app)
-      .get('/money/transactions?selectedDate=')
-      .expect(200)
-      .then(() => {
-        expect(
-          mockPrisonerInformationService.getTransactionInformationFor,
-        ).toHaveBeenCalledWith(
-          testUser,
-          'spends',
-          new Date('2021-03-01T00:00:00.000Z'),
-          new Date('2021-03-10T12:00:00.000Z'),
-        );
-      });
-
-    await request(app)
-      .get('/money/transactions?selectedDate=2021-02-31')
-      .expect(200)
-      .then(() => {
-        expect(
-          mockPrisonerInformationService.getTransactionInformationFor,
-        ).toHaveBeenCalledWith(
-          testUser,
-          'spends',
-          new Date('2021-03-01T00:00:00.000Z'),
-          new Date('2021-03-10T12:00:00.000Z'),
-        );
-      });
-
-    clock.uninstall();
   });
 });

--- a/server/routes/formatters.js
+++ b/server/routes/formatters.js
@@ -143,43 +143,50 @@ function formatDamageObligations(damageObligations) {
       0,
     );
 
-  const rows = activeDamageObligations.map(damageObligation => {
-    const startDate = formatDateOrDefault(
-      'Unknown',
-      'd MMMM yyyy',
-      damageObligation.startDateTime,
-    );
-    const endDate = formatDateOrDefault(
-      'Unknown',
-      'd MMMM yyyy',
-      damageObligation.endDateTime,
-    );
+  const rows = activeDamageObligations
+    .sort((damageObligation1, damageObligation2) =>
+      sortByDateTime(
+        damageObligation2.startDateTime,
+        damageObligation1.startDateTime,
+      ),
+    )
+    .map(damageObligation => {
+      const startDate = formatDateOrDefault(
+        'Unknown',
+        'd MMMM yyyy',
+        damageObligation.startDateTime,
+      );
+      const endDate = formatDateOrDefault(
+        'Unknown',
+        'd MMMM yyyy',
+        damageObligation.endDateTime,
+      );
 
-    return {
-      adjudicationNumber: damageObligation.referenceNumber,
-      timePeriod:
-        damageObligation.startDateTime && damageObligation.endDateTime
-          ? `${startDate} to ${endDate}`
-          : 'Unknown',
-      totalAmount: formatBalanceOrDefault(
-        null,
-        damageObligation.amountToPay,
-        damageObligation.currency,
-      ),
-      amountPaid: formatBalanceOrDefault(
-        null,
-        damageObligation.amountPaid,
-        damageObligation.currency,
-      ),
-      amountOwed: formatBalanceOrDefault(
-        null,
-        damageObligation.amountToPay - damageObligation.amountPaid,
-        damageObligation.currency,
-      ),
-      prison: damageObligation.prison,
-      description: damageObligation.comment,
-    };
-  });
+      return {
+        adjudicationNumber: damageObligation.referenceNumber,
+        timePeriod:
+          damageObligation.startDateTime && damageObligation.endDateTime
+            ? `${startDate} to ${endDate}`
+            : 'Unknown',
+        totalAmount: formatBalanceOrDefault(
+          null,
+          damageObligation.amountToPay,
+          damageObligation.currency,
+        ),
+        amountPaid: formatBalanceOrDefault(
+          null,
+          damageObligation.amountPaid,
+          damageObligation.currency,
+        ),
+        amountOwed: formatBalanceOrDefault(
+          null,
+          damageObligation.amountToPay - damageObligation.amountPaid,
+          damageObligation.currency,
+        ),
+        prison: damageObligation.prison,
+        description: damageObligation.comment,
+      };
+    });
 
   return {
     rows,

--- a/server/routes/formatters.js
+++ b/server/routes/formatters.js
@@ -125,6 +125,73 @@ function formatTransactionPageData(accountType, transactionsData) {
   return {};
 }
 
+function formatDamageObligations(damageObligations) {
+  if (damageObligations.error) {
+    return damageObligations;
+  }
+
+  const activeDamageObligations = damageObligations.filter(
+    damageObligation => damageObligation.status === 'ACTIVE',
+  );
+
+  const totalRemainingAmount = activeDamageObligations
+    .filter(damageObligation => damageObligation.currency === 'GBP')
+    .reduce(
+      (runningTotal, damageObligation) =>
+        runningTotal +
+        (damageObligation.amountToPay - damageObligation.amountPaid),
+      0,
+    );
+
+  const rows = activeDamageObligations.map(damageObligation => {
+    const startDate = formatDateOrDefault(
+      'Unknown',
+      'd MMMM yyyy',
+      damageObligation.startDateTime,
+    );
+    const endDate = formatDateOrDefault(
+      'Unknown',
+      'd MMMM yyyy',
+      damageObligation.endDateTime,
+    );
+
+    return {
+      adjudicationNumber: damageObligation.referenceNumber,
+      timePeriod:
+        damageObligation.startDateTime && damageObligation.endDateTime
+          ? `${startDate} to ${endDate}`
+          : 'Unknown',
+      totalAmount: formatBalanceOrDefault(
+        null,
+        damageObligation.amountToPay,
+        damageObligation.currency,
+      ),
+      amountPaid: formatBalanceOrDefault(
+        null,
+        damageObligation.amountPaid,
+        damageObligation.currency,
+      ),
+      amountOwed: formatBalanceOrDefault(
+        null,
+        damageObligation.amountToPay - damageObligation.amountPaid,
+        damageObligation.currency,
+      ),
+      prison: damageObligation.prison,
+      description: damageObligation.comment,
+    };
+  });
+
+  return {
+    rows,
+    totalRemainingAmount: formatBalanceOrDefault(
+      null,
+      totalRemainingAmount,
+      'GBP',
+    ),
+  };
+}
+
 module.exports = {
   formatTransactionPageData,
+  formatDamageObligations,
 };

--- a/server/routes/formatters.js
+++ b/server/routes/formatters.js
@@ -116,6 +116,8 @@ function formatTransactionPageData(accountType, transactionsData) {
       balance: balances.error
         ? { error: balances.error }
         : formatBalance(accountType, balances),
+      shouldShowDamageObligationsTab:
+        balances && balances.damageObligations > 0,
       transactions: transactions.error
         ? { error: transactions.error }
         : flattenTransactions(transactions).map(formatTransaction),

--- a/server/services/prisonerInformation.js
+++ b/server/services/prisonerInformation.js
@@ -109,7 +109,7 @@ class PrisonerInformationService {
       }
 
       return {
-        error: 'We are unable to show your damage obligations at this time',
+        error: 'We are not able to show your damage obligations at this time',
       };
     } catch (e) {
       Sentry.captureException(e);

--- a/server/views/components/personal-transactions/macro.njk
+++ b/server/views/components/personal-transactions/macro.njk
@@ -1,3 +1,3 @@
-{% macro personalTransactions(params, isLoggedIn) %}
+{% macro personalTransactions(data, returnUrl, isLoggedIn) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/server/views/components/personal-transactions/template.njk
+++ b/server/views/components/personal-transactions/template.njk
@@ -101,7 +101,7 @@
           {{data.damageObligations.error}}, <a href="{{ returnUrl }}" class="govuk-link">try again</a>
         </p>
       {% else %}
-        <h3 class="govuk-heading-m">Total for all damage obligations</h3>
+        <h3 class="govuk-heading-m">You currently owe</h3>
         <p>{{data.damageObligations.totalRemainingAmount}}</p>
         {# <a href="#" class="govuk-link">Find out more about what the information on this page means</a>. #}
         <table class="govuk-table">

--- a/server/views/components/personal-transactions/template.njk
+++ b/server/views/components/personal-transactions/template.njk
@@ -4,90 +4,131 @@
 {% if not isLoggedIn %}
   <h2 class="govuk-heading-m">You are signed out</h2>
   <p class="govuk-!-font-size-24">
-    <a href="/auth/sign-in?returnUrl={{ params.authReturnUrl }}" class="govuk-link">Sign in</a> to see your personal information.
+    <a href="/auth/sign-in?returnUrl={{ returnUrl }}" class="govuk-link">Sign in</a> to see your personal information.
     </p>
 {% else %}
   <ul class="govuk-tabs__list">
-    {% for accountType in params.accountTypes %}
-      <li class="govuk-tabs__list-item{% if accountType == params.selected %} govuk-tabs__list-item--selected{% endif %}">
+    {% for accountType in data.accountTypes %}
+      <li class="govuk-tabs__list-item{% if accountType == data.selected %} govuk-tabs__list-item--selected{% endif %}">
         <a class="govuk-tabs__tab" href="/money/transactions?accountType={{accountType}}">
           {{ accountType | capitalize }}
         </a>
       </li>
     {% endfor %}
+    <li class="govuk-tabs__list-item{% if data.selected == 'damage-obligations' %} govuk-tabs__list-item--selected{% endif %}">
+      <a class="govuk-tabs__tab" href="/money/damage-obligations">Damage obligations</a>
+    </li>
   </ul>
-  <div class="govuk-tabs__panel" id="past-day">
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Current balance</h2>
-    {% if params.balance.error %}
-      <p class="govuk-!-font-size-24">
-        {{params.balance.error}}, <a href="{{ params.authReturnUrl }}" class="govuk-link">try again</a>
-      </p>
-    {% else %}
-      <p>{{ params.balance.amount }}</P>
-    {% endif %}
-    {% if params.transactions.error %}
-      <p class="govuk-!-font-size-24">
-        {{params.transactions.error}}, <a href="{{ params.authReturnUrl }}" class="govuk-link">try again</a>
-      </p>
-    {% else %}
-      <details class="govuk-details" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text">
+  <div class="govuk-tabs__panel">
+    {% if data.transactions %}
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Current balance</h2>
+      {% if data.balance.error %}
+        <p class="govuk-!-font-size-24">
+          {{data.balance.error}}, <a href="{{ returnUrl }}" class="govuk-link">try again</a>
+        </p>
+      {% else %}
+        <p>{{ data.balance.amount }}</P>
+      {% endif %}
+      {% if data.transactions.error %}
+        <p class="govuk-!-font-size-24">
+          {{data.transactions.error}}, <a href="{{ returnUrl }}" class="govuk-link">try again</a>
+        </p>
+      {% else %}
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
           Help with your transactions
         </span>
-        </summary>
-        <div class="govuk-details__text">
-          <p>The Hub team cannot help you with transaction queries.</p>
+          </summary>
+          <div class="govuk-details__text">
+            <p>The Hub team cannot help you with transaction queries.</p>
 
-          <p>If you're unsure about a transaction, you should submit an app or ask an officer.</p>
+            <p>If you're unsure about a transaction, you should submit an app or ask an officer.</p>
 
-          <a href="/content/8534" class="govuk-link">Read more about what the information on this page means</a>.
+            <a href="/content/8534" class="govuk-link">Read more about what the information on this page means</a>.
         </div>
-      </details>
-      {% from "govuk/components/select/macro.njk" import govukSelect %}
-      <div class="transactions__selection_wrapper">
-        <h3 class="govuk-heading-m">View by</h3>
-        <form method="GET">
-          <div class="transactions__selection__form">
-            <input type="hidden" name="accountType" value="{{ params.selected }}"/>
-            {{ govukSelect({
+        </details>
+        {% from "govuk/components/select/macro.njk" import govukSelect %}
+        <div class="transactions__selection_wrapper">
+          <h3 class="govuk-heading-m">View by</h3>
+          <form method="GET">
+            <div class="transactions__selection__form">
+              <input type="hidden" name="accountType" value="{{ data.selected }}"/>
+              {{ govukSelect({
               id: "selected-date",
               name: "selectedDate",
               label: {
                 text: "Date"
               },
-              items: params.dateSelection
+              items: data.dateSelection
             }) }}
-            {{ govukButton({
+              {{ govukButton({
               text: "View"
             }) }}
-          </div>
-        </form>
-      </div>
-      <table class="govuk-table">
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Payment date</th>
-            <th scope="col" class="govuk-table__header">Money in</th>
-            <th scope="col" class="govuk-table__header">Money out</th>
-            <th scope="col" class="govuk-table__header">Balance</th>
-            <th scope="col" class="govuk-table__header">Payment description</th>
-            <th scope="col" class="govuk-table__header">Prison</th>
-          </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-          {% for t in params.transactions %}
+            </div>
+          </form>
+        </div>
+        <table class="govuk-table">
+          <thead class="govuk-table__head">
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell">{{t.paymentDate}}</td>
-              <td class="govuk-table__cell">{{t.moneyIn}}</td>
-              <td class="govuk-table__cell">{{t.moneyOut}}</td>
-              <td class="govuk-table__cell">{{t.balance}}</td>
-              <td class="govuk-table__cell">{{t.paymentDescription}}</td>
-              <td class="govuk-table__cell">{{t.prison}}</td>
+              <th scope="col" class="govuk-table__header">Payment date</th>
+              <th scope="col" class="govuk-table__header">Money in</th>
+              <th scope="col" class="govuk-table__header">Money out</th>
+              <th scope="col" class="govuk-table__header">Balance</th>
+              <th scope="col" class="govuk-table__header">Payment description</th>
+              <th scope="col" class="govuk-table__header">Prison</th>
             </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+          </thead>
+          <tbody class="govuk-table__body">
+            {% for t in data.transactions %}
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell">{{t.paymentDate}}</td>
+                <td class="govuk-table__cell">{{t.moneyIn}}</td>
+                <td class="govuk-table__cell">{{t.moneyOut}}</td>
+                <td class="govuk-table__cell">{{t.balance}}</td>
+                <td class="govuk-table__cell">{{t.paymentDescription}}</td>
+                <td class="govuk-table__cell">{{t.prison}}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
+    {% elif data.damageObligations %}
+      {% if data.damageObligations.error %}
+        <p class="govuk-!-font-size-24">
+          {{data.damageObligations.error}}, <a href="{{ returnUrl }}" class="govuk-link">try again</a>
+        </p>
+      {% else %}
+        <h3 class="govuk-heading-m">Total for all damage obligations</h3>
+        <p>{{data.damageObligations.totalRemainingAmount}}</p>
+        <a href="#" class="govuk-link">Find out more about what the information on this page means</a>.
+        <table class="govuk-table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">Adjudication number</th>
+              <th scope="col" class="govuk-table__header">Payment start and end date</th>
+              <th scope="col" class="govuk-table__header">Total amount</th>
+              <th scope="col" class="govuk-table__header">Amount paid</th>
+              <th scope="col" class="govuk-table__header">Amount owed</th>
+              <th scope="col" class="govuk-table__header">Prison</th>
+              <th scope="col" class="govuk-table__header">Description</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            {% for o in data.damageObligations.rows %}
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell">{{o.adjudicationNumber}}</td>
+                <td class="govuk-table__cell">{{o.timePeriod}}</td>
+                <td class="govuk-table__cell">{{o.totalAmount}}</td>
+                <td class="govuk-table__cell">{{o.amountPaid}}</td>
+                <td class="govuk-table__cell">{{o.amountOwed}}</td>
+                <td class="govuk-table__cell">{{o.prison}}</td>
+                <td class="govuk-table__cell">{{o.description}}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
     {% endif %}
   </div>
 {% endif %}

--- a/server/views/components/personal-transactions/template.njk
+++ b/server/views/components/personal-transactions/template.njk
@@ -29,9 +29,11 @@
         </a>
       </li>
     {% endfor %}
-    <li class="govuk-tabs__list-item{% if data.selected == 'damage-obligations' %} govuk-tabs__list-item--selected{% endif %}">
-      <a class="govuk-tabs__tab" href="/money/damage-obligations">Damage obligations</a>
-    </li>
+    {% if (data.selected === 'damage-obligations') or (data.shouldShowDamageObligationsTab) %}
+      <li class="govuk-tabs__list-item{% if data.selected == 'damage-obligations' %} govuk-tabs__list-item--selected{% endif %}">
+        <a class="govuk-tabs__tab" href="/money/damage-obligations">Damage obligations</a>
+      </li>
+    {% endif %}
   </ul>
   <div class="govuk-tabs__panel">
     {% if data.transactions %}

--- a/server/views/components/personal-transactions/template.njk
+++ b/server/views/components/personal-transactions/template.njk
@@ -7,6 +7,20 @@
     <a href="/auth/sign-in?returnUrl={{ returnUrl }}" class="govuk-link">Sign in</a> to see your personal information.
     </p>
 {% else %}
+  <details class="govuk-details" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+          Help with your transactions
+        </span>
+    </summary>
+    <div class="govuk-details__text">
+      <p>The Hub team cannot help you with transaction queries.</p>
+
+      <p>If you're unsure about a transaction, you should submit an app or ask an officer.</p>
+
+      <a href="/content/8534" class="govuk-link">Read more about what the information on this page means</a>.
+        </div>
+  </details>
   <ul class="govuk-tabs__list">
     {% for accountType in data.accountTypes %}
       <li class="govuk-tabs__list-item{% if accountType == data.selected %} govuk-tabs__list-item--selected{% endif %}">
@@ -34,20 +48,6 @@
           {{data.transactions.error}}, <a href="{{ returnUrl }}" class="govuk-link">try again</a>
         </p>
       {% else %}
-        <details class="govuk-details" data-module="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-          Help with your transactions
-        </span>
-          </summary>
-          <div class="govuk-details__text">
-            <p>The Hub team cannot help you with transaction queries.</p>
-
-            <p>If you're unsure about a transaction, you should submit an app or ask an officer.</p>
-
-            <a href="/content/8534" class="govuk-link">Read more about what the information on this page means</a>.
-        </div>
-        </details>
         {% from "govuk/components/select/macro.njk" import govukSelect %}
         <div class="transactions__selection_wrapper">
           <h3 class="govuk-heading-m">View by</h3>
@@ -101,7 +101,7 @@
       {% else %}
         <h3 class="govuk-heading-m">Total for all damage obligations</h3>
         <p>{{data.damageObligations.totalRemainingAmount}}</p>
-        <a href="#" class="govuk-link">Find out more about what the information on this page means</a>.
+        {# <a href="#" class="govuk-link">Find out more about what the information on this page means</a>. #}
         <table class="govuk-table">
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">

--- a/server/views/pages/transactions.html
+++ b/server/views/pages/transactions.html
@@ -50,15 +50,7 @@
 {% block main %}
   <div class="govuk-width-container govuk-body">
 
-    {{ personalTransactions({
-        transactions: prisonerInformation.transactions,
-        balance: prisonerInformation.balance,
-        selected: prisonerInformation.selected,
-        accountTypes: prisonerInformation.accountTypes,
-        selectedDate: prisonerInformation.selectedDate,
-        dateSelection: prisonerInformation.dateSelection,
-        authReturnUrl: config.returnUrl
-    }, config.userName) }}
+    {{ personalTransactions(prisonerInformation, config.returnUrl, config.userName) }}
 
     <div class="govuk-hub-article-feedback">
       <p class="govuk-body">Tell us what you think:</p>


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/3X7tu4po/1961-damage-obligations

### Intent

> What changes are introduced by this PR that correspond to the above card?

- Add damage obligations route
- Add damage obligations template
- Move help section to appear on all tabs

> Would this PR benefit from screenshots?

**Damage Obligations to display**

![image](https://user-images.githubusercontent.com/20080441/111779758-6aa7c900-88ae-11eb-94b5-0bbf4eead6bf.png)

**No Damage Obligations to display**

![image](https://user-images.githubusercontent.com/20080441/111779769-6da2b980-88ae-11eb-8348-9dfb54457de4.png)

**Something has gone wrong, let the user retry**

![image](https://user-images.githubusercontent.com/20080441/111779783-70051380-88ae-11eb-912d-851f85e566f5.png)


### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
