### PR TITLE
Add Sentry client alerting

### DIFF
--- a/server/clients/__tests__/hubClient.spec.js
+++ b/server/clients/__tests__/hubClient.spec.js
@@ -1,3 +1,7 @@
+const Sentry = require('@sentry/node');
+
+jest.mock('@sentry/node');
+
 const nock = require('nock');
 const { HubClient } = require('../hub');
 
@@ -59,6 +63,9 @@ describe('HubClient', () => {
       const client = new HubClient();
       const result = await client.get('https://hub-api.com/bar');
 
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        new Error('Request failed with status code 404'),
+      );
       expect(result).toStrictEqual(null);
     });
   });

--- a/server/clients/__tests__/hubClient.spec.js
+++ b/server/clients/__tests__/hubClient.spec.js
@@ -6,6 +6,9 @@ const nock = require('nock');
 const { HubClient } = require('../hub');
 
 describe('HubClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   describe('.get', () => {
     it('makes a request simple GET request', async () => {
       nock('https://hub-api.com')

--- a/server/clients/__tests__/standardClient.spec.js
+++ b/server/clients/__tests__/standardClient.spec.js
@@ -1,3 +1,7 @@
+const Sentry = require('@sentry/node');
+
+jest.mock('@sentry/node');
+
 const nock = require('nock');
 const { StandardClient } = require('../standard');
 
@@ -47,6 +51,9 @@ describe('StandardClient', () => {
       const client = new StandardClient();
       const result = await client.get('https://some-api.com/bar');
 
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        new Error('Request failed with status code 404'),
+      );
       expect(result).toStrictEqual(null);
     });
   });
@@ -74,7 +81,12 @@ describe('StandardClient', () => {
       const result = await client.post('https://www.example.com/bar', {
         foo: 'bar',
       });
-
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        new Error('Request failed with status code 404'),
+      );
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        new Error('Request failed with status code 400'),
+      );
       expect(result).toStrictEqual(null);
     });
   });

--- a/server/clients/__tests__/standardClient.spec.js
+++ b/server/clients/__tests__/standardClient.spec.js
@@ -10,6 +10,10 @@ describe('StandardClient', () => {
     nock.cleanAll();
   });
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   afterEach(() => {
     nock.cleanAll();
   });
@@ -81,9 +85,7 @@ describe('StandardClient', () => {
       const result = await client.post('https://www.example.com/bar', {
         foo: 'bar',
       });
-      expect(Sentry.captureException).toHaveBeenCalledWith(
-        new Error('Request failed with status code 404'),
-      );
+
       expect(Sentry.captureException).toHaveBeenCalledWith(
         new Error('Request failed with status code 400'),
       );

--- a/server/clients/hub.js
+++ b/server/clients/hub.js
@@ -1,3 +1,4 @@
+const Sentry = require('@sentry/node');
 const qs = require('querystring');
 const { baseClient } = require('./baseClient');
 const { logger } = require('../utils/logger');
@@ -23,6 +24,7 @@ class HubContentClient {
         return res.data;
       })
       .catch(e => {
+        Sentry.captureException(e);
         logger.error(
           `HubContentClient (GET) - ${endpoint}?${qs.stringify(
             queryString,

--- a/server/clients/standard.js
+++ b/server/clients/standard.js
@@ -1,3 +1,4 @@
+const Sentry = require('@sentry/node');
 const qs = require('querystring');
 const { path } = require('ramda');
 const { baseClient } = require('./baseClient');
@@ -16,6 +17,7 @@ class StandardClient {
         return res.data;
       })
       .catch(e => {
+        Sentry.captureException(e);
         logger.error(`StandardClient (GET) - Failed: ${e.message}`);
         logger.debug(e.stack);
         return null;
@@ -30,6 +32,7 @@ class StandardClient {
         return res.data;
       })
       .catch(e => {
+        Sentry.captureException(e);
         logger.error(`StandardClient (POST) - Failed: ${e.message}`);
         logger.debug(e.stack);
         return null;
@@ -59,6 +62,7 @@ class StandardClient {
         return res.data;
       })
       .catch(e => {
+        Sentry.captureException(e);
         logger.error(`StandardClient (POST URLENCODED) - Failed: ${e.message}`);
         logger.debug(e.stack);
         return null;


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/c6JWJSeX/1994-5xx-responses-from-frontend-dont-raise-sentry-alerts

### Intent

> What changes are introduced by this PR that correspond to the above card?

Enable Sentry on client failures

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
