### PR TITLE
Feature/add transactions by type to prison api repo

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -23,9 +23,7 @@ const { createPrisonApiOffenderService } = require('./services/offender');
 const { createSearchService } = require('./services/search');
 const { createAnalyticsService } = require('./services/analytics');
 const { createFeedbackService } = require('./services/feedback');
-const {
-  PrisonerInformationService,
-} = require('./services/prisonerInformation');
+const PrisonerInformationService = require('./services/prisonerInformation');
 
 // Repositories
 const {
@@ -40,7 +38,7 @@ const { offenderRepository } = require('./repositories/offender');
 const { searchRepository } = require('./repositories/search');
 const { analyticsRepository } = require('./repositories/analytics');
 const { feedbackRepository } = require('./repositories/feedback');
-const { PrisonApiRepository } = require('./repositories/prisonApi');
+const PrisonApiRepository = require('./repositories/prisonApi');
 
 const cachingStrategy = path(['features', 'useRedisCache'], config)
   ? new RedisCachingStrategy(

--- a/server/repositories/__tests__/prisonApi.spec.js
+++ b/server/repositories/__tests__/prisonApi.spec.js
@@ -1,5 +1,5 @@
 const Sentry = require('@sentry/node');
-const { PrisonApiRepository } = require('../prisonApi');
+const PrisonApiRepository = require('../prisonApi');
 
 jest.mock('@sentry/node');
 
@@ -12,18 +12,17 @@ describe('PrisonApiRepository', () => {
     jest.clearAllMocks();
   });
 
-  describe('getTransactionsFor', () => {
+  describe('getTransactionsForDateRange', () => {
     it('should return when the transactions request succeeds', async () => {
       const repository = new PrisonApiRepository({ client, apiUrl });
 
       client.get.mockResolvedValue('API_RESPONSE');
 
-      const response = await repository.getTransactionsFor(
-        'A1234BC',
-        'spends',
-        new Date('2020-01-01'),
-        new Date('2020-01-31'),
-      );
+      const response = await repository.getTransactionsForDateRange('A1234BC', {
+        accountCode: 'spends',
+        fromDate: new Date('2020-01-01'),
+        toDate: new Date('2020-01-31'),
+      });
 
       expect(client.get).toHaveBeenCalledWith(
         'http://foo.bar/api/offenders/A1234BC/transaction-history?account_code=spends&from_date=2020-01-01&to_date=2020-01-31',
@@ -38,12 +37,11 @@ describe('PrisonApiRepository', () => {
       client.get.mockResolvedValue('API_RESPONSE');
 
       await expect(
-        repository.getTransactionsFor(
-          null,
-          'spends',
-          new Date('2020-01-01'),
-          new Date('2020-01-31'),
-        ),
+        repository.getTransactionsForDateRange(null, {
+          accountCode: 'spends',
+          fromDate: new Date('2020-01-01'),
+          toDate: new Date('2020-01-31'),
+        }),
       ).rejects.toThrow();
 
       expect(client.get).not.toHaveBeenCalled();
@@ -55,12 +53,11 @@ describe('PrisonApiRepository', () => {
       client.get.mockResolvedValue('API_RESPONSE');
 
       await expect(
-        repository.getTransactionsFor(
-          'A1234BC',
-          null,
-          new Date('2020-01-01'),
-          new Date('2020-01-31'),
-        ),
+        repository.getTransactionsForDateRange('A1234BC', {
+          accountCode: null,
+          fromDate: new Date('2020-01-01'),
+          toDate: new Date('2020-01-31'),
+        }),
       ).rejects.toThrow();
 
       expect(client.get).not.toHaveBeenCalled();
@@ -72,12 +69,11 @@ describe('PrisonApiRepository', () => {
       client.get.mockResolvedValue('API_RESPONSE');
 
       await expect(
-        repository.getTransactionsFor(
-          'A1234BC',
-          'spends',
-          null,
-          new Date('2020-01-31'),
-        ),
+        repository.getTransactionsForDateRange('A1234BC', {
+          accountCode: 'spends',
+          fromDate: 'expectToBreak',
+          toDate: new Date('2020-01-31'),
+        }),
       ).rejects.toThrow();
     });
 
@@ -87,12 +83,11 @@ describe('PrisonApiRepository', () => {
       client.get.mockResolvedValue('API_RESPONSE');
 
       await expect(
-        repository.getTransactionsFor(
-          'A1234BC',
-          'spends',
-          new Date('2020-01-01'),
-          null,
-        ),
+        repository.getTransactionsForDateRange('A1234BC', {
+          accountCode: 'spends',
+          fromDate: new Date('2020-01-01'),
+          toDate: 'expectToBreak',
+        }),
       ).rejects.toThrow();
 
       expect(client.get).not.toHaveBeenCalled();
@@ -103,15 +98,74 @@ describe('PrisonApiRepository', () => {
 
       client.get.mockRejectedValue('💥');
 
-      const response = await repository.getTransactionsFor(
-        'A1234BC',
-        'spends',
-        new Date('2020-01-01'),
-        new Date('2020-01-31'),
-      );
+      const response = await repository.getTransactionsForDateRange('A1234BC', {
+        accountCode: 'spends',
+        fromDate: new Date('2020-01-01'),
+        toDate: new Date('2020-01-31'),
+      });
 
       expect(Sentry.captureException).toHaveBeenCalledWith('💥');
       expect(response).toBeNull();
+    });
+  });
+
+  describe('getTransactionsByType', () => {
+    it('should return when the transactions request succeeds', async () => {
+      const repository = new PrisonApiRepository({ client, apiUrl });
+
+      client.get.mockResolvedValue('API_RESPONSE');
+
+      const response = await repository.getTransactionsByType('A1234BC', {
+        accountCode: 'cash',
+        transactionType: 'HOA',
+      });
+
+      expect(client.get).toHaveBeenCalledWith(
+        'http://foo.bar/api/offenders/A1234BC/transaction-history?account_code=cash&transaction_type=HOA',
+      );
+
+      expect(response).toBe('API_RESPONSE');
+    });
+
+    it('should throw when no prisoner ID is passed', async () => {
+      const repository = new PrisonApiRepository({ client, apiUrl });
+
+      client.get.mockResolvedValue('API_RESPONSE');
+
+      await expect(
+        repository.getTransactionsByType(null, {
+          accountCode: 'cash',
+          transactionType: 'HOA',
+        }),
+      ).rejects.toThrow();
+
+      expect(client.get).not.toHaveBeenCalled();
+    });
+
+    it('should throw when no accountCode is passed', async () => {
+      const repository = new PrisonApiRepository({ client, apiUrl });
+
+      client.get.mockResolvedValue('API_RESPONSE');
+
+      await expect(
+        repository.getTransactionsByType('A1234BC', {
+          transactionType: 'HOA',
+        }),
+      ).rejects.toThrow();
+
+      expect(client.get).not.toHaveBeenCalled();
+    });
+
+    it('should throw when no transactionType is passed', async () => {
+      const repository = new PrisonApiRepository({ client, apiUrl });
+
+      client.get.mockResolvedValue('API_RESPONSE');
+
+      await expect(
+        repository.getTransactionsForDateRange('A1234BC', {
+          accountCode: 'cash',
+        }),
+      ).rejects.toThrow();
     });
   });
 

--- a/server/repositories/__tests__/prisonApi.spec.js
+++ b/server/repositories/__tests__/prisonApi.spec.js
@@ -162,7 +162,7 @@ describe('PrisonApiRepository', () => {
       client.get.mockResolvedValue('API_RESPONSE');
 
       await expect(
-        repository.getTransactionsForDateRange('A1234BC', {
+        repository.getTransactionsByType('A1234BC', {
           accountCode: 'cash',
         }),
       ).rejects.toThrow();

--- a/server/repositories/prisonApi.js
+++ b/server/repositories/prisonApi.js
@@ -42,7 +42,7 @@ class PrisonApiRepository {
       });
 
       logger.info(
-        `PrisonApiRepository (getTransactionsFor) - User: ${prisonerId}`,
+        `PrisonApiRepository (getTransactionsForDateRange) - User: ${prisonerId}`,
       );
 
       const response = await this.client.get(
@@ -53,7 +53,7 @@ class PrisonApiRepository {
     } catch (e) {
       Sentry.captureException(e);
       logger.error(
-        `PrisonApiRepository (getTransactionsFor) - Failed: ${e.message} - User: ${prisonerId}`,
+        `PrisonApiRepository (getTransactionsForDateRange) - Failed: ${e.message} - User: ${prisonerId}`,
       );
       logger.debug(e.stack);
       return null;
@@ -84,7 +84,7 @@ class PrisonApiRepository {
       });
 
       logger.info(
-        `PrisonApiRepository (getTransactionsFor) - User: ${prisonerId}`,
+        `PrisonApiRepository (getTransactionsByType) - User: ${prisonerId}`,
       );
 
       const response = await this.client.get(
@@ -95,7 +95,7 @@ class PrisonApiRepository {
     } catch (e) {
       Sentry.captureException(e);
       logger.error(
-        `PrisonApiRepository (getTransactionsFor) - Failed: ${e.message} - User: ${prisonerId}`,
+        `PrisonApiRepository (getTransactionsByType) - Failed: ${e.message} - User: ${prisonerId}`,
       );
       logger.debug(e.stack);
       return null;

--- a/server/repositories/prisonApi.js
+++ b/server/repositories/prisonApi.js
@@ -9,6 +9,7 @@ const {
   isValidAccountCode,
   isValidDate,
   isValidBookingId,
+  isValidTransactionType,
 } = require('../utils/validators');
 const { getEnvironmentVariableOrThrow } = require('../../utils');
 
@@ -70,6 +71,10 @@ class PrisonApiRepository {
     assert(
       isValidAccountCode(accountCode),
       `Invalid account code - Received: ${accountCode}`,
+    );
+    assert(
+      isValidTransactionType(transactionType),
+      `Invalid transaction type - Received: ${transactionType}`,
     );
 
     try {

--- a/server/routes/__tests__/money.spec.js
+++ b/server/routes/__tests__/money.spec.js
@@ -4,10 +4,8 @@ const createAxiosRequestError = require('axios/lib/core/createError');
 const FakeTimers = require('@sinonjs/fake-timers');
 
 const { createMoneyRouter } = require('../money');
-const {
-  PrisonerInformationService,
-} = require('../../services/prisonerInformation');
-const { PrisonApiRepository } = require('../../repositories/prisonApi');
+const PrisonerInformationService = require('../../services/prisonerInformation');
+const PrisonApiRepository = require('../../repositories/prisonApi');
 const { User } = require('../../auth/user');
 
 const {

--- a/server/services/__tests__/prisonerInformation.spec.js
+++ b/server/services/__tests__/prisonerInformation.spec.js
@@ -1,8 +1,10 @@
 const Sentry = require('@sentry/node');
-const { PrisonerInformationService } = require('../prisonerInformation');
 const { User } = require('../../auth/user');
+const PrisonerInformationService = require('../prisonerInformation');
+const PrisonApi = require('../../repositories/prisonApi');
 
 jest.mock('@sentry/node');
+jest.mock('../../repositories/prisonApi');
 
 describe('PrisonerInformation', () => {
   let prisonApiRepository = {};
@@ -84,12 +86,7 @@ describe('PrisonerInformation', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    prisonApiRepository = {
-      getTransactionsFor: jest.fn(),
-      getBalancesFor: jest.fn(),
-      getPrisonDetails: jest.fn(),
-      getDamageObligationsFor: jest.fn(),
-    };
+    prisonApiRepository = new PrisonApi();
   });
 
   describe('getTransactionInformationFor', () => {
@@ -98,7 +95,9 @@ describe('PrisonerInformation', () => {
         prisonApiRepository,
       });
 
-      prisonApiRepository.getTransactionsFor.mockResolvedValue(transactions);
+      prisonApiRepository.getTransactionsForDateRange.mockResolvedValue(
+        transactions,
+      );
       prisonApiRepository.getBalancesFor.mockResolvedValue(balances);
       prisonApiRepository.getPrisonDetails.mockResolvedValue(prisons);
 
@@ -128,7 +127,9 @@ describe('PrisonerInformation', () => {
         prisonApiRepository,
       });
 
-      prisonApiRepository.getTransactionsFor.mockResolvedValue(transactions);
+      prisonApiRepository.getTransactionsForDateRange.mockResolvedValue(
+        transactions,
+      );
       prisonApiRepository.getBalancesFor.mockResolvedValue(balances);
       prisonApiRepository.getPrisonDetails.mockResolvedValue([]);
 
@@ -158,7 +159,7 @@ describe('PrisonerInformation', () => {
         prisonApiRepository,
       });
 
-      prisonApiRepository.getTransactionsFor.mockResolvedValue(null);
+      prisonApiRepository.getTransactionsForDateRange.mockResolvedValue(null);
       prisonApiRepository.getBalancesFor.mockResolvedValue(balances);
       prisonApiRepository.getPrisonDetails.mockResolvedValue(prisons);
 
@@ -178,7 +179,9 @@ describe('PrisonerInformation', () => {
         prisonApiRepository,
       });
 
-      prisonApiRepository.getTransactionsFor.mockResolvedValue(transactions);
+      prisonApiRepository.getTransactionsForDateRange.mockResolvedValue(
+        transactions,
+      );
       prisonApiRepository.getBalancesFor.mockResolvedValue(balances);
       prisonApiRepository.getPrisonDetails.mockResolvedValue(prisons);
 
@@ -198,7 +201,9 @@ describe('PrisonerInformation', () => {
         prisonApiRepository,
       });
 
-      prisonApiRepository.getTransactionsFor.mockResolvedValue(transactions);
+      prisonApiRepository.getTransactionsForDateRange.mockResolvedValue(
+        transactions,
+      );
       prisonApiRepository.getBalancesFor.mockResolvedValue(null);
       prisonApiRepository.getPrisonDetails.mockResolvedValue(prisons);
 
@@ -218,7 +223,9 @@ describe('PrisonerInformation', () => {
         prisonApiRepository,
       });
 
-      prisonApiRepository.getTransactionsFor.mockResolvedValue(transactions);
+      prisonApiRepository.getTransactionsForDateRange.mockResolvedValue(
+        transactions,
+      );
       prisonApiRepository.getBalancesFor.mockResolvedValue(balances);
       prisonApiRepository.getPrisonDetails.mockResolvedValue(prisons);
 
@@ -231,7 +238,9 @@ describe('PrisonerInformation', () => {
         ),
       ).rejects.toThrow();
 
-      expect(prisonApiRepository.getTransactionsFor).not.toHaveBeenCalled();
+      expect(
+        prisonApiRepository.getTransactionsForDateRange,
+      ).not.toHaveBeenCalled();
       expect(prisonApiRepository.getBalancesFor).not.toHaveBeenCalled();
       expect(prisonApiRepository.getPrisonDetails).not.toHaveBeenCalled();
     });
@@ -241,7 +250,9 @@ describe('PrisonerInformation', () => {
         prisonApiRepository,
       });
 
-      prisonApiRepository.getTransactionsFor.mockResolvedValue(transactions);
+      prisonApiRepository.getTransactionsForDateRange.mockResolvedValue(
+        transactions,
+      );
       prisonApiRepository.getBalancesFor.mockResolvedValue(balances);
       prisonApiRepository.getPrisonDetails.mockResolvedValue(prisons);
 
@@ -254,7 +265,9 @@ describe('PrisonerInformation', () => {
         ),
       ).rejects.toThrow();
 
-      expect(prisonApiRepository.getTransactionsFor).not.toHaveBeenCalled();
+      expect(
+        prisonApiRepository.getTransactionsForDateRange,
+      ).not.toHaveBeenCalled();
       expect(prisonApiRepository.getBalancesFor).not.toHaveBeenCalled();
       expect(prisonApiRepository.getPrisonDetails).not.toHaveBeenCalled();
     });
@@ -264,7 +277,9 @@ describe('PrisonerInformation', () => {
         prisonApiRepository,
       });
 
-      prisonApiRepository.getTransactionsFor.mockResolvedValue(transactions);
+      prisonApiRepository.getTransactionsForDateRange.mockResolvedValue(
+        transactions,
+      );
       prisonApiRepository.getBalancesFor.mockResolvedValue(balances);
       prisonApiRepository.getPrisonDetails.mockResolvedValue(prisons);
 
@@ -277,7 +292,9 @@ describe('PrisonerInformation', () => {
         ),
       ).rejects.toThrow();
 
-      expect(prisonApiRepository.getTransactionsFor).not.toHaveBeenCalled();
+      expect(
+        prisonApiRepository.getTransactionsForDateRange,
+      ).not.toHaveBeenCalled();
       expect(prisonApiRepository.getBalancesFor).not.toHaveBeenCalled();
       expect(prisonApiRepository.getPrisonDetails).not.toHaveBeenCalled();
     });
@@ -287,7 +304,9 @@ describe('PrisonerInformation', () => {
         prisonApiRepository,
       });
 
-      prisonApiRepository.getTransactionsFor.mockResolvedValue(transactions);
+      prisonApiRepository.getTransactionsForDateRange.mockResolvedValue(
+        transactions,
+      );
       prisonApiRepository.getBalancesFor.mockResolvedValue(balances);
       prisonApiRepository.getPrisonDetails.mockResolvedValue(prisons);
 
@@ -300,7 +319,9 @@ describe('PrisonerInformation', () => {
         ),
       ).rejects.toThrow();
 
-      expect(prisonApiRepository.getTransactionsFor).not.toHaveBeenCalled();
+      expect(
+        prisonApiRepository.getTransactionsForDateRange,
+      ).not.toHaveBeenCalled();
       expect(prisonApiRepository.getBalancesFor).not.toHaveBeenCalled();
       expect(prisonApiRepository.getPrisonDetails).not.toHaveBeenCalled();
     });
@@ -310,7 +331,7 @@ describe('PrisonerInformation', () => {
         prisonApiRepository,
       });
 
-      prisonApiRepository.getTransactionsFor.mockRejectedValue('💥');
+      prisonApiRepository.getTransactionsForDateRange.mockRejectedValue('💥');
       prisonApiRepository.getBalancesFor.mockResolvedValue(balances);
       prisonApiRepository.getPrisonDetails.mockResolvedValue(prisons);
 
@@ -330,7 +351,9 @@ describe('PrisonerInformation', () => {
         prisonApiRepository,
       });
 
-      prisonApiRepository.getTransactionsFor.mockResolvedValue(transactions);
+      prisonApiRepository.getTransactionsForDateRange.mockResolvedValue(
+        transactions,
+      );
       prisonApiRepository.getBalancesFor.mockRejectedValue('💥');
       prisonApiRepository.getPrisonDetails.mockResolvedValue(prisons);
 
@@ -350,7 +373,9 @@ describe('PrisonerInformation', () => {
         prisonApiRepository,
       });
 
-      prisonApiRepository.getTransactionsFor.mockResolvedValue(transactions);
+      prisonApiRepository.getTransactionsForDateRange.mockResolvedValue(
+        transactions,
+      );
       prisonApiRepository.getBalancesFor.mockResolvedValue(balances);
       prisonApiRepository.getPrisonDetails.mockRejectedValue('💥');
 

--- a/server/services/__tests__/prisonerInformation.spec.js
+++ b/server/services/__tests__/prisonerInformation.spec.js
@@ -391,7 +391,7 @@ describe('PrisonerInformation', () => {
     });
   });
 
-  describe('getDamageObligationsFor', async () => {
+  describe('getDamageObligationsFor', () => {
     it('returns damage obligations data', async () => {
       const prisonerInformationService = new PrisonerInformationService({
         prisonApiRepository,

--- a/server/services/prisonerInformation.js
+++ b/server/services/prisonerInformation.js
@@ -43,12 +43,11 @@ class PrisonerInformationService {
         balancesResponse,
         listOfPrisons,
       ] = await Promise.all([
-        this.prisonApi.getTransactionsFor(
-          user.prisonerId,
+        this.prisonApi.getTransactionsForDateRange(user.prisonerId, {
           accountCode,
           fromDate,
           toDate,
-        ),
+        }),
         this.prisonApi.getBalancesFor(user.bookingId),
         this.prisonApi.getPrisonDetails(),
       ]);
@@ -122,6 +121,4 @@ class PrisonerInformationService {
   }
 }
 
-module.exports = {
-  PrisonerInformationService,
-};
+module.exports = PrisonerInformationService;

--- a/server/utils/__tests__/validators.spec.js
+++ b/server/utils/__tests__/validators.spec.js
@@ -4,6 +4,7 @@ const {
   isValidAccountCode,
   isValidDate,
   isValidPrisonId,
+  isValidTransactionType,
 } = require('../validators');
 
 describe('Validators', () => {
@@ -104,6 +105,28 @@ describe('Validators', () => {
     it('returns null when passed no data', () => {
       expect(isValidPrisonId(null)).toBeFalsy();
       expect(isValidPrisonId(undefined)).toBeFalsy();
+    });
+  });
+
+  describe('isValidTransactionType', () => {
+    it('returns truthy when the string passed is a valid transaction type', () => {
+      expect(isValidTransactionType('HOA')).toBeTruthy();
+      expect(isValidTransactionType('WHF')).toBeTruthy();
+    });
+
+    it('returns null when the string passed is not a valid transaction type', () => {
+      expect(isValidTransactionType('thisWillFail')).toBeFalsy();
+    });
+
+    it('returns null when passed data of the wrong type', () => {
+      expect(isValidTransactionType(123)).toBeFalsy();
+      expect(isValidTransactionType(['HOA'])).toBeFalsy();
+      expect(isValidTransactionType({}));
+    });
+
+    it('returns null when passed no data', () => {
+      expect(isValidTransactionType(null)).toBeFalsy();
+      expect(isValidTransactionType(undefined)).toBeFalsy();
     });
   });
 });

--- a/server/utils/validators.js
+++ b/server/utils/validators.js
@@ -5,6 +5,8 @@ const isValidPrisonId = s => typeof s === 'string' && s.match(/^[A-Z]{3}$/i);
 const isValidAccountCode = s =>
   typeof s === 'string' && ['spends', 'cash', 'savings'].includes(s);
 const isValidDate = d => d instanceof Date;
+const isValidTransactionType = t =>
+  typeof t === 'string' && ['HOA', 'WHF'].includes(t);
 
 module.exports = {
   isValidPrisonerId,
@@ -12,4 +14,5 @@ module.exports = {
   isValidPrisonId,
   isValidAccountCode,
   isValidDate,
+  isValidTransactionType,
 };


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/ohGgiiSP

### Intent

> What changes are introduced by this PR that correspond to the above card?

- Add method to get transactions by type
- Update existing transactions method to differentiate
- Refactor both Prison API repo and Prisoner Information service to use unnamed exports, this allows us to use `jest.mock(import)` to automatically create/update mocks for these dependencies

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
