### PR TITLE
Remove jest setup script

### DIFF
--- a/.env-test
+++ b/.env-test
@@ -1,3 +1,0 @@
-NODE_ENV=test
-HUB_API_ENDPOINT=www.foo.com
-PRISON_API_BASE_URL=http://foo.bar/api

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,0 @@
-require('dotenv').config({
-  path: './.env-test',
-});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "css-build": "./bin/build-css",
     "clean": "rm -rf public/* .port.tmp *.log build/* uploads/* test-results.xml",
     "lint": "eslint . --cache --max-warnings 0",
-    "test": "jest --setupFiles ./jest.setup.js",
+    "test": "jest",
     "clear_jest": "jest --clearCache",
     "cy:run": "cypress run",
     "cy:open": "cypress open",

--- a/server/routes/__tests__/money.spec.js
+++ b/server/routes/__tests__/money.spec.js
@@ -18,16 +18,9 @@ const {
 describe('Prisoner Money', () => {
   let app;
   const client = { get: jest.fn() };
-
-  const prisonApiRepository = new PrisonApiRepository({ client });
-  const prisonerInformationService = new PrisonerInformationService({
-    prisonApiRepository,
-  });
-  const moneyRouter = createMoneyRouter({
-    hubContentService: () => {},
-    offenderService: () => {},
-    prisonerInformationService,
-  });
+  let prisonApiRepository;
+  let prisonerInformationService;
+  let moneyRouter;
 
   const testUser = new User({
     prisonerId: 'A1234BC',
@@ -117,6 +110,25 @@ describe('Prisoner Money', () => {
     req.user = testUser;
     next();
   };
+
+  const oldEnv = process.env;
+
+  beforeAll(() => {
+    process.env.PRISON_API_BASE_URL = 'http://foo.bar/api';
+    prisonApiRepository = new PrisonApiRepository({ client });
+    prisonerInformationService = new PrisonerInformationService({
+      prisonApiRepository,
+    });
+    moneyRouter = createMoneyRouter({
+      hubContentService: () => {},
+      offenderService: () => {},
+      prisonerInformationService,
+    });
+  });
+
+  afterAll(() => {
+    process.env = oldEnv;
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION


### Context

> Does this issue have a Trello card?

Nope, just a PR to provoke discussion

### Intent

> What changes are introduced by this PR that correspond to the above card?

The intent here is to remove the Jest setup file in favour of being explicit in individual tests. This also fixes with tests failing in VSCode with the Jest test runner, this was due to the test runner not being configured to use the setup file.
