### PR TITLE
Allow retrieval of the names of inactive prisons 

### DIFF
--- a/server/repositories/__tests__/prisonApi.spec.js
+++ b/server/repositories/__tests__/prisonApi.spec.js
@@ -178,7 +178,7 @@ describe('PrisonApiRepository', () => {
       const response = await repository.getPrisonDetails();
 
       expect(client.get).toHaveBeenCalledWith(
-        'http://foo.bar/api/agencies/prison',
+        'http://foo.bar/api/agencies/type/INST?activeOnly=false',
       );
 
       expect(response).toBe('API_RESPONSE');

--- a/server/repositories/prisonApi.js
+++ b/server/repositories/prisonApi.js
@@ -106,7 +106,9 @@ class PrisonApiRepository {
     try {
       logger.info('PrisonApiRepository (getPrisonDetailsFor)');
 
-      const response = await this.client.get(`${this.url}/api/agencies/prison`);
+      const response = await this.client.get(
+        `${this.url}/api/agencies/type/INST?activeOnly=false`,
+      );
 
       return response;
     } catch (e) {

--- a/server/routes/__tests__/money.spec.js
+++ b/server/routes/__tests__/money.spec.js
@@ -78,8 +78,7 @@ describe('Prisoner Money', () => {
   const agencyApiResponse = [
     {
       agencyId: 'TST',
-      description: 'TEST (HMP)',
-      formattedDescription: 'Test (HMP)',
+      description: 'Test (HMP)',
     },
   ];
 
@@ -154,7 +153,7 @@ describe('Prisoner Money', () => {
         if (requestUrl.match(/\/transaction-history/i)) {
           return Promise.resolve(transactionApiResponse);
         }
-        if (requestUrl.match(/\/agencies\/prison/i)) {
+        if (requestUrl.match(/\/agencies\/type\/INST\?activeOnly=false/i)) {
           return Promise.resolve(agencyApiResponse);
         }
         if (requestUrl.match(/\/balances/i)) {
@@ -305,7 +304,7 @@ describe('Prisoner Money', () => {
         if (requestUrl.match(/\/transaction-history/i)) {
           return Promise.resolve(transactionApiResponse);
         }
-        if (requestUrl.match(/\/agencies\/prison/i)) {
+        if (requestUrl.match(/\/agencies\/type\/INST\?activeOnly=false/i)) {
           return Promise.reject(fiveOhThree);
         }
         if (requestUrl.match(/\/balances/i)) {
@@ -341,7 +340,7 @@ describe('Prisoner Money', () => {
         if (requestUrl.match(/\/transaction-history/i)) {
           return Promise.resolve(transactionApiResponse);
         }
-        if (requestUrl.match(/\/agencies\/prison/i)) {
+        if (requestUrl.match(/\/agencies\/type\/INST\?activeOnly=false/i)) {
           return Promise.resolve(agencyApiResponse);
         }
         if (requestUrl.match(/\/balances/i)) {
@@ -494,7 +493,7 @@ describe('Prisoner Money', () => {
         if (requestUrl.match(/\/transaction-history/i)) {
           return Promise.resolve(transactionApiResponse);
         }
-        if (requestUrl.match(/\/agencies\/prison/i)) {
+        if (requestUrl.match(/\/agencies\/type\/INST\?activeOnly=false/i)) {
           return Promise.resolve(agencyApiResponse);
         }
         if (requestUrl.match(/\/balances/i)) {
@@ -612,7 +611,7 @@ describe('Prisoner Money', () => {
         if (requestUrl.match(/\/transaction-history/i)) {
           return Promise.resolve(transactionApiResponse);
         }
-        if (requestUrl.match(/\/agencies\/prison/i)) {
+        if (requestUrl.match(/\/agencies\/type\/INST\?activeOnly=false/i)) {
           return Promise.resolve(agencyApiResponse);
         }
         if (requestUrl.match(/\/balances/i)) {
@@ -745,7 +744,7 @@ describe('Prisoner Money', () => {
         if (requestUrl.match(/\/transaction-history/i)) {
           return Promise.resolve(transactionApiResponse);
         }
-        if (requestUrl.match(/\/agencies\/prison/i)) {
+        if (requestUrl.match(/\/agencies\/type\/INST\?activeOnly=false/i)) {
           return Promise.reject(fiveOhThree);
         }
         if (requestUrl.match(/\/balances/i)) {
@@ -785,7 +784,7 @@ describe('Prisoner Money', () => {
         if (requestUrl.match(/\/transaction-history/i)) {
           return Promise.resolve(transactionApiResponse);
         }
-        if (requestUrl.match(/\/agencies\/prison/i)) {
+        if (requestUrl.match(/\/agencies\/type\/INST\?activeOnly=false/i)) {
           return Promise.resolve(agencyApiResponse);
         }
         if (requestUrl.match(/\/balances/i)) {
@@ -922,7 +921,7 @@ describe('Prisoner Money', () => {
         if (requestUrl.match(/\/transaction-history/i)) {
           return Promise.resolve(transactionApiResponse);
         }
-        if (requestUrl.match(/\/agencies\/prison/i)) {
+        if (requestUrl.match(/\/agencies\/type\/INST\?activeOnly=false/i)) {
           return Promise.resolve(agencyApiResponse);
         }
         if (requestUrl.match(/\/balances/i)) {
@@ -1073,7 +1072,7 @@ describe('Prisoner Money', () => {
         if (requestUrl.match(/\/transaction-history/i)) {
           return Promise.resolve(transactionApiResponse);
         }
-        if (requestUrl.match(/\/agencies\/prison/i)) {
+        if (requestUrl.match(/\/agencies\/type\/INST\?activeOnly=false/i)) {
           return Promise.reject(fiveOhThree);
         }
         if (requestUrl.match(/\/balances/i)) {
@@ -1106,7 +1105,7 @@ describe('Prisoner Money', () => {
         if (requestUrl.match(/\/transaction-history/i)) {
           return Promise.resolve(transactionApiResponse);
         }
-        if (requestUrl.match(/\/agencies\/prison/i)) {
+        if (requestUrl.match(/\/agencies\/type\/INST\?activeOnly=false/i)) {
           return Promise.resolve(agencyApiResponse);
         }
         if (requestUrl.match(/\/balances/i)) {
@@ -1261,7 +1260,7 @@ describe('Prisoner Money', () => {
         if (requestUrl.match(/\/damage-obligations/i)) {
           return Promise.resolve(damageObligationsApiResponse);
         }
-        if (requestUrl.match(/\/agencies\/prison/i)) {
+        if (requestUrl.match(/\/agencies\/type\/INST\?activeOnly=false/i)) {
           return Promise.resolve(agencyApiResponse);
         }
         return Promise.reject(fourOhFour);
@@ -1300,7 +1299,7 @@ describe('Prisoner Money', () => {
         if (requestUrl.match(/\/damage-obligations/i)) {
           return Promise.resolve({ damageObligations: [] });
         }
-        if (requestUrl.match(/\/agencies\/prison/i)) {
+        if (requestUrl.match(/\/agencies\/type\/INST\?activeOnly=false/i)) {
           return Promise.resolve(agencyApiResponse);
         }
         return Promise.reject(fourOhFour);
@@ -1328,7 +1327,7 @@ describe('Prisoner Money', () => {
         if (requestUrl.match(/\/damage-obligations/i)) {
           return Promise.reject(fiveOhThree);
         }
-        if (requestUrl.match(/\/agencies\/prison/i)) {
+        if (requestUrl.match(/\/agencies\/type\/INST\?activeOnly=false/i)) {
           return Promise.resolve(agencyApiResponse);
         }
         return Promise.reject(fourOhFour);

--- a/server/services/__tests__/prisonerInformation.spec.js
+++ b/server/services/__tests__/prisonerInformation.spec.js
@@ -72,12 +72,10 @@ describe('PrisonerInformation', () => {
     {
       agencyId: 'TST',
       description: 'Test (HMP)',
-      formattedDescription: 'Test (HMP)',
     },
     {
       agencyId: 'TST2',
       description: 'Test 2 (HMP)',
-      formattedDescription: 'Test 2 (HMP)',
     },
   ];
 

--- a/server/services/prisonerInformation.js
+++ b/server/services/prisonerInformation.js
@@ -4,7 +4,7 @@ const { logger } = require('../utils/logger');
 
 function createPrisonFormatter(listOfPrisons, key) {
   const lookup = listOfPrisons.reduce((a, p) => {
-    a.set(p.agencyId, p.formattedDescription);
+    a.set(p.agencyId, p.description);
     return a;
   }, new Map());
 


### PR DESCRIPTION

### Context

> Does this issue have a Trello card?

https://trello.com/c/O82U3mp8

> If this is an issue, do we have steps to reproduce?

View a transaction that occurred in an inactive prison such as Camp Hill

### Intent

> What changes are introduced by this PR that correspond to the above card?

Altering the code that performs the prison name lookup to include inactive prisons. 

> Would this PR benefit from screenshots?

### Considerations

> Is there any additional information that would help when reviewing this PR?


If I generate two lists of prisons from both the old and new endpoints, it produces the exact same output
```
curl -X GET  -v  "https://api-preprod.prison.service.justice.gov.uk/api/agencies/type/INST?activeOnly=true" -H "Authorization: Bearer $TOKEN" | jq '.[] | .description' > insts.txt

curl -X GET  -v  "https://api-preprod.prison.service.justice.gov.uk/api/agencies/prison" -H "Authorization: Bearer $TOKEN" | jq '.[] | .formattedDescription' > prisons.txt 
```

If I then switch the `activeOnly` flag to `false` THE DIFF shows that the inactive prisons are added. 

This API method is only used to look up prison names for a specific agency

> Are there any steps required when merging/deploying this PR?

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
