### PR TITLE
jh-pending-transactions-split-out-the-amount

### DIFF
--- a/server/routes/__tests__/formatters.spec.js
+++ b/server/routes/__tests__/formatters.spec.js
@@ -412,6 +412,7 @@ describe('Responses', () => {
       expect(formatted.rows).toEqual([
         [
           { text: '28 March 2021' },
+          { text: '' },
           { text: '-£25.00' },
           { text: 'Pending 2' },
           { text: 'Test (HMP)' },
@@ -419,6 +420,7 @@ describe('Responses', () => {
         [
           { text: '29 March 2021' },
           { text: '£50.00' },
+          { text: '' },
           { text: 'Pending 1' },
           { text: 'Test (HMP)' },
         ],

--- a/server/routes/formatters.js
+++ b/server/routes/formatters.js
@@ -217,34 +217,33 @@ function createPendingTransactionsResponseFrom(pending) {
         'Payment description',
         'Prison',
       ].map(toGovUkTableCells),
-      rows: holdingNotCleared
-        .map(
-          ({
-            entryDate,
-            postingType,
-            penceAmount,
-            currency,
-            entryDescription: paymentDescription,
-            prison,
-          }) => ({
-            paymentDate: formatDateOrDefault('', 'd MMMM yyyy', entryDate),
-            moneyIn:
-              postingType === 'CR'
-                ? formatBalanceOrDefault(null, penceAmount / 100, currency)
-                : '',
-            moneyOut:
-              postingType === 'CR'
-                ? ''
-                : formatBalanceOrDefault(null, 0 - penceAmount / 100, currency),
+      rows: holdingNotCleared.map(
+        ({
+          entryDate,
+          postingType,
+          penceAmount,
+          currency,
+          entryDescription: paymentDescription,
+          prison,
+        }) => {
+          const paymentDate = formatDateOrDefault('', 'd MMMM yyyy', entryDate);
+          const moneyIn =
+            postingType === 'CR'
+              ? formatBalanceOrDefault(null, penceAmount / 100, currency)
+              : '';
+          const moneyOut =
+            postingType === 'CR'
+              ? ''
+              : formatBalanceOrDefault(null, 0 - penceAmount / 100, currency);
+          return [
+            paymentDate,
+            moneyIn,
+            moneyOut,
             paymentDescription,
             prison,
-          }),
-        )
-        .map(({ paymentDate, moneyIn, moneyOut, paymentDescription, prison }) =>
-          [paymentDate, moneyIn, moneyOut, paymentDescription, prison].map(
-            toGovUkTableCells,
-          ),
-        ),
+          ].map(toGovUkTableCells);
+        },
+      ),
     };
   } catch (e) {
     Sentry.captureException(e);

--- a/server/routes/formatters.js
+++ b/server/routes/formatters.js
@@ -210,38 +210,40 @@ function createPendingTransactionsResponseFrom(pending) {
 
     return {
       total: formatBalanceOrDefault(null, totalPendingPenceAmount / 100, 'GBP'),
-      head: ['Date', 'Amount', 'Payment description', 'Prison'].map(
-        toGovUkTableCells,
-      ),
+      head: [
+        'Payment date',
+        'Money in',
+        'Money out',
+        'Payment description',
+        'Prison',
+      ].map(toGovUkTableCells),
       rows: holdingNotCleared
-        .map(transaction => ({
-          paymentDate: formatDateOrDefault(
-            '',
-            'd MMMM yyyy',
-            transaction.entryDate,
+        .map(
+          ({
+            entryDate,
+            postingType,
+            penceAmount,
+            currency,
+            entryDescription: paymentDescription,
+            prison,
+          }) => ({
+            paymentDate: formatDateOrDefault('', 'd MMMM yyyy', entryDate),
+            moneyIn:
+              postingType === 'CR'
+                ? formatBalanceOrDefault(null, penceAmount / 100, currency)
+                : '',
+            moneyOut:
+              postingType === 'CR'
+                ? ''
+                : formatBalanceOrDefault(null, 0 - penceAmount / 100, currency),
+            paymentDescription,
+            prison,
+          }),
+        )
+        .map(({ paymentDate, moneyIn, moneyOut, paymentDescription, prison }) =>
+          [paymentDate, moneyIn, moneyOut, paymentDescription, prison].map(
+            toGovUkTableCells,
           ),
-          amount:
-            transaction.postingType === 'CR'
-              ? formatBalanceOrDefault(
-                  null,
-                  transaction.penceAmount / 100,
-                  transaction.currency,
-                )
-              : formatBalanceOrDefault(
-                  null,
-                  0 - transaction.penceAmount / 100,
-                  transaction.currency,
-                ),
-          paymentDescription: transaction.entryDescription,
-          prison: transaction.prison,
-        }))
-        .map(transaction =>
-          [
-            transaction.paymentDate,
-            transaction.amount,
-            transaction.paymentDescription,
-            transaction.prison,
-          ].map(toGovUkTableCells),
         ),
     };
   } catch (e) {


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/moVmbEYm

> If this is an issue, do we have steps to reproduce?

Navigate to the pending transactions page.

### Intent

> What changes are introduced by this PR that correspond to the above card?

Pending transactions table amount column split to display "Money in" and "Money out" separately.

> Would this PR benefit from screenshots?

Probably.

### Considerations

> Is there any additional information that would help when reviewing this PR?

n/a

> Are there any steps required when merging/deploying this PR?

no

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
