### PR TITLE
Improving speed of docker image build and reducing image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,8 @@ WORKDIR /home/node/app
 # A wildcard is used to ensure both package.json AND package-lock.json are copied
 # where available (npm@5+)
 COPY package*.json ./
-RUN npm install
-# If you are building your code for production
-# RUN npm install --only=production
+RUN CYPRESS_INSTALL_BINARY=0 npm install
+
 # Bundle app source
 COPY . /home/node/app
 


### PR DESCRIPTION
### Ticket

* https://trello.com/c/nXLfU3he

### Context

Whilst getting the build out for a fix to the release, we noticed that the docker image took a really long time to build.
This was due to it install cypress (testing library) as part of the production image.

This contains a copy of chromium which is really big.

On my laptop, setting the env flag to prevent the download reduces the build time by >40 seconds and the final image by >600m (over a 13/rd):

```
pch-w-cypress                          01          2fa3e69b3f16   8 minutes ago    1.61GB
pch-wo-cypress                         01          809705a0b2ae   24 minutes ago   993MB
```

> Does this issue have a Trello card?
No

