### PR TITLE
Bugfix popular topics links

### DIFF
--- a/server/content/establishmentData.json
+++ b/server/content/establishmentData.json
@@ -29,11 +29,11 @@
       "Music & talk": "/content/3662",
       "Chaplaincy": "/tags/901",
       "Inspiration": "/content/3659",
-      "Exercise": "/tags/90",
+      "Exercise": "/tags/907",
       "Games": "/content/3621",
       "Healthy mind & body": "/content/3657",
       "PSIs & PSOs": "/tags/796",
-      "Facilities list & catalogues": "/content/3990"
+      "Facilities list & catalogues": "/content/4539"
     },
     "personalInformation": true
   },
@@ -48,11 +48,11 @@
       "Music & talk": "/content/3662",
       "Chaplaincy": "/tags/901",
       "Inspiration": "/content/3659",
-      "Exercise": "/tags/90",
+      "Exercise": "/tags/907",
       "Games": "/content/3621",
       "Healthy mind & body": "/content/3657",
       "PSIs & PSOs": "/tags/796",
-      "Facilities list & catalogues": "/content/3990"
+      "Guide to Cookham Wood": "/content/5925"
     },
     "personalInformation": true
   }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/4GFGbytk

### Intent

> What changes are introduced by this PR that correspond to the above card?

Identified 404 errors in Sentry in relation to broken links on the popular topics for Wayland and Cookham Wood. Working links to exercise and facilities list restored with this PR

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
