### PR TITLE
Extracting out a topic service and new json api client

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,6 +1,13 @@
 {
   "restartable": "rs",
-  "ignore": [".git", "node_modules/**/node_modules", "assets/stylesheets"],
+  "ignore": [
+    ".git",
+    "node_modules/**/node_modules",
+    "assets/stylesheets",
+    "**/__tests__/**",
+    ".circleci/*",
+    "build-info.json"
+  ],
   "verbose": true,
   "execMap": {
     "js": "node --harmony"
@@ -13,5 +20,6 @@
   "env": {
     "NODE_ENV": "development"
   },
-  "ext": "js,json,css,scss,njk,html"
+  "ext": "js,json,css,scss,njk,html",
+  "delay": "2500"
 }

--- a/package.json
+++ b/package.json
@@ -31,16 +31,6 @@
     "node": ">= 14",
     "npm": ">=6.14.8"
   },
-  "nodemonConfig": {
-    "ignore": [
-      ".circleci/*",
-      "migrations/*",
-      "node_modules/*",
-      "**/__tests__/**",
-      "build-info.json"
-    ],
-    "delay": "2500"
-  },
   "jest": {
     "verbose": true,
     "testMatch": ["**/__tests__/**/*.[jt]s?(x)"]

--- a/server/app.js
+++ b/server/app.js
@@ -42,7 +42,7 @@ const createApp = ({
   logger,
   requestLogger,
   hubFeaturedContentService,
-  hubMenuService,
+  topicsService,
   hubContentService,
   hubTagsService,
   offenderService,
@@ -247,7 +247,7 @@ const createApp = ({
     }),
   );
 
-  app.use('/topics', createTopicsRouter({ hubMenuService }));
+  app.use('/topics', createTopicsRouter({ topicsService }));
 
   app.use('/timetable', createTimetableRouter({ offenderService }));
 

--- a/server/clients/jsonApiClient.js
+++ b/server/clients/jsonApiClient.js
@@ -1,0 +1,35 @@
+const axios = require('axios');
+const httpAdapter = require('axios/lib/adapters/http');
+const { logger } = require('../utils/logger');
+
+class JsonApiClient {
+  constructor(baseURL) {
+    this.client = axios.create({
+      baseURL,
+      timeout: 30000,
+      adapter: httpAdapter,
+    });
+    this.client.interceptors.request.use(request => {
+      logger.info(
+        `JsonApiClient [${request.method}] request - ${request.baseURL}${request.url}`,
+      );
+      return request;
+    });
+
+    this.client.interceptors.response.use(res => {
+      logger.info(
+        `JsonApiClient [${res.config?.method}], status: ${res.status} response - ${res.config?.baseURL}${res.config?.url}`,
+      );
+      return res;
+    });
+  }
+
+  async get(path, { query } = {}) {
+    const res = await this.client.get(path, { params: query });
+    return res.data;
+  }
+}
+
+module.exports = {
+  JsonApiClient,
+};

--- a/server/config.js
+++ b/server/config.js
@@ -41,13 +41,13 @@ module.exports = {
     callbackPath: '/auth/provider/callback',
   },
   api: {
+    hubEndpoint,
     hubContent: `${hubEndpoint}/v1/api/content`,
     hubCategoryFeatured: `${hubEndpoint}/v1/api/category/featured`,
     categoryMenu: `${hubEndpoint}/v1/api/category-menu`,
     hubTerm: `${hubEndpoint}/v1/api/term`,
     series: `${hubEndpoint}/v1/api/content/series`,
     tags: `${hubEndpoint}/v1/api/vocabulary/tags`,
-    primary: `${hubEndpoint}/jsonapi/node/landing_page?fields[node--landing_page]=title,field_moj_description,drupal_internal__nid,field_moj_prisons`,
   },
   apiV2: {
     hubContentFeatured: `${hubEndpoint}/v2/api/content/featured`,

--- a/server/repositories/__tests__/cmsApi.spec.js
+++ b/server/repositories/__tests__/cmsApi.spec.js
@@ -1,0 +1,132 @@
+const nock = require('nock');
+const {
+  primaryMenuResponse,
+  prisons,
+  landingPage,
+} = require('../../../test/resources/primaryMenu');
+const { JsonApiClient } = require('../../clients/jsonApiClient');
+const { CmsApi } = require('../cmsApi');
+
+describe('CmsApi', () => {
+  let cmsApi;
+  let mockDrupal;
+
+  beforeEach(() => {
+    if (!nock.isActive()) {
+      nock.activate();
+    }
+    const host = 'http://localhost:3333';
+    cmsApi = new CmsApi(new JsonApiClient(host));
+    mockDrupal = nock(host);
+  });
+
+  afterEach(() => {
+    nock.restore();
+  });
+
+  describe('primaryMenu', () => {
+    const path =
+      '/jsonapi/node/landing_page?fields[node--landing_page]=title,field_moj_description,drupal_internal__nid,field_moj_prisons';
+
+    it('should handle no items', async () => {
+      mockDrupal.get(path).reply(200, primaryMenuResponse([]));
+
+      const response = await cmsApi.primaryMenu(792);
+
+      expect(response).toStrictEqual([]);
+    });
+
+    it('should handle empty responses', async () => {
+      mockDrupal.get(path).reply(200);
+
+      const response = await cmsApi.primaryMenu(792);
+
+      expect(response).toStrictEqual([]);
+    });
+
+    it('should propagate errors', () => {
+      mockDrupal.get(path).reply(500, 'unexpected error');
+
+      return expect(cmsApi.primaryMenu(792)).rejects.toEqual(
+        Error('Request failed with status code 500'),
+      );
+    });
+
+    it('should format and return matching item', async () => {
+      mockDrupal.get(path).reply(
+        200,
+        primaryMenuResponse([
+          landingPage({
+            id: '1',
+            title: 'One',
+            processed: 'Desc 1',
+            prisons: [prisons[792]],
+          }),
+          landingPage({
+            id: '2',
+            title: 'Two',
+            processed: 'Desc 2',
+            prisons: [prisons[792]],
+          }),
+        ]),
+      );
+      const response = await cmsApi.primaryMenu(792);
+
+      expect(response).toStrictEqual([
+        {
+          description: 'Desc 1',
+          href: '/content/1',
+          id: '1',
+          linkText: 'One',
+        },
+        {
+          description: 'Desc 2',
+          href: '/content/2',
+          id: '2',
+          linkText: 'Two',
+        },
+      ]);
+    });
+
+    it('does not return pages configured for other prisons', async () => {
+      mockDrupal.get(path).reply(
+        200,
+        primaryMenuResponse([
+          landingPage({
+            id: '1',
+            title: 'One',
+            processed: 'Desc 1',
+            prisons: [prisons[793]],
+          }),
+        ]),
+      );
+      const response = await cmsApi.primaryMenu(792);
+
+      expect(response).toStrictEqual([]);
+    });
+
+    it('returns pages configured for no prisons', async () => {
+      mockDrupal.get(path).reply(
+        200,
+        primaryMenuResponse([
+          landingPage({
+            id: '1',
+            title: 'One',
+            processed: 'Desc 1',
+            prisons: [],
+          }),
+        ]),
+      );
+      const response = await cmsApi.primaryMenu(792);
+
+      expect(response).toStrictEqual([
+        {
+          description: 'Desc 1',
+          href: '/content/1',
+          id: '1',
+          linkText: 'One',
+        },
+      ]);
+    });
+  });
+});

--- a/server/repositories/cmsApi.js
+++ b/server/repositories/cmsApi.js
@@ -1,0 +1,37 @@
+const { getEstablishmentUiId } = require('../utils');
+
+class CmsApi {
+  constructor(jsonApiClient) {
+    this.jsonApiClient = jsonApiClient;
+  }
+
+  async primaryMenu(prisonId = 0) {
+    const response = await this.jsonApiClient.get(
+      `/jsonapi/node/landing_page?fields[node--landing_page]=title,field_moj_description,drupal_internal__nid,field_moj_prisons`,
+    );
+    return this.transform(response?.data || {}, prisonId);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  transform(data, prisonId) {
+    const items = Object.values(data)
+      .filter(({ relationships }) => {
+        const prisons = relationships?.field_moj_prisons?.data;
+        const matchingPrison = prisons.some(
+          prison => prison.id === getEstablishmentUiId(prisonId),
+        );
+
+        return prisons.length === 0 || matchingPrison;
+      })
+      .map(({ attributes }) => ({
+        id: attributes.drupal_internal__nid,
+        linkText: attributes.title,
+        description: attributes?.field_moj_description?.processed,
+        href: `/content/${attributes.drupal_internal__nid}`,
+      }));
+
+    return items;
+  }
+}
+
+module.exports = { CmsApi };

--- a/server/routes/__tests__/money.spec.js
+++ b/server/routes/__tests__/money.spec.js
@@ -481,7 +481,9 @@ describe('Prisoner Money', () => {
         .expect(200)
         .then(response => {
           const $ = cheerio.load(response.text);
-          expect( $('#completed-payments__heading h2').text()).toBe('Completed payments');
+          expect($('#completed-payments__heading h2').text()).toBe(
+            'Completed payments',
+          );
         });
     });
 
@@ -492,17 +494,17 @@ describe('Prisoner Money', () => {
           [api.pendingTransactions, success([])],
         ]);
       });
-    it('does not show pending transactions', async () => {
-      await request(app)
-        .get('/money/transactions/private')
-        .expect(200)
-        .then(response => {
-          const $ = cheerio.load(response.text);
-          // We should be presented the balance
-          expect($('.transaction__balances li').text()).toContain('£456.78');
-          // We should be presented with the pending transactions
-          expect($('#pending-transactions').length).toBe(0);
-        });
+      it('does not show pending transactions', async () => {
+        await request(app)
+          .get('/money/transactions/private')
+          .expect(200)
+          .then(response => {
+            const $ = cheerio.load(response.text);
+            // We should be presented the balance
+            expect($('.transaction__balances li').text()).toContain('£456.78');
+            // We should be presented with the pending transactions
+            expect($('#pending-transactions').length).toBe(0);
+          });
       });
       it('does not show the "Completed payments" title', async () => {
         await request(app)
@@ -510,9 +512,9 @@ describe('Prisoner Money', () => {
           .expect(200)
           .then(response => {
             const $ = cheerio.load(response.text);
-            expect( $('#completed-payments__heading h2').length).toBe(0);
+            expect($('#completed-payments__heading h2').length).toBe(0);
           });
-        });
+      });
     });
 
     describe('when unable to fetch pending transactions data', () => {
@@ -522,9 +524,8 @@ describe('Prisoner Money', () => {
           [api.transactionHistory, success(transactionApiResponse)],
           [api.balances, success(balancesApiResponse)],
         ]);
-      })
-    it('notifies the user', async () => {
-
+      });
+      it('notifies the user', async () => {
         await request(app)
           .get('/money/transactions/private')
           .expect(200)
@@ -551,7 +552,9 @@ describe('Prisoner Money', () => {
           .expect(200)
           .then(response => {
             const $ = cheerio.load(response.text);
-            expect( $('#completed-payments__heading h2').text()).toBe('Completed payments');
+            expect($('#completed-payments__heading h2').text()).toBe(
+              'Completed payments',
+            );
           });
       });
     });

--- a/server/routes/__tests__/topics.spec.js
+++ b/server/routes/__tests__/topics.spec.js
@@ -16,11 +16,11 @@ describe('GET /topics', () => {
   });
 
   it('passes exceptions to Sentry', async () => {
-    const hubMenuService = {
-      allTopics: jest.fn().mockRejectedValue('💥'),
+    const topicsService = {
+      getTopics: jest.fn().mockRejectedValue('💥'),
     };
 
-    const router = createTopicsRouter({ hubMenuService });
+    const router = createTopicsRouter({ topicsService });
 
     const app = setupBasicApp();
     app.use('/topics', router);
@@ -30,14 +30,14 @@ describe('GET /topics', () => {
   });
 
   describe('Topics', () => {
-    const hubMenuService = {
-      allTopics: jest.fn().mockReturnValue([
+    const topicsService = {
+      getTopics: jest.fn().mockReturnValue([
         { linkText: 'foo', href: '/content/foo' },
         { linkText: 'bar', href: '/content/bar' },
       ]),
     };
 
-    const router = createTopicsRouter({ hubMenuService });
+    const router = createTopicsRouter({ topicsService });
 
     const app = setupBasicApp();
     app.use((req, res, next) => {

--- a/server/routes/formatters.js
+++ b/server/routes/formatters.js
@@ -180,7 +180,7 @@ function createTransactionsResponseFrom(accountType, transactionsData) {
 
 function createPendingTransactionsResponseFrom(pending) {
   const failureNotification = createUserNotification(
-    'We are not able to show information about pending payments at this time'
+    'We are not able to show information about pending payments at this time',
   );
 
   try {

--- a/server/routes/topics.js
+++ b/server/routes/topics.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { path } = require('ramda');
 const Sentry = require('@sentry/node');
+const { logger } = require('../utils/logger');
 
 const fixUrls = element => {
   const { id, description, href, linkText } = element;
@@ -13,14 +14,14 @@ const fixUrls = element => {
   }
 };
 
-const createTopicsRouter = ({ hubMenuService }) => {
+const createTopicsRouter = ({ topicsService }) => {
   const router = express.Router();
 
   router.get('/', async (req, res, next) => {
     try {
       const userName = req.user && req.user.getFullName();
       const establishmentId = path(['session', 'establishmentId'], req);
-      const topics = await hubMenuService.allTopics(establishmentId);
+      const topics = await topicsService.getTopics(establishmentId);
 
       const config = {
         content: false,
@@ -37,6 +38,7 @@ const createTopicsRouter = ({ hubMenuService }) => {
         config,
       });
     } catch (e) {
+      logger.error(`Error loading topics: ${e.message}`);
       Sentry.captureException(e);
       next(e);
     }

--- a/server/services/__tests__/topicsService.spec.js
+++ b/server/services/__tests__/topicsService.spec.js
@@ -1,0 +1,99 @@
+const { TopicsService } = require('../topics');
+
+describe('Topics Service', () => {
+  const hubMenuRepo = { tagsMenu: jest.fn() };
+  const cmsApi = { primaryMenu: jest.fn() };
+  let topicService;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    topicService = new TopicsService(hubMenuRepo, cmsApi);
+  });
+
+  const createTopic = name => ({
+    description: `${name} Desc`,
+    href: '/content/1',
+    id: '1',
+    linkText: name,
+  });
+
+  describe('getTopics', () => {
+    it('returns topics from both sources', async () => {
+      hubMenuRepo.tagsMenu.mockResolvedValue([createTopic('Hub menu topic')]);
+      cmsApi.primaryMenu.mockResolvedValue([createTopic('Primary menu topic')]);
+
+      const result = await topicService.getTopics(1);
+
+      expect(result).toStrictEqual([
+        {
+          description: 'Hub menu topic Desc',
+          href: '/content/1',
+          id: '1',
+          linkText: 'Hub menu topic',
+        },
+        {
+          description: 'Primary menu topic Desc',
+          href: '/content/1',
+          id: '1',
+          linkText: 'Primary menu topic',
+        },
+      ]);
+    });
+
+    it('sorts topic by link text ignoring case', async () => {
+      hubMenuRepo.tagsMenu.mockResolvedValue([
+        createTopic('Ad'),
+        createTopic('Aa'),
+        createTopic('ab'),
+      ]);
+      cmsApi.primaryMenu.mockResolvedValue([createTopic('Ac')]);
+
+      const result = await topicService.getTopics(1);
+
+      expect(result.map(r => r.linkText)).toStrictEqual([
+        'Aa',
+        'ab',
+        'Ac',
+        'Ad',
+      ]);
+    });
+
+    it('Sources to have been called correctly', async () => {
+      hubMenuRepo.tagsMenu.mockResolvedValue([]);
+      cmsApi.primaryMenu.mockResolvedValue([]);
+
+      await topicService.getTopics(1);
+
+      expect(hubMenuRepo.tagsMenu).toHaveBeenCalledWith(1);
+      expect(cmsApi.primaryMenu).toHaveBeenCalledWith(1);
+    });
+
+    it('Sources to have been called correctly', async () => {
+      hubMenuRepo.tagsMenu.mockResolvedValue([]);
+      cmsApi.primaryMenu.mockResolvedValue([]);
+
+      await topicService.getTopics(1);
+
+      expect(hubMenuRepo.tagsMenu).toHaveBeenCalledWith(1);
+      expect(cmsApi.primaryMenu).toHaveBeenCalledWith(1);
+    });
+
+    it('Propagates errors from cmsApi', async () => {
+      hubMenuRepo.tagsMenu.mockRejectedValue(Error('some error!'));
+      cmsApi.primaryMenu.mockResolvedValue([]);
+
+      return expect(topicService.getTopics(1)).rejects.toEqual(
+        Error('some error!'),
+      );
+    });
+
+    it('Propagates errors from hub menu repo', async () => {
+      hubMenuRepo.tagsMenu.mockResolvedValue([]);
+      cmsApi.primaryMenu.mockRejectedValue(Error('some error!'));
+
+      return expect(topicService.getTopics(1)).rejects.toEqual(
+        Error('some error!'),
+      );
+    });
+  });
+});

--- a/server/services/__tests__/topicsService.spec.js
+++ b/server/services/__tests__/topicsService.spec.js
@@ -68,16 +68,6 @@ describe('Topics Service', () => {
       expect(cmsApi.primaryMenu).toHaveBeenCalledWith(1);
     });
 
-    it('Sources to have been called correctly', async () => {
-      hubMenuRepo.tagsMenu.mockResolvedValue([]);
-      cmsApi.primaryMenu.mockResolvedValue([]);
-
-      await topicService.getTopics(1);
-
-      expect(hubMenuRepo.tagsMenu).toHaveBeenCalledWith(1);
-      expect(cmsApi.primaryMenu).toHaveBeenCalledWith(1);
-    });
-
     it('Propagates errors from cmsApi', async () => {
       hubMenuRepo.tagsMenu.mockRejectedValue(Error('some error!'));
       cmsApi.primaryMenu.mockResolvedValue([]);

--- a/server/services/hubMenu.js
+++ b/server/services/hubMenu.js
@@ -1,7 +1,0 @@
-const createHubMenuService = repository => ({
-  allTopics: prisonId => repository.allTopics(prisonId),
-});
-
-module.exports = {
-  createHubMenuService,
-};

--- a/server/services/index.js
+++ b/server/services/index.js
@@ -6,6 +6,8 @@ const config = require('../config');
 const { HubClient } = require('../clients/hub');
 const { StandardClient } = require('../clients/standard');
 const { PrisonApiClient } = require('../clients/prisonApiClient');
+const { JsonApiClient } = require('../clients/jsonApiClient');
+
 const {
   RedisCachingStrategy,
   InMemoryCachingStrategy,
@@ -24,10 +26,11 @@ const { offenderRepository } = require('../repositories/offender');
 const { searchRepository } = require('../repositories/search');
 const { analyticsRepository } = require('../repositories/analytics');
 const { feedbackRepository } = require('../repositories/feedback');
+const { CmsApi } = require('../repositories/cmsApi');
 const PrisonApiRepository = require('../repositories/prisonApi');
 
 // Services
-const { createHubMenuService } = require('./hubMenu');
+const { TopicsService } = require('./topics');
 const { createHubFeaturedContentService } = require('./hubFeaturedContent');
 const { createHubContentService } = require('./hubContent');
 const { createHubTagsService } = require('./hubTags');
@@ -57,8 +60,9 @@ module.exports = {
   hubFeaturedContentService: createHubFeaturedContentService(
     hubFeaturedContentRepository(hubClient),
   ),
-  hubMenuService: createHubMenuService(
-    hubMenuRepository(hubClient, standardClient),
+  topicsService: new TopicsService(
+    hubMenuRepository(hubClient),
+    new CmsApi(new JsonApiClient(config.api.hubEndpoint)),
   ),
   hubContentService: createHubContentService({
     contentRepository: contentRepository(hubClient),

--- a/server/services/topics.js
+++ b/server/services/topics.js
@@ -1,15 +1,19 @@
 const caseInsensitive = new Intl.Collator('en', { caseFirst: 'lower' });
 
 class TopicsService {
+  #hubMenuRepository;
+
+  #cmsApi;
+
   constructor(hubMenuRepository, cmsApi) {
-    this.hubMenuRepository = hubMenuRepository;
-    this.cmsApi = cmsApi;
+    this.#hubMenuRepository = hubMenuRepository;
+    this.#cmsApi = cmsApi;
   }
 
   async getTopics(prisonId) {
     const [tags, primary] = await Promise.all([
-      this.hubMenuRepository.tagsMenu(prisonId),
-      this.cmsApi.primaryMenu(prisonId),
+      this.#hubMenuRepository.tagsMenu(prisonId),
+      this.#cmsApi.primaryMenu(prisonId),
     ]);
 
     return tags

--- a/server/services/topics.js
+++ b/server/services/topics.js
@@ -1,0 +1,23 @@
+const caseInsensitive = new Intl.Collator('en', { caseFirst: 'lower' });
+
+class TopicsService {
+  constructor(hubMenuRepository, cmsApi) {
+    this.hubMenuRepository = hubMenuRepository;
+    this.cmsApi = cmsApi;
+  }
+
+  async getTopics(prisonId) {
+    const [tags, primary] = await Promise.all([
+      this.hubMenuRepository.tagsMenu(prisonId),
+      this.cmsApi.primaryMenu(prisonId),
+    ]);
+
+    return tags
+      .concat(primary)
+      .sort((a, b) => caseInsensitive.compare(a.linkText, b.linkText));
+  }
+}
+
+module.exports = {
+  TopicsService,
+};

--- a/test/resources/primaryMenu.js
+++ b/test/resources/primaryMenu.js
@@ -1,0 +1,70 @@
+const primaryMenuResponse = (landingPages = []) => ({
+  jsonapi: {
+    version: '1.0',
+    meta: {
+      links: {
+        self: {
+          href: 'http://jsonapi.org/format/1.0/',
+        },
+      },
+    },
+  },
+  data: landingPages,
+  links: {
+    self: {
+      href:
+        'http://cms.prg/jsonapi/node/landing_page?fields%5Bnode--landing_page%5D=title%2Cfield_moj_description%2Cdrupal_internal__nid%2Cfield_moj_prisons',
+    },
+  },
+});
+
+const landingPage = ({ id, title, processed, prisons = [] }) => ({
+  type: 'node--landing_page',
+  id: 'fb260ea4-ee70-4070-b2fa-f34480d3be73',
+  links: {
+    self: {
+      href:
+        'http://cms.gov.uk/jsonapi/node/landing_page/fb260ea4-ee70-4070-b2fa-f34480d3be73?resourceVersion=id%3A4758',
+    },
+  },
+  attributes: {
+    drupal_internal__nid: id,
+    title,
+    field_moj_description: {
+      value: 'A value',
+      format: 'basic_html',
+      processed,
+      summary: 'A summary',
+    },
+  },
+  relationships: {
+    field_moj_prisons: {
+      data: prisons,
+      links: {
+        related: {
+          href:
+            'http://cms.gov.uk/jsonapi/node/landing_page/fb260ea4-ee70-4070-b2fa-f34480d3be73/field_moj_prisons?resourceVersion=id%3A4758',
+        },
+        self: {
+          href:
+            'http://cms.gov.uk/jsonapi/node/landing_page/fb260ea4-ee70-4070-b2fa-f34480d3be73/relationships/field_moj_prisons?resourceVersion=id%3A4758',
+        },
+      },
+    },
+  },
+});
+
+module.exports = {
+  primaryMenuResponse,
+  landingPage,
+  prisons: {
+    792: {
+      type: 'taxonomy_term--prisons',
+      id: 'fd1e1db7-d0be-424a-a3a6-3b0f49e33293',
+    },
+    793: {
+      type: 'taxonomy_term--prisons',
+      id: 'b73767ea-2cbb-4ad5-ba22-09379cc07241',
+    },
+  },
+};


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/cuCgbKtD

### Intent

Put in place the start of a new json api client and extract out a cmsApi which will be the basis of new json api functionality.

I've then moved the existing json api call into it and ensured its covered by nock tests

As part of this I realised that the sorting on the topic page only checked the first character. This lead to strange results in certain cases: 
<img width="649" alt="Screenshot 2021-05-05 at 15 37 53" src="https://user-images.githubusercontent.com/1517745/117268902-b22ee800-ae4f-11eb-92bd-37f8e4fee837.png">


### Considerations

This has changed some of the error handling behaviour. 

The topic page is made out of landing pages and categories - previously if either call failed then it would still show the results of the other call. Not if one call fails it will show an error page. 

Could look at reinstating this if necessary, but going forward we will hopefully merge both calls into one by making changes in drupal.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
