### PR TITLE
bug/fix-search: Changing search type

### DIFF
--- a/server/repositories/search.js
+++ b/server/repositories/search.js
@@ -35,8 +35,8 @@ function searchRepository(httpClient) {
               .operator('and'),
           )
           .should([
-            esb.termQuery('prison_name', prison),
-            esb.boolQuery().mustNot([esb.existsQuery('prison_name')]),
+            esb.termQuery('prison_name.keyword', prison),
+            esb.boolQuery().mustNot([esb.existsQuery('prison_name.keyword')]),
           ])
           .minimumShouldMatch(1),
       )
@@ -108,8 +108,8 @@ function searchRepository(httpClient) {
               .minimumShouldMatch(1),
           )
           .should([
-            esb.termQuery('prison_name', prison),
-            esb.boolQuery().mustNot([esb.existsQuery('prison_name')]),
+            esb.termQuery('prison_name.keyword', prison),
+            esb.boolQuery().mustNot([esb.existsQuery('prison_name.keyword')]),
           ])
           .minimumShouldMatch(1),
       )

--- a/server/routes/__tests__/health.spec.js
+++ b/server/routes/__tests__/health.spec.js
@@ -1,14 +1,14 @@
 const request = require('supertest');
-const express = require('express')
+const express = require('express');
 
 const { createHealthRouter } = require('../health');
 
 describe('GET healthchecks', () => {
   let config;
   let app;
-  const BUILD_NUMBER = 'foo-number'
-  const GIT_REF = 'foo-ref'
-  const GIT_DATE = 'foo-date'
+  const BUILD_NUMBER = 'foo-number';
+  const GIT_REF = 'foo-ref';
+  const GIT_DATE = 'foo-date';
   beforeEach(() => {
     config = {
       buildInfo: {
@@ -17,10 +17,10 @@ describe('GET healthchecks', () => {
         gitDate: GIT_DATE,
       },
     };
-    app = express()
+    app = express();
     app.use('/health', createHealthRouter(config));
-  })
-  it('returns the health status of the application on /health', () => 
+  });
+  it('returns the health status of the application on /health', () =>
     request(app)
       .get('/health')
       .expect(200)
@@ -36,9 +36,8 @@ describe('GET healthchecks', () => {
           uptime: expect.any(Number),
           version: BUILD_NUMBER,
         });
-      })
-  );
-  it('returns the readiness status of the application', () => 
+      }));
+  it('returns the readiness status of the application', () =>
     request(app)
       .get('/health/readiness')
       .expect(200)
@@ -47,6 +46,5 @@ describe('GET healthchecks', () => {
         expect(res.body).toStrictEqual({
           status: 'OK',
         });
-      })
-  );
+      }));
 });

--- a/server/routes/health.js
+++ b/server/routes/health.js
@@ -1,6 +1,6 @@
 const express = require('express');
 
-const createHealthRouter = ({ buildInfo:build }) => {
+const createHealthRouter = ({ buildInfo: build }) => {
   const router = express.Router();
 
   router.get('/', (_, res) => res.json(addAppInfo({ healthy: true }, build)));
@@ -14,9 +14,9 @@ function addAppInfo(result, build) {
     uptime: process.uptime(),
     build,
     version: build && build.buildNumber,
-  }
+  };
 
-  return { ...result, ...buildInfo }
+  return { ...result, ...buildInfo };
 }
 
 module.exports = {

--- a/server/services/__tests__/search.spec.js
+++ b/server/services/__tests__/search.spec.js
@@ -1,18 +1,32 @@
 const { createSearchService } = require('../search');
-const { lastCall } = require('../../../test/test-helpers');
 
 describe('SearchService', () => {
+  const searchRepository = {
+    find: jest.fn(),
+    typeAhead: jest.fn(),
+  };
+  const getEstablishmentFormattedName = jest
+    .fn()
+    .mockReturnValue('HMP Development');
+  let service;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    getEstablishmentFormattedName.mockReturnValue('HMP Development');
+
+    service = createSearchService({
+      searchRepository,
+      getEstablishmentFormattedName,
+    });
+  });
+
   describe('#find', () => {
     it('returns search results', async () => {
-      const searchRepository = {
-        find: jest.fn().mockResolvedValue(['result_1', 'result_2', 'result_3']),
-      };
-      const getEstablishmentName = jest.fn().mockReturnValue('HMP Development');
-
-      const service = createSearchService({
-        searchRepository,
-        getEstablishmentName,
-      });
+      searchRepository.find.mockResolvedValue([
+        'result_1',
+        'result_2',
+        'result_3',
+      ]);
 
       const result = await service.find({
         query: 'Test Query',
@@ -21,44 +35,22 @@ describe('SearchService', () => {
         from: 5,
       });
 
-      expect(searchRepository.find).toHaveBeenCalledTimes(
-        1,
-        'The repository should have been called',
-      );
+      expect(searchRepository.find).toHaveBeenCalledTimes(1);
 
-      expect(lastCall(searchRepository.find)[0]).toStrictEqual(
-        {
-          query: 'Test Query',
-          prison: 'HMP Development',
-          limit: 10,
-          from: 5,
-        },
-        'The repository should have been called with the correct arguments',
-      );
+      expect(searchRepository.find).toHaveBeenCalledWith({
+        query: 'Test Query',
+        prison: 'HMP Development',
+        limit: 10,
+        from: 5,
+      });
 
-      expect(getEstablishmentName).toHaveBeenCalledTimes(
-        1,
-        'The service should get the establishment name',
-      );
-
-      expect(lastCall(getEstablishmentName)[0]).toStrictEqual(123);
-
-      expect(Array.isArray(result)).toBe(
-        true,
-        'The service should return an array of results',
-      );
+      expect(getEstablishmentFormattedName).toHaveBeenCalledTimes(1);
+      expect(getEstablishmentFormattedName).toHaveBeenCalledWith(123);
+      expect(Array.isArray(result)).toBe(true);
     });
 
     it('returns empty when there is no query', async () => {
-      const searchRepository = {
-        find: jest.fn(),
-      };
-      const getEstablishmentName = jest.fn().mockReturnValue('HMP Development');
-
-      const service = createSearchService({
-        searchRepository,
-        getEstablishmentName,
-      });
+      searchRepository.find.mockResolvedValue([]);
 
       const results = await service.find({
         query: '',
@@ -67,30 +59,19 @@ describe('SearchService', () => {
         from: 5,
       });
 
-      expect(Array.isArray(results)).toBe(
-        true,
-        'The method should return an array',
-      );
-
-      expect(results.length).toBe(0, 'The array should be empty');
-
+      expect(Array.isArray(results)).toBe(true);
+      expect(results.length).toBe(0);
       expect(searchRepository.find).not.toHaveBeenCalled();
     });
   });
 
   describe('#typeAhead', () => {
     it('returns search results', async () => {
-      const searchRepository = {
-        typeAhead: jest
-          .fn()
-          .mockResolvedValue(['result_1', 'result_2', 'result_3']),
-      };
-      const getEstablishmentName = jest.fn().mockReturnValue('HMP Development');
-
-      const service = createSearchService({
-        searchRepository,
-        getEstablishmentName,
-      });
+      searchRepository.typeAhead.mockResolvedValue([
+        'result_1',
+        'result_2',
+        'result_3',
+      ]);
 
       const result = await service.typeAhead({
         query: 'Test Query',
@@ -98,43 +79,21 @@ describe('SearchService', () => {
         limit: 3,
       });
 
-      expect(searchRepository.typeAhead).toHaveBeenCalledTimes(
-        1,
-        'The repository should have been called',
-      );
+      expect(searchRepository.typeAhead).toHaveBeenCalledTimes(1);
 
-      expect(lastCall(searchRepository.typeAhead)[0]).toStrictEqual(
-        {
-          query: 'Test Query',
-          prison: 'HMP Development',
-          limit: 3,
-        },
-        'The repository should have been called with the correct arguments',
-      );
+      expect(searchRepository.typeAhead).toHaveBeenCalledWith({
+        query: 'Test Query',
+        prison: 'HMP Development',
+        limit: 3,
+      });
 
-      expect(getEstablishmentName).toHaveBeenCalledTimes(
-        1,
-        'The service should get the establishment name',
-      );
-
-      expect(lastCall(getEstablishmentName)[0]).toStrictEqual(123);
-
-      expect(Array.isArray(result)).toBe(
-        true,
-        'The service should return an array of results',
-      );
+      expect(getEstablishmentFormattedName).toHaveBeenCalledTimes(1);
+      expect(getEstablishmentFormattedName).toHaveBeenCalledWith(123);
+      expect(Array.isArray(result)).toBe(true);
     });
 
     it('returns empty when there is no query', async () => {
-      const searchRepository = {
-        typeAhead: jest.fn(),
-      };
-      const getEstablishmentName = jest.fn().mockReturnValue('HMP Development');
-
-      const service = createSearchService({
-        searchRepository,
-        getEstablishmentName,
-      });
+      searchRepository.typeAhead.mockResolvedValue([]);
 
       const results = await service.typeAhead({
         query: '',
@@ -142,14 +101,9 @@ describe('SearchService', () => {
         limit: 3,
       });
 
-      expect(Array.isArray(results)).toBe(
-        true,
-        'The method should return an array',
-      );
-
-      expect(results.length).toBe(0, 'The array should be empty');
-
       expect(searchRepository.typeAhead).not.toHaveBeenCalled();
+      expect(Array.isArray(results)).toBe(true);
+      expect(results.length).toBe(0);
     });
   });
 });

--- a/server/services/search.js
+++ b/server/services/search.js
@@ -2,10 +2,10 @@ const utils = require('../utils');
 
 const createSearchService = ({
   searchRepository,
-  getEstablishmentName = utils.getEstablishmentName,
+  getEstablishmentFormattedName = utils.getEstablishmentFormattedName,
 }) => {
   function find({ query, limit, from, establishmentId }) {
-    const prison = getEstablishmentName(establishmentId);
+    const prison = getEstablishmentFormattedName(establishmentId);
 
     if (query === '') {
       return [];
@@ -15,7 +15,7 @@ const createSearchService = ({
   }
 
   function typeAhead({ query, limit, establishmentId }) {
-    const prison = getEstablishmentName(establishmentId);
+    const prison = getEstablishmentFormattedName(establishmentId);
 
     if (query === '') {
       return [];


### PR DESCRIPTION
### Context

https://trello.com/c/AHyLgirl

We were previously doing a term search on a text value.
This has [known limitations](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html#avoid-term-query-text-fields)

 This would only work for single word prisons. The text value would be processed during index to split by individual word and lower case whereas the terms query would pass the exact phrase.

So when we searched for 'Cookham wood' it would fail to match either the tokens 'cookham' or 'wood'.
Luckily according to the index I could see that a separate  prison_name.keyword was also indexed which indexes the whole thing.

This change moves to using the formatted name and the keyword field as these currently always match.
We should see if drupal would allow us to index establishment id as going forward a keyword index on establishment id would be more robust.

### Considerations

Worth giving search a bit of a tire kicking generally across each prison