### PR TITLE
Increase category page content limit

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -3,7 +3,6 @@ const addRequestId = require('express-request-id')();
 const compression = require('compression');
 const helmet = require('helmet');
 const noCache = require('nocache');
-const nunjucks = require('nunjucks');
 const path = require('path');
 const sassMiddleware = require('node-sass-middleware');
 const session = require('cookie-session');
@@ -11,6 +10,7 @@ const passport = require('passport');
 const AzureAdOAuth2Strategy = require('passport-azure-ad-oauth2');
 const { path: ramdaPath, pathOr } = require('ramda');
 const Sentry = require('@sentry/node');
+const nunjucksSetup = require('./utils/nunjucksSetup');
 
 const { createIndexRouter } = require('./routes/index');
 const { createTopicsRouter } = require('./routes/topics');
@@ -54,21 +54,12 @@ const createApp = ({
 }) => {
   const app = express();
 
-  const appViews = [
-    path.join(__dirname, '../node_modules/govuk-frontend/'),
-    path.join(__dirname, '/views/'),
-  ];
-
   app.locals.config = config;
 
   // View Engine Configuration
-  app.set('views', path.join(__dirname, '../server/views'));
   app.set('view engine', 'html');
-  nunjucks.configure(appViews, {
-    express: app,
-    autoescape: true,
-  });
 
+  nunjucksSetup(app);
   app.set('json spaces', 2);
 
   // Configure Express for running behind proxies

--- a/server/repositories/categoryFeaturedContent.js
+++ b/server/repositories/categoryFeaturedContent.js
@@ -6,7 +6,7 @@ const config = require('../config');
 const { featuredContentResponseFrom } = require('../utils/adapters');
 
 function categoryFeaturedContentRepository(httpClient) {
-  async function contentFor({ categoryId, establishmentId, number = 8 } = {}) {
+  async function contentFor({ categoryId, establishmentId, number = 10 } = {}) {
     const endpoint = `${config.api.hubCategoryFeatured}`;
     const query = {
       _number: number,

--- a/server/utils/__tests__/nunjucksSetup.spec.js
+++ b/server/utils/__tests__/nunjucksSetup.spec.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const nunjucksSetup = require('../nunjucksSetup');
+
+describe('skip', () => {
+  let skip;
+  beforeEach(() => {
+    const env = nunjucksSetup(express());
+    skip = env.getFilter('skip');
+  });
+  it('should handle an empty array', () => {
+    expect(skip([], 1)).toEqual([]);
+  });
+
+  it('should skip first item', () => {
+    expect(skip([1, 2, 3], 1)).toEqual([2, 3]);
+  });
+
+  it('should handle negative indexes', () => {
+    expect(skip([1, 2, 3], -1)).toEqual([3]);
+  });
+
+  it('should handle null', () => {
+    expect(() => skip(null, -1)).toThrowError();
+  });
+});

--- a/server/utils/nunjucksSetup.js
+++ b/server/utils/nunjucksSetup.js
@@ -1,0 +1,18 @@
+const nunjucks = require('nunjucks');
+const path = require('path');
+
+module.exports = expressApp => {
+  const appViews = [
+    path.join(__dirname, '../../node_modules/govuk-frontend/'),
+    path.join(__dirname, '../views/'),
+  ];
+
+  const nunjucksEnv = nunjucks.configure(appViews, {
+    express: expressApp,
+    autoescape: true,
+  });
+
+  nunjucksEnv.addFilter('skip', (array, count) => array.slice(count));
+
+  return nunjucksEnv;
+};

--- a/server/views/pages/category.html
+++ b/server/views/pages/category.html
@@ -85,21 +85,14 @@
     <h2>Featured</h2>
     <div class="category-content">
       {{ contentTileLarge({content: data.categoryFeaturedContent.data[0], imageAlign: 'right'}) }}
-      {% for tile in data.categoryFeaturedContent.data %}
-        {% if loop.index === 1 or loop.index === 5 %}
-          <div class="category-content__three-items">
-          {% endif %}
-          {% if loop.index > 1 and loop.index <= 7 %}
-            {{ contentTileSmall(tile) }}
-          {% endif %}
-          {% if loop.index === 4 or loop.index === 7 %}
-          </div>
-        {% endif %}
-      {% endfor %}
-      {% if data.categoryFeaturedContent.data.length !== 4 and data.categoryFeaturedContent.data.length !== 7 and data.categoryFeaturedContent.data.length < 8 %}
+      {%- for tiles in data.categoryFeaturedContent.data | skip(1) | batch(3) %}
+      <div class="category-content__three-items">
+        {%- for tile in tiles %}
+          {{ contentTileSmall(tile) }}
+        {%- endfor %}
       </div>
-    {% endif %}
-  </div>
+      {%- endfor %}
+    </div>
   <div class="feedback-tablet">
     <h2 class="govuk-heading-m">Give us feedback</h2>
     {{ hubFeedbackWidget({

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -1,22 +1,12 @@
 const express = require('express');
-const path = require('path');
-const nunjucks = require('nunjucks');
 const chance = require('chance')();
+const nunjucksSetup = require('../server/utils/nunjucksSetup');
 
 function setupBasicApp(config = {}) {
   const app = express();
-  app.set('views', path.join(__dirname, '../server/views'));
   app.set('view engine', 'html');
 
-  const appViews = [
-    path.join(__dirname, '../node_modules/govuk-frontend/'),
-    path.join(__dirname, '../server/views/'),
-  ];
-
-  nunjucks.configure(appViews, {
-    express: app,
-    autoescape: true,
-  });
+  nunjucksSetup(app);
 
   app.locals.config = config;
 


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/S1EaJpo1

### Intent

> What changes are introduced by this PR that correspond to the above card?

*Increase category page content limit to 10 items
*Add standalone nunjucks app setup
*Refactor category featured content logic

> Would this PR benefit from screenshots?

![Screenshot 2021-06-03 at 12 00 41](https://user-images.githubusercontent.com/29005413/120634759-89583d80-c463-11eb-9c98-398acaaaed22.png)

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
