### PR TITLE
Deploying adhoc development environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,8 @@ commands:
         type: string
       releaseName:
         type: string
+      qualifier:
+        type: string  
     steps:
       - attach_workspace:
           at: /tmp/build-info
@@ -61,7 +63,7 @@ commands:
           command: |
             VERSION_TO_DEPLOY=$(cat /tmp/build-info/version-to-deploy.txt)
             sed -i "s/appVersion:.*/appVersion: \"${VERSION_TO_DEPLOY}\"/g" "./helm_deploy/prisoner-content-hub-frontend/Chart.yaml"
-            helm upgrade << parameters.releaseName >> ./helm_deploy/prisoner-content-hub-frontend \
+            helm upgrade << parameters.releaseName >><< parameters.qualifier >> ./helm_deploy/prisoner-content-hub-frontend \
               --install --wait --force --reset-values --timeout 360s \
               --namespace=${KUBE_NAMESPACE} \
               --values ./helm_deploy/prisoner-content-hub-frontend/values.<< parameters.environment >>.yaml \
@@ -78,7 +80,8 @@ commands:
               --set prisonerAuthAD.clientId=${AZURE_AD_CLIENT_ID} \
               --set prisonerAuthAD.clientSecret=${AZURE_AD_CLIENT_SECRET} \
               --set hotJarId=${HOTJAR_ID} \
-              --set image.tag=${VERSION_TO_DEPLOY}
+              --set image.tag=${VERSION_TO_DEPLOY} \
+              --set ingress.qualifier="<< parameters.qualifier >>"
 
 jobs:
   build:
@@ -233,56 +236,43 @@ jobs:
     parameters:
       environment:
         type: string
+      qualifier:
+        type: string
+        default: ""    
     steps:
       - checkout
       - set_up_helm
       - release_to_namespace:
           environment: "<< parameters.environment >>"
           releaseName: "prisoner-content-hub-frontend"
+          qualifier: "<< parameters.qualifier >>"
 
 workflows:
   version: 2
   build-test-deploy:
     jobs:
-      - build
-      - run_unit_tests:
-          requires:
-            - build
-      - run_e2e_tests:
-          requires:
-            - build
-
       - build_preview:
           <<: *feature_branch
-
-      - approve_preview_build:
-          <<: *feature_branch
-          type: approval
-          requires:
-            - build_preview
 
       - deploy_cloud_platform:
           <<: *feature_branch
           context: prisoner-content-hub-development
-          matrix:
-            parameters:
-              environment: ["development"]
+          environment: "development"
+          qualifier: "-${CIRCLE_PULL_REQUEST##*/}"
           requires:
-            - approve_preview_build
+            - build_preview
 
       - build_production:
           <<: *main_branch
-          requires:
-            - run_unit_tests
-            - run_e2e_tests
+#          requires:
+#            - run_unit_tests
+#            - run_e2e_tests
 
       - deploy_cloud_platform:
           <<: *main_branch
           context: prisoner-content-hub-staging
-          matrix:
-            alias: deploy_to_staging
-            parameters:
-              environment: ["staging"]
+          name: deploy_to_staging
+          environment: "staging"
           requires:
             - build_production
 
@@ -295,9 +285,7 @@ workflows:
       - deploy_cloud_platform:
           <<: *main_branch
           context: prisoner-content-hub-prod
-          matrix:
-            parameters:
-              environment: ["production"]
+          environment: "production"
           requires:
             - approve_deploy_production
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ commands:
           command: |
             VERSION_TO_DEPLOY=$(cat /tmp/build-info/version-to-deploy.txt)
             sed -i "s/appVersion:.*/appVersion: \"${VERSION_TO_DEPLOY}\"/g" "./helm_deploy/prisoner-content-hub-frontend/Chart.yaml"
-            helm upgrade << parameters.releaseName >><< parameters.qualifier >> ./helm_deploy/prisoner-content-hub-frontend \
+            helm upgrade << parameters.releaseName >>-<< parameters.qualifier >> ./helm_deploy/prisoner-content-hub-frontend \
               --install --wait --force --reset-values --timeout 360s \
               --namespace=${KUBE_NAMESPACE} \
               --values ./helm_deploy/prisoner-content-hub-frontend/values.<< parameters.environment >>.yaml \
@@ -251,6 +251,13 @@ workflows:
   version: 2
   build-test-deploy:
     jobs:
+      - build
+      - run_unit_tests:
+          requires:
+            - build
+      - run_e2e_tests:
+          requires:
+            - build
       - build_preview:
           <<: *feature_branch
 
@@ -258,15 +265,15 @@ workflows:
           <<: *feature_branch
           context: prisoner-content-hub-development
           environment: "development"
-          qualifier: "-${CIRCLE_PULL_REQUEST##*/}"
+          qualifier: "${CIRCLE_PULL_REQUEST##*/}"
           requires:
             - build_preview
 
       - build_production:
           <<: *main_branch
-#          requires:
-#            - run_unit_tests
-#            - run_e2e_tests
+          requires:
+            - run_unit_tests
+            - run_e2e_tests
 
       - deploy_cloud_platform:
           <<: *main_branch

--- a/helm_deploy/prisoner-content-hub-frontend/templates/NOTES.txt
+++ b/helm_deploy/prisoner-content-hub-frontend/templates/NOTES.txt
@@ -3,9 +3,9 @@ Ingress not enabled
 {{ else }}
 Application is running at:
   {{- range .Values.ingress.hosts }}
-    {{- $domainSuffix := .suffix -}}
+    {{- $domainPattern := .pattern -}}
     {{- range $.Values.ingress.prefixes }}
-    - {{ . }}{{ $domainSuffix }}
+    - {{ tpl $domainPattern (dict "prison" . "qualifier" $.Values.ingress.qualifier "Template" $.Template) }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/helm_deploy/prisoner-content-hub-frontend/templates/ingress.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/templates/ingress.yaml
@@ -13,20 +13,20 @@ metadata:
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.ingress.allowed | quote }}
 spec:
   tls:
-   {{- range .Values.ingress.hosts }}
+  {{- range .Values.ingress.hosts }}
   {{- $certSecret := .cert_secret -}}
-  {{- $domainSuffix := .suffix }}
+  {{- $domainPattern := .pattern }}
   - hosts:
     {{- range $.Values.ingress.prefixes }}
-      - {{ . }}-prisoner-content-hub{{ if $.Values.ingress.qualifier }}{{$.Values.ingress.qualifier}}{{- end}}{{ $domainSuffix }}
+      - {{ tpl $domainPattern (dict "prison" . "qualifier" $.Values.ingress.qualifier "Template" $.Template) }}
     {{ if $certSecret }}secretName: {{ $certSecret }}{{ end }}
     {{- end }}
   {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    {{- $domainSuffix := .suffix -}}
+    {{- $domainPattern := .pattern -}}
     {{- range $.Values.ingress.prefixes }}
-    - host: {{ . }}-prisoner-content-hub{{ if $.Values.ingress.qualifier }}{{$.Values.ingress.qualifier}}{{- end}}{{ $domainSuffix }}
+    - host: {{ tpl $domainPattern (dict "prison" . "qualifier" $.Values.ingress.qualifier "Template" $.Template) }}
       http:
         paths:
           - path: "/"

--- a/helm_deploy/prisoner-content-hub-frontend/templates/ingress.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/templates/ingress.yaml
@@ -13,12 +13,12 @@ metadata:
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.ingress.allowed | quote }}
 spec:
   tls:
-  {{- range .Values.ingress.hosts }}
+   {{- range .Values.ingress.hosts }}
   {{- $certSecret := .cert_secret -}}
   {{- $domainSuffix := .suffix }}
   - hosts:
     {{- range $.Values.ingress.prefixes }}
-      - {{ . }}{{ $domainSuffix }}
+      - {{ . }}-prisoner-content-hub{{ if $.Values.ingress.qualifier }}{{$.Values.ingress.qualifier}}{{- end}}{{ $domainSuffix }}
     {{ if $certSecret }}secretName: {{ $certSecret }}{{ end }}
     {{- end }}
   {{- end }}
@@ -26,7 +26,7 @@ spec:
   {{- range .Values.ingress.hosts }}
     {{- $domainSuffix := .suffix -}}
     {{- range $.Values.ingress.prefixes }}
-    - host: {{ . }}{{ $domainSuffix }}
+    - host: {{ . }}-prisoner-content-hub{{ if $.Values.ingress.qualifier }}{{$.Values.ingress.qualifier}}{{- end}}{{ $domainSuffix }}
       http:
         paths:
           - path: "/"

--- a/helm_deploy/prisoner-content-hub-frontend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.development.yaml
@@ -12,4 +12,4 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
   hosts:
-    - suffix: -development.apps.live-1.cloud-platform.service.justice.gov.uk
+    - pattern: "{{ .prison }}-prisoner-content-hub-development-{{ .qualifier }}.apps.live-1.cloud-platform.service.justice.gov.uk"

--- a/helm_deploy/prisoner-content-hub-frontend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.development.yaml
@@ -12,4 +12,4 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
   hosts:
-    - suffix: -prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk
+    - suffix: -development.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-frontend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.production.yaml
@@ -9,6 +9,6 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
   hosts:
-    - suffix: .content-hub.prisoner.service.justice.gov.uk
+    - pattern: "{{ .prison }}.content-hub.prisoner.service.justice.gov.uk"
       cert_secret: prisoner-content-hub-frontend-certificate
-    - suffix: -production.apps.live-1.cloud-platform.service.justice.gov.uk
+    - pattern: "{{ .prison }}-prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk"

--- a/helm_deploy/prisoner-content-hub-frontend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.production.yaml
@@ -11,4 +11,4 @@ ingress:
   hosts:
     - suffix: .content-hub.prisoner.service.justice.gov.uk
       cert_secret: prisoner-content-hub-frontend-certificate
-    - suffix: -prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk
+    - suffix: -production.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-frontend/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.staging.yaml
@@ -9,4 +9,4 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
   hosts:
-    - suffix: -staging.apps.live-1.cloud-platform.service.justice.gov.uk
+    - pattern: "{{ .prison }}-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk"

--- a/helm_deploy/prisoner-content-hub-frontend/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.staging.yaml
@@ -9,4 +9,4 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
   hosts:
-    - suffix: -prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk
+    - suffix: -staging.apps.live-1.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
### Context

https://trello.com/c/O5qXdz7V 

### Intent

Creating individual dev deployments of the frontend app for each PR

Move to pushing through the circle CI PR number as a qualifier to distinguish between different helm releases.
This  qualifier is then fed into domain name construction

PR build 280 would listen to: 

* https://cookhamwood-prisoner-content-hub-development-280.apps.live-1.cloud-platform.service.justice.gov.uk
* https://berwyn-prisoner-content-hub-development-280.apps.live-1.cloud-platform.service.justice.gov.uk 
... etc 

These releases can be seen with: 

```
helm -n prisoner-content-hub-development list   
```

Further pushes to a remote branch with a PR on will lead to the app being upgraded. 

### Considerations

These environments will not currently be disposed of after merging - need to manually uninstall them using helm. e.g:

```
helm -n prisoner-content-hub-development uninstall prisoner-content-hub-frontend-280   
```

This will remove the deployment and all associated resources (secrets, ingress etc..)

### In follow ups also need to consider:

* Dropping number of replicas for each deployment to 1 on dev
* Sending notification that the environment has been created 
* Automating deletion of deployments after PR merged