### PR TITLE
Fixing staging deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,9 @@ commands:
           command: |
             VERSION_TO_DEPLOY=$(cat /tmp/build-info/version-to-deploy.txt)
             sed -i "s/appVersion:.*/appVersion: \"${VERSION_TO_DEPLOY}\"/g" "./helm_deploy/prisoner-content-hub-frontend/Chart.yaml"
-            helm upgrade << parameters.releaseName >>-<< parameters.qualifier >> ./helm_deploy/prisoner-content-hub-frontend \
+            QUALIFIER=<< parameters.qualifier >>
+            RELEASE_NAME=<< parameters.releaseName >>${QUALIFIER:+-$QUALIFIER}
+            helm upgrade $RELEASE_NAME ./helm_deploy/prisoner-content-hub-frontend \
               --install --wait --force --reset-values --timeout 360s \
               --namespace=${KUBE_NAMESPACE} \
               --values ./helm_deploy/prisoner-content-hub-frontend/values.<< parameters.environment >>.yaml \


### PR DESCRIPTION
In staging and prod there would be no qualifier so the helm release would be named `prisoner-content-hub-frontend-` which is invalid

This change only adds the `-` separator between release name and qualifier if qualifier is present
