### PR TITLE
bug/remove-padding-for-next-visit-time

### DIFF
--- a/server/views/pages/profile.html
+++ b/server/views/pages/profile.html
@@ -177,8 +177,8 @@
             <li class="govuk-grid-column-one-quarter card-group__item">
               {% call card({ id: 'nextVisit', heading: 'Your next visit'}) -%}
                 {% if visitsSummary.hasNextVisit %}
-                  <strong>{{ visitsSummary.nextVisit }}</strong>
-                  <p>{{ visitsSummary.startTime }} to {{ visitsSummary.endTime }}</p>
+                  <strong>{{ visitsSummary.nextVisit }}</strong><br/>
+                  {{ visitsSummary.startTime }} to {{ visitsSummary.endTime }}
                 {% else %}
                   No upcoming visit
                 {% endif %}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/dW459ORh/153-display-the-visit-time-on-the-prisoner-profile

> If this is an issue, do we have steps to reproduce?

Go to profile and next visits

### Intent

> What changes are introduced by this PR that correspond to the above card?

Minor layout changes.

> Would this PR benefit from screenshots?

<img width="1309" alt="Screenshot 2021-06-15 at 12 21 42" src="https://user-images.githubusercontent.com/50403492/122044433-65d2b280-cdd4-11eb-9a97-1d8dd30e2ed5.png">


### Considerations

> Is there any additional information that would help when reviewing this PR?

N/A

> Are there any steps required when merging/deploying this PR?

N/A

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
