### PR TITLE
Enabling mock auth in dev

### DIFF
--- a/helm_deploy/prisoner-content-hub-frontend/templates/_envs.tpl
+++ b/helm_deploy/prisoner-content-hub-frontend/templates/_envs.tpl
@@ -74,7 +74,7 @@ env:
       value: {{ .Values.application.sentry_release }}
 
     - name: ENABLE_MOCK_AUTH
-      value: "false"
+      value: {{ .Values.mockAuthEnabled | quote }}
 
     - name: HOTJAR_ID
       value: {{ .Values.hotJarId | quote }}

--- a/helm_deploy/prisoner-content-hub-frontend/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.development.yaml
@@ -7,6 +7,7 @@ application:
     feedbackServiceName: aws-es-proxy-service
     feedbackEndpoint: /prod-feedback/_doc
     analyticsSiteId: UA-152065860-4
+    mockAuthEnabled: true
 
 ingress:
   annotations:

--- a/helm_deploy/prisoner-content-hub-frontend/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.production.yaml
@@ -4,6 +4,7 @@ application:
     feedbackServiceName: aws-es-proxy-service
     feedbackEndpoint: /prod-feedback/_doc
     analyticsSiteId: UA-152065860-6
+    mockAuthEnabled: false
 
 ingress:
   annotations:

--- a/helm_deploy/prisoner-content-hub-frontend/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.staging.yaml
@@ -4,6 +4,7 @@ application:
     feedbackServiceName: aws-es-proxy-service
     feedbackEndpoint: /prod-feedback/_doc
     analyticsSiteId: UA-152065860-7
+    mockAuthEnabled: false
 
 ingress:
   annotations:


### PR DESCRIPTION
### Context

https://trello.com/c/gt21UBzk

### Intent

We have done the work to create an environment per PR but unfortunately we cannot get production style auth working with these as it doesn't support dynamic URLs

We've agreed to use mock auth in dev instead and this change enables that. 

This will mean that we can actually  provision different users on different PRs or potentially have somekind of  user switcher.

### Considerations

Going forward we will only be able to test auth in staging
Need to ensure that mock auth is DISABLED in staging and prod during the release.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
