### PR TITLE
Fixing veracode job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,6 @@ workflows:
           context:
             - hmpps-common-vars
       - hmpps/veracode_policy_scan:
-          docker_image_app_dir: /home/node/app
           slack_channel: hub_frontend
           context:
             - hmpps-common-vars


### PR DESCRIPTION
The source folder has moved in the docker image which is killing the veracode scheduled build


### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
