### PR TITLE
Feature/merge type of card with next visit card

### DIFF
--- a/server/content/visitType.json
+++ b/server/content/visitType.json
@@ -1,0 +1,4 @@
+{
+  "OFFI": "Official visit",
+  "SCON": "Social visit"
+}

--- a/server/routes/__tests__/profile.spec.js
+++ b/server/routes/__tests__/profile.spec.js
@@ -305,7 +305,7 @@ describe('GET /profile', () => {
     it('displays the visits information when the user is signed in', () => {
       offenderService.getVisitsFor.mockResolvedValue({
         nextVisit: 'Tuesday 20 April 2021',
-        visitType: 'Social',
+        visitType: 'Social visit',
         visitorName: 'Bob Visitor',
         hasNextVisit: true,
       });
@@ -323,9 +323,7 @@ describe('GET /profile', () => {
 
           const nextVisit = $('[data-test="nextVisit"]').text();
           expect(nextVisit).toContain('Tuesday 20 April 2021');
-
-          const visitType = $('[data-test="visitType"]').text();
-          expect(visitType).toContain('Social');
+          expect(nextVisit).toContain('Social visit');
 
           const visitsRemaining = $('[data-test="visitsRemaining"]').text();
           expect(visitsRemaining).toContain('42');

--- a/server/services/offender/responses/__tests__/nextVisit.spec.js
+++ b/server/services/offender/responses/__tests__/nextVisit.spec.js
@@ -2,6 +2,9 @@ const { NextVisit } = require('../nextVisit');
 const {
   placeholders: { DEFAULT },
 } = require('../../../../utils/enums');
+const visitTypeDisplayText = require('../../../../content/visitType.json');
+
+const VISIT_TYPE = 'SCON';
 
 describe('NextVisit', () => {
   it('Should handle an empty response', () => {
@@ -20,7 +23,7 @@ describe('NextVisit', () => {
         nextVisit: DEFAULT,
         nextVisitDate: DEFAULT,
         nextVisitDay: DEFAULT,
-        visitType: DEFAULT,
+        visitType: null,
         visitorName: DEFAULT,
         startTime: DEFAULT,
         endTime: DEFAULT,
@@ -44,7 +47,7 @@ describe('NextVisit', () => {
         nextVisit: 'Saturday 7 December',
         nextVisitDate: '7 December',
         nextVisitDay: 'Saturday',
-        visitType: DEFAULT,
+        visitType: null,
         visitorName: DEFAULT,
         startTime: '11:30am',
         endTime: '1:00pm',
@@ -58,7 +61,7 @@ describe('NextVisit', () => {
       startTime: '2019-12-07T11:30:30',
       endTime: '2019-12-07T12:30:30',
       eventStatus: 'SCH',
-      visitTypeDescription: 'TVT test visit type',
+      visitType: VISIT_TYPE,
       leadVisitor: 'MICKY MOUSE',
     };
 
@@ -69,7 +72,7 @@ describe('NextVisit', () => {
       nextVisit: 'Saturday 7 December',
       nextVisitDate: '7 December',
       nextVisitDay: 'Saturday',
-      visitType: 'TVT',
+      visitType: visitTypeDisplayText[VISIT_TYPE],
       visitorName: 'Micky Mouse',
       startTime: '11:30am',
       endTime: '12:30pm',

--- a/server/services/offender/responses/nextVisit.js
+++ b/server/services/offender/responses/nextVisit.js
@@ -10,6 +10,11 @@ const {
 } = require('../../../utils/enums');
 const { formatDateOrDefault } = require('../../../utils/date');
 
+const visitTypeDisplayText = {
+  OFFI: 'Official visit',
+  SCON: 'Social visit',
+};
+
 class NextVisit {
   constructor(options = {}) {
     this.startTime = options.startTime;
@@ -36,7 +41,7 @@ class NextVisit {
       visitorName: this.visitorName
         ? capitalizePersonName(this.visitorName)
         : DEFAULT,
-      visitType: this.visitType ? this.visitType.split(' ').shift() : DEFAULT,
+      visitType: visitTypeDisplayText?.[this.visitType],
       startTime: formatDateOrDefault(DEFAULT, PRETTY_TIME, this.startTime),
       endTime: formatDateOrDefault(DEFAULT, PRETTY_TIME, this.endTime),
     };

--- a/server/services/offender/responses/nextVisit.js
+++ b/server/services/offender/responses/nextVisit.js
@@ -10,10 +10,7 @@ const {
 } = require('../../../utils/enums');
 const { formatDateOrDefault } = require('../../../utils/date');
 
-const visitTypeDisplayText = {
-  OFFI: 'Official visit',
-  SCON: 'Social visit',
-};
+const visitTypeDisplayText = require('../../../content/visitType.json');
 
 class NextVisit {
   constructor(options = {}) {
@@ -41,27 +38,22 @@ class NextVisit {
       visitorName: this.visitorName
         ? capitalizePersonName(this.visitorName)
         : DEFAULT,
-      visitType: visitTypeDisplayText?.[this.visitType],
+      visitType: visitTypeDisplayText?.[this.visitType] || null,
       startTime: formatDateOrDefault(DEFAULT, PRETTY_TIME, this.startTime),
       endTime: formatDateOrDefault(DEFAULT, PRETTY_TIME, this.endTime),
     };
   }
 
   static from(response = {}) {
-    const {
-      startTime,
-      endTime,
-      eventStatus,
-      leadVisitor,
-      visitTypeDescription,
-    } = response;
+    const { startTime, endTime, eventStatus, leadVisitor, visitType } =
+      response;
 
     return new NextVisit({
       startTime,
       endTime,
       status: eventStatus,
       visitorName: leadVisitor,
-      visitType: visitTypeDescription,
+      visitType,
     });
   }
 }

--- a/server/views/pages/profile.html
+++ b/server/views/pages/profile.html
@@ -179,17 +179,14 @@
                 {% if visitsSummary.hasNextVisit %}
                   <strong>{{ visitsSummary.nextVisit }}</strong><br/>
                   {{ visitsSummary.startTime }} to {{ visitsSummary.endTime }}
+                  <br/><br/>
+                  {{ visitsSummary.visitType }}
                 {% else %}
                   No upcoming visit
                 {% endif %}
               {%- endcall %}
             </li>
             {% if visitsSummary.hasNextVisit %}
-              <li class="govuk-grid-column-one-quarter card-group__item">
-                {% call card({ id: 'visitType', heading: 'Type of visit'}) -%}
-                  {{ visitsSummary.visitType }}
-                {%- endcall %}
-              </li>
               <li class="govuk-grid-column-one-quarter card-group__item">
                 {% call cardSensitiveData({ id: 'visitorName', heading: 'Lead visitor' }) -%}
                   <p>Name of the lead visitor</p>


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/5fg3uc2E/192-merge-type-of-visit-card-with-your-next-visit-card

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?

Visit type is now recorded on the next visit card. Visit type card is removed.

> Would this PR benefit from screenshots?

<img width="1252" alt="Screenshot 2021-07-01 at 15 00 30" src="https://user-images.githubusercontent.com/50403492/124136989-2adfa880-da7d-11eb-8eba-27be21ae0b69.png">

### Considerations

> Is there any additional information that would help when reviewing this PR?

no

> Are there any steps required when merging/deploying this PR?

no

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
