### PR TITLE
Fix double click issue on logout

### DIFF
--- a/server/auth/__tests__/middleware.spec.js
+++ b/server/auth/__tests__/middleware.spec.js
@@ -247,6 +247,20 @@ describe('AuthMiddleware', () => {
         expect(res.redirect).toHaveBeenCalledWith(TEST_RETURN_URL);
       });
 
+      it('should not fail when already logged out', () => {
+        req.query = { returnUrl: TEST_RETURN_URL };
+
+        const signOut = createSignOutMiddleware({
+          analyticsService,
+          logger: MOCK_LOGGER,
+        });
+
+        signOut({ ...req, user: undefined }, res);
+
+        expect(req.logOut).not.toHaveBeenCalled();
+        expect(res.redirect).toHaveBeenCalledWith(TEST_RETURN_URL);
+      });
+
       it('should call logOut and redirect to the homepage if passed a returnUrl that is not relative', () => {
         req.query = { returnUrl: 'https://foo.bar' };
 

--- a/server/auth/middleware.js
+++ b/server/auth/middleware.js
@@ -131,16 +131,18 @@ const createSignInCallbackMiddleware = ({
 
 const createSignOutMiddleware = ({ logger, analyticsService }) =>
   function signOut(req, res) {
-    logger.info(`SignOutMiddleware (signOut) - User: ${req.user.prisonerId}`);
-    req.logOut();
-    analyticsService.sendEvent({
-      category: 'Signin',
-      action: 'signout',
-      label: 'success',
-      value: 1,
-      sessionId: path(['session', 'id'], req),
-      userAgent: path(['body', 'userAgent'], req),
-    });
+    if (req.user) {
+      logger.info(`SignOutMiddleware (signOut) - User: ${req.user.prisonerId}`);
+      req.logOut();
+      analyticsService.sendEvent({
+        category: 'Signin',
+        action: 'signout',
+        label: 'success',
+        value: 1,
+        sessionId: path(['session', 'id'], req),
+        userAgent: path(['body', 'userAgent'], req),
+      });
+    }
     res.redirect(getSafeReturnUrl(req.query));
   };
 


### PR DESCRIPTION
### Context

https://trello.com/c/PSj4hCb0


When logged in with real auth, if you double click the logout button - it triggers a null pointer. 

### Intent

This should fix the bug by not triggering logout if already logged out.

### Considerations


This bug only affects "real" auth, this branch is deployed to [dev](https://cookhamwood-prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk/
) so can compare with [staging](https://cookhamwood-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk/) which currently shows the bug.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
