### PR TITLE
Update prisonAPI to include related transactions current balance

### DIFF
--- a/server/routes/__tests__/formatters.spec.js
+++ b/server/routes/__tests__/formatters.spec.js
@@ -51,6 +51,7 @@ describe('Responses', () => {
           {
             transactionEntrySequence: 1,
             calendarDate: '2021-03-07',
+            currentBalance: 12295,
             payTypeCode: 'TST2',
             eventId: null,
             payAmount: 50,
@@ -58,9 +59,11 @@ describe('Responses', () => {
             bonusPay: 0,
             paymentDescription: 'Test 2',
           },
+
           {
             transactionEntrySequence: 1,
             calendarDate: '2021-03-08',
+            currentBalance: 12345,
             payTypeCode: 'TST',
             eventId: null,
             payAmount: 50,

--- a/server/routes/formatters.js
+++ b/server/routes/formatters.js
@@ -107,6 +107,7 @@ function createTransactionTableFrom(transactions) {
           .map(relatedTransaction => ({
             entryDate: batchTransaction.entryDate,
             penceAmount: relatedTransaction.payAmount,
+            currentBalance: relatedTransaction.currentBalance,
             entryDescription: `${
               relatedTransaction.paymentDescription
             } from ${formatDateOrDefault(
@@ -119,16 +120,7 @@ function createTransactionTableFrom(transactions) {
             prison: batchTransaction.prison,
           }));
 
-        let adjustedBalance = batchTransaction.currentBalance;
-
-        return related.map(current => {
-          const withBalance = {
-            ...current,
-            currentBalance: adjustedBalance,
-          };
-          adjustedBalance -= current.penceAmount;
-          return withBalance;
-        });
+        return related;
       });
 
     const transactionsExcludingRelated = transactions.filter(


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/YPw8oRCh

### Intent

> What changes are introduced by this PR that correspond to the above card?

We have updated the code base to replace a related transactions balance function with the related Offender Transactions current balance from the prisonAPI  

### Considerations

> Is there any additional information that would help when reviewing this PR?

Conducted further local testing by pulling transactions data from May. Pre/Post implementation data matched.

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
