### PR TITLE
Global protect vpn access

### DIFF
--- a/helm_deploy/prisoner-content-hub-frontend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.yaml
@@ -73,6 +73,7 @@ ingress:
     ark-data-center-5: "194.33.193.0/25"
     ark-data-center-6: "194.33.196.0/25"
     ark-data-center-7: "194.33.197.0/25"
+    moj-official-globalprotect-alpha: "35.176.93.186"
     moj-official: "51.149.250.0/24"
     pfs-egress-dp-primary: "18.130.83.42/32"
     pfs-egress-dp-secondary: "52.56.168.163/32"

--- a/helm_deploy/prisoner-content-hub-frontend/values.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values.yaml
@@ -73,7 +73,7 @@ ingress:
     ark-data-center-5: "194.33.193.0/25"
     ark-data-center-6: "194.33.196.0/25"
     ark-data-center-7: "194.33.197.0/25"
-    moj-official-globalprotect-alpha: "35.176.93.186"
+    moj-official-globalprotect-alpha: "35.176.93.186/32"
     moj-official: "51.149.250.0/24"
     pfs-egress-dp-primary: "18.130.83.42/32"
     pfs-egress-dp-secondary: "52.56.168.163/32"


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/Qgdi5nC7/224-access-the-content-hub-frontend-from-globalprotect-vpn

### Intent

This PR enables users on the GlobalProtect VPN to access the Prisoner Content Hub frontend, hopefully preventing the dreaded "are you using the right VPN" conversation.

IP range taken from https://github.com/ministryofjustice/moj-ip-addresses/blob/main/moj-cidr-addresses.yml and checked against local GlobalProtect settings.


### Checklist

- [x] This PR contains **only** changes related to the above card
