### PR TITLE
Tidying up deployments that are no longer required

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,10 +311,12 @@ jobs:
 
             deployments_to_delete=($(comm -23 deployments.txt prs.txt))
 
-            echo "deleting deployments:"
+            echo "Deployments to delete: ${#deployments_to_delete[@]}"
             for i in "${deployments_to_delete[@]}"
               do
-                echo "* $i"
+                DEPLOYMENT="prisoner-content-hub-frontend-${i}"
+                echo "Uninstalling deployment: ${DEPLOYMENT}"
+                helm -n prisoner-content-hub-development uninstall "${DEPLOYMENT}"
             done
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,6 @@ commands:
             }
           event: always
 
-
 jobs:
   build:
     executor:
@@ -292,10 +291,39 @@ jobs:
           qualifier: "<< parameters.qualifier >>"
           releaseChannel: "<< parameters.releaseChannel >>"
 
+  clean_up_dev_deployments:
+    executor:
+      name: hmpps/node
+      tag: << pipeline.parameters.node-version >>
+    steps:
+      - checkout
+      - hmpps/k8s_setup:
+          ca-cert: KUBE_CLUSTER_CERT
+          cluster-name: KUBE_CLUSTER_NAME
+          kube-namespace: KUBE_NAMESPACE
+          kube-token: KUBE_TOKEN
+      - hmpps/install_helm
+      - run:
+          name: Clean up dev deployments
+          command: |
+            curl -s "https://api.github.com/repos/ministryofjustice/prisoner-content-hub-frontend/pulls" | jq  '.[].number' | sort > prs.txt
+            helm --namespace prisoner-content-hub-development list | awk '{ print $1 }' | tail -n +2 | grep 'frontend-' | sed "s/[^0-9]//g" | sort >> deployments.txt
+
+            deployments_to_delete=($(comm -23 deployments.txt prs.txt))
+
+            echo "deleting deployments:"
+            for i in "${deployments_to_delete[@]}"
+              do
+                echo "* $i"
+            done
+
 workflows:
   version: 2
   build-test-deploy:
     jobs:
+      - clean_up_dev_deployments:
+          context:
+            - prisoner-content-hub-development
       - build
       - run_unit_tests:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,9 +323,6 @@ workflows:
   version: 2
   build-test-deploy:
     jobs:
-      - clean_up_dev_deployments:
-          context:
-            - prisoner-content-hub-development
       - build
       - run_unit_tests:
           requires:
@@ -398,3 +395,6 @@ workflows:
           context:
             - hmpps-common-vars
             - veracode-credentials
+      - clean_up_dev_deployments:
+          context:
+            - prisoner-content-hub-development

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,7 +307,7 @@ jobs:
           name: Clean up dev deployments
           command: |
             curl -s "https://api.github.com/repos/ministryofjustice/prisoner-content-hub-frontend/pulls" | jq  '.[].number' | sort > prs.txt
-            helm --namespace prisoner-content-hub-development list | awk '{ print $1 }' | tail -n +2 | grep 'frontend-' | sed "s/[^0-9]//g" | sort >> deployments.txt
+            helm --namespace prisoner-content-hub-development list | awk '{ print $1 }' | grep 'frontend-' | sed "s/[^0-9]//g" | sort > deployments.txt
 
             deployments_to_delete=($(comm -23 deployments.txt prs.txt))
 


### PR DESCRIPTION
### Context

https://trello.com/c/VnJjg78y

When deployments to delete:
<kbd>
<img width="1311" alt="Screenshot 2021-07-21 at 20 19 40" src="https://user-images.githubusercontent.com/1517745/126547136-a95c6581-6f07-4788-bf3f-083e194e0384.png">
</kbd>

When no deployments to delete:
<kbd>
<img width="1296" alt="Screenshot 2021-07-21 at 20 19 16" src="https://user-images.githubusercontent.com/1517745/126547234-c5f59eb4-10fd-4d24-8792-d656cb34f127.png">

</kbd>

### Intent

An extra step that runs as part of the daily scheduled job.

Deletes every PR release that no longer has an open PR.

### Considerations

I've tested this and it seems to work with a variety of situations.
 
Would be good to keep an eye on after merging to ensure that it acts as we expect it to behave. 

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
