### PR TITLE
Showing resized images on the homepage

### DIFF
--- a/server/repositories/cmsQueries/__tests__/HomepageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/HomepageQuery.spec.js
@@ -5,7 +5,7 @@ describe('Homepage query', () => {
   describe('path', () => {
     it('should create correct path', async () => {
       expect(query.path()).toStrictEqual(
-        '/jsonapi/prison/berwyn/node/featured_articles?include=field_moj_featured_tile_large.field_moj_thumbnail_image%2Cfield_moj_featured_tile_large.field_image%2Cfield_moj_featured_tile_small.field_moj_thumbnail_image%2Cfield_moj_featured_tile_small.field_image&page%5Blimit%5D=1&fields%5Bnode--featured_articles%5D=title%2Cdrupal_internal__nid%2Cfield_moj_featured_tile_large%2Cfield_moj_featured_tile_small&fields%5Bnode--page%5D=drupal_internal__nid%2Cfield_moj_thumbnail_image%2Cfield_image%2Ctitle%2Cfield_moj_description%2Cfield_moj_series&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Cfield_moj_thumbnail_image%2Cfield_image%2Ctitle%2Cfield_moj_description%2Cfield_moj_series&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Cfield_moj_thumbnail_image%2Cfield_image%2Ctitle%2Cfield_moj_description%2Cfield_moj_series&fields%5Bnode--moj_pdf_item%5D=drupal_internal__nid%2Cfield_moj_thumbnail_image%2Cfield_image%2Ctitle%2Cfield_moj_description%2Cfield_moj_series&fields%5Bnode--landing_page%5D=drupal_internal__nid%2Cfield_moj_thumbnail_image%2Cfield_image%2Ctitle%2Cfield_moj_description%2Cfield_moj_series&fields%5Bfile--file%5D=drupal_internal__fid%2Cid%2Curi',
+        '/jsonapi/prison/berwyn/node/featured_articles?include=field_moj_featured_tile_large.field_moj_thumbnail_image%2Cfield_moj_featured_tile_large.field_image%2Cfield_moj_featured_tile_small.field_moj_thumbnail_image%2Cfield_moj_featured_tile_small.field_image&page%5Blimit%5D=1&fields%5Bnode--featured_articles%5D=title%2Cdrupal_internal__nid%2Cfield_moj_featured_tile_large%2Cfield_moj_featured_tile_small&fields%5Bnode--page%5D=drupal_internal__nid%2Cfield_moj_thumbnail_image%2Cfield_image%2Ctitle%2Cfield_moj_description%2Cfield_moj_series&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Cfield_moj_thumbnail_image%2Cfield_image%2Ctitle%2Cfield_moj_description%2Cfield_moj_series&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Cfield_moj_thumbnail_image%2Cfield_image%2Ctitle%2Cfield_moj_description%2Cfield_moj_series&fields%5Bnode--moj_pdf_item%5D=drupal_internal__nid%2Cfield_moj_thumbnail_image%2Cfield_image%2Ctitle%2Cfield_moj_description%2Cfield_moj_series&fields%5Bnode--landing_page%5D=drupal_internal__nid%2Cfield_moj_thumbnail_image%2Cfield_image%2Ctitle%2Cfield_moj_description%2Cfield_moj_series&fields%5Bfile--file%5D=drupal_internal__fid%2Cid%2Curi%2Cimage_style_uri',
       );
     });
   });
@@ -46,6 +46,86 @@ describe('Homepage query', () => {
             },
           },
         ],
+      });
+    });
+
+    it('should show small tile image when provided', async () => {
+      const contentItem = {
+        fieldMojFeaturedTileLarge: [],
+        fieldMojFeaturedTileSmall: [
+          {
+            drupalInternal_Nid: '10001',
+            type: 'moj_video_item',
+            fieldMojSeries: {},
+            title: 'Lower Abs workout',
+            fieldMojDescription: { summary: 'Intense lower core workout' },
+            fieldMojThumbnailImage: {
+              uri: { url: 'https://cloud-platform-c3b3.eu-west-2' },
+              resourceIdObjMeta: { alt: 'Picture of core workout' },
+              imageStyleUri: [
+                { tile_large: 'large-image', tile_small: 'small-image' },
+              ],
+            },
+          },
+        ],
+      };
+
+      expect(query.transform(contentItem)).toStrictEqual({
+        upperFeatured: undefined,
+        lowerFeatured: undefined,
+        smallTiles: [
+          {
+            id: '10001',
+            contentUrl: '/content/10001',
+            contentType: 'moj_video_item',
+            isSeries: true,
+            title: 'Lower Abs workout',
+            summary: 'Intense lower core workout',
+            image: {
+              url: 'small-image',
+              alt: 'Picture of core workout',
+            },
+          },
+        ],
+      });
+    });
+
+    it('should show large tile image when provided', async () => {
+      const contentItem = {
+        fieldMojFeaturedTileLarge: [
+          {
+            drupalInternal_Nid: '10001',
+            type: 'moj_video_item',
+            fieldMojSeries: {},
+            title: 'Lower Abs workout',
+            fieldMojDescription: { summary: 'Intense lower core workout' },
+            fieldMojThumbnailImage: {
+              uri: { url: 'https://cloud-platform-c3b3.eu-west-2' },
+              resourceIdObjMeta: { alt: 'Picture of core workout' },
+              imageStyleUri: [
+                { tile_large: 'large-image', tile_small: 'small-image' },
+              ],
+            },
+          },
+        ],
+        fieldMojFeaturedTileSmall: [],
+      };
+
+      expect(query.transform(contentItem)).toStrictEqual({
+        upperFeatured: {
+          id: '10001',
+          contentUrl: '/content/10001',
+          contentType: 'moj_video_item',
+          isSeries: true,
+          title: 'Lower Abs workout',
+          summary: 'Intense lower core workout',
+          image: {
+            url: 'large-image',
+            alt: 'Picture of core workout',
+          },
+        },
+        lowerFeatured: undefined,
+        smallTiles: [],
       });
     });
 


### PR DESCRIPTION
### Context

https://trello.com/c/0yV9FDqz/239-use-new-resized-images-in-home-page

### Intent

Should use resized images when present. Fallback to normal images if not present for whatever reason.

### Considerations

A good way to test this is viewing download page size in chrome in 

new vs old dev: 

https://cookhamwood-prisoner-content-hub-development-342.apps.live-1.cloud-platform.service.justice.gov.uk/
https://cookhamwood-prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk/



<img width="562" alt="Screenshot 2021-08-16 at 09 26 48" src="https://user-images.githubusercontent.com/1517745/129534331-76dcce29-3b31-494e-bfe8-7f89a789d66c.png">

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
