### PR TITLE
bug/empty_secondary_tags

### DIFF
--- a/server/repositories/cmsQueries/secondaryTagPageQuery.js
+++ b/server/repositories/cmsQueries/secondaryTagPageQuery.js
@@ -70,6 +70,7 @@ class SecondaryTagPageQuery {
   };
 
   transform(deserializedResponse) {
+    if (deserializedResponse.length === 0) return null;
     return Object.assign(
       this.#getTag(deserializedResponse[0].fieldMojSecondaryTags),
       {


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

Bug - Empty secondary tags throwing error

> If this is an issue, do we have steps to reproduce?

https://lindholme.content-hub.prisoner.service.justice.gov.uk/tags/1133

### Intent

> What changes are introduced by this PR that correspond to the above card?

Checking for an array.

> Would this PR benefit from screenshots?

N/A

### Considerations

> Is there any additional information that would help when reviewing this PR?

N/A

> Are there any steps required when merging/deploying this PR?

N/A

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
