### PR TITLE
Preventing missing content from triggering alerts

### DIFF
--- a/server/repositories/__tests__/cmsApi.spec.js
+++ b/server/repositories/__tests__/cmsApi.spec.js
@@ -3,6 +3,7 @@
 const nock = require('nock');
 const { jsonApiResponse } = require('../../../test/resources/jsonApi');
 const { JsonApiClient } = require('../../clients/jsonApiClient');
+const { NotFound } = require('../apiError');
 const { CmsApi } = require('../cmsApi');
 
 const host = 'http://localhost:3333';
@@ -105,12 +106,12 @@ describe('CmsApi', () => {
       ).rejects.toEqual(Error('Request failed with status code 500'));
     });
 
-    it('propogates 404 as error', () => {
+    it('propogates 404 as NotFound', () => {
       mockDrupal.get(path).reply(404, 'unexpected error');
 
       return expect(
         cmsApi.get(new TestUrlTransformEachQuery()),
-      ).rejects.toEqual(Error('Request failed with status code 404'));
+      ).rejects.toEqual(new NotFound('/jsonapi/test'));
     });
 
     it('should format and return single value', async () => {
@@ -196,7 +197,15 @@ describe('CmsApi', () => {
       mockDrupal.get(lookupPath).reply(404, 'unexpected error');
 
       return expect(cmsApi.lookupContent('berwyn', 1234)).rejects.toEqual(
-        Error('Request failed with status code 404'),
+        Error(lookupPath),
+      );
+    });
+
+    it('propagates 403 as NotFound', () => {
+      mockDrupal.get(lookupPath).reply(403, 'unexpected error');
+
+      return expect(cmsApi.lookupContent('berwyn', 1234)).rejects.toEqual(
+        new NotFound(lookupPath),
       );
     });
 
@@ -231,11 +240,19 @@ describe('CmsApi', () => {
       );
     });
 
-    it('propagates 404 as error', () => {
+    it('propagates 404 as NotFound', () => {
       mockDrupal.get(lookupPath).reply(404, 'unexpected error');
 
       return expect(cmsApi.lookupTag('berwyn', 1234)).rejects.toEqual(
-        Error('Request failed with status code 404'),
+        new NotFound(lookupPath),
+      );
+    });
+
+    it('propagates 403 as NotFound', () => {
+      mockDrupal.get(lookupPath).reply(403, 'unexpected error');
+
+      return expect(cmsApi.lookupTag('berwyn', 1234)).rejects.toEqual(
+        new NotFound(lookupPath),
       );
     });
 

--- a/server/repositories/apiError.js
+++ b/server/repositories/apiError.js
@@ -1,0 +1,11 @@
+/* eslint-disable class-methods-use-this */
+
+class NotFound extends Error {
+  getCode() {
+    return 404;
+  }
+}
+
+module.exports = {
+  NotFound,
+};

--- a/server/repositories/hubContent.js
+++ b/server/repositories/hubContent.js
@@ -18,7 +18,7 @@ const hubContentRepository = httpClient => {
     const endpoint = `${config.api.hubContent}/${id}`;
 
     if (!id) {
-      logger.error(`HubContentRepository (contentFor) - No ID passed`);
+      logger.info(`HubContentRepository (contentFor) - No ID passed`);
       return null;
     }
     const query = {
@@ -39,7 +39,7 @@ const hubContentRepository = httpClient => {
     const endpoint = `${config.api.hubTerm}/${id}`;
 
     if (!id) {
-      logger.error(`HubContentRepository (termFor) - No ID passed`);
+      logger.info(`HubContentRepository (termFor) - No ID passed`);
       return null;
     }
 
@@ -71,7 +71,7 @@ const hubContentRepository = httpClient => {
     };
 
     if (!id) {
-      logger.error(`HubContentRepository (seasonFor) - No ID passed`);
+      logger.info(`HubContentRepository (seasonFor) - No ID passed`);
       return [];
     }
 
@@ -127,7 +127,7 @@ const hubContentRepository = httpClient => {
     };
 
     if (!id) {
-      logger.error(`HubContentRepository (relatedContentFor) - No ID passed`);
+      logger.info(`HubContentRepository (relatedContentFor) - No ID passed`);
       return [];
     }
 


### PR DESCRIPTION
### Context

https://trello.com/c/AGF41AVL

Try and access content that doesn't exist: `/content/123456` or `/tag/123456`
Or content that is not available for a specific prison: `/content/5925` in berwyn

### Intent

We now capture 404 errors when calling queries and convert them to 404 responses sent to the browser.
The router returns 403 responses when content exists but not at a specific prison - we are now handling these as well

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
