### PR TITLE
bug/restore-coronavirus-berwyn-homepage-link

### DIFF
--- a/server/content/establishmentData.json
+++ b/server/content/establishmentData.json
@@ -4,6 +4,7 @@
     "displayName": "HMP Berwyn",
     "homePageLinksTitle": "Popular topics",
     "homePageLinks": {
+      "Coronavirus": "/tags/894",
       "Visits": "/content/4203",
       "Games": "/content/3621",
       "Inspiration": "/content/3659",


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/RehSBZ6F

> If this is an issue, do we have steps to reproduce?

go to homepage

### Intent

> What changes are introduced by this PR that correspond to the above card?

the home screen links look odd at the moment

> Would this PR benefit from screenshots?

<img width="662" alt="Screenshot 2021-09-24 at 14 20 49" src="https://user-images.githubusercontent.com/50403492/134681321-aac02321-2ecf-498d-8a39-8d4b1df52053.png">
fixing this :-)

### Considerations

> Is there any additional information that would help when reviewing this PR?

n/a

> Are there any steps required when merging/deploying this PR?

n/a

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
