### PR TITLE
Removing series badge from homepage titles

### DIFF
--- a/assets/sass/components/_home-content.scss
+++ b/assets/sass/components/_home-content.scss
@@ -167,21 +167,6 @@
   }
 }
 
-.home-content-img-series {
-  position: relative;
-
-  &::before {
-    @include govuk-font(19, 'bold');
-    position: absolute;
-    content: 'SERIES';
-    color: govuk-colour('white');
-    padding: govuk-spacing(1);
-    background-color: govuk-colour('purple');
-    bottom: 0;
-    right: 0;
-  }
-}
-
 .content-link--article,
 .content-link--audio,
 .content-link--video {

--- a/server/repositories/cmsQueries/__tests__/homePageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/homePageQuery.spec.js
@@ -37,7 +37,6 @@ describe('Homepage query', () => {
             id: '10001',
             contentUrl: '/content/10001',
             contentType: 'moj_video_item',
-            isSeries: true,
             title: 'Lower Abs workout',
             summary: 'Intense lower core workout',
             image: {
@@ -86,7 +85,6 @@ describe('Homepage query', () => {
           id: '10002',
           contentUrl: '/content/10002',
           contentType: 'moj_video_item',
-          isSeries: true,
           title: 'Yoga',
           summary: 'Yoga workout',
           image: {
@@ -98,7 +96,6 @@ describe('Homepage query', () => {
           id: '10003',
           contentUrl: '/content/10003',
           contentType: 'moj_video_item',
-          isSeries: false,
           title: 'Lower Abs workout',
           summary: 'Intense lower core workout',
           image: {

--- a/server/repositories/cmsQueries/homePageQuery.js
+++ b/server/repositories/cmsQueries/homePageQuery.js
@@ -66,7 +66,6 @@ class HomepageQuery {
     id: item.drupalInternal_Nid,
     contentUrl: `/content/${item.drupalInternal_Nid}`,
     contentType: item.type.replace(/^node--/, ''),
-    isSeries: Boolean(item.fieldMojSeries),
     title: item.title,
     summary: item.fieldMojDescription?.summary,
     image: getImage(item.fieldMojThumbnailImage),

--- a/server/routes/__tests__/homepage.spec.js
+++ b/server/routes/__tests__/homepage.spec.js
@@ -21,7 +21,6 @@ describe('GET /', () => {
       contentType: 'foo',
       summary: 'foo summary',
       contentUrl: `/content/foo`,
-      isSeries: false,
       image: {
         alt: 'Foo image alt text',
         url: 'image.url.com',

--- a/server/services/__tests__/cmsService.spec.js
+++ b/server/services/__tests__/cmsService.spec.js
@@ -308,7 +308,6 @@ describe('cms Service', () => {
               title: 'bar episode',
             },
           ],
-
           seasonId: 1,
           seriesSortValue: SERIES_SORT_VALUE,
           secondaryTags: [
@@ -399,7 +398,6 @@ describe('cms Service', () => {
         id: '10002',
         contentUrl: '/content/10002',
         contentType: 'moj_video_item',
-        isSeries: true,
         title: 'Yoga',
         summary: 'Yoga workout',
         image: {
@@ -411,7 +409,6 @@ describe('cms Service', () => {
         id: '10003',
         contentUrl: '/content/10003',
         contentType: 'moj_video_item',
-        isSeries: false,
         title: 'Lower Abs workout',
         summary: 'Intense lower core workout',
         image: {
@@ -424,7 +421,6 @@ describe('cms Service', () => {
           id: '10001',
           contentUrl: '/content/10001',
           contentType: 'moj_video_item',
-          isSeries: true,
           title: 'Lower Abs workout',
           summary: 'Intense lower core workout',
           image: {
@@ -445,7 +441,6 @@ describe('cms Service', () => {
           id: '10002',
           contentUrl: '/content/10002',
           contentType: 'moj_video_item',
-          isSeries: true,
           title: 'Yoga',
           summary: 'Yoga workout',
           image: {
@@ -457,7 +452,6 @@ describe('cms Service', () => {
           id: '10003',
           contentUrl: '/content/10003',
           contentType: 'moj_video_item',
-          isSeries: false,
           title: 'Lower Abs workout',
           summary: 'Intense lower core workout',
           image: {
@@ -470,7 +464,6 @@ describe('cms Service', () => {
             id: '10001',
             contentUrl: '/content/10001',
             contentType: 'moj_video_item',
-            isSeries: true,
             title: 'Lower Abs workout',
             summary: 'Intense lower core workout',
             image: {

--- a/server/utils/__tests__/adapters.spec.js
+++ b/server/utils/__tests__/adapters.spec.js
@@ -1,7 +1,6 @@
 const {
   contentResponseFrom,
   featuredContentResponseFrom,
-  featuredContentTileResponseFrom,
   mediaResponseFrom,
   seasonResponseFrom,
   termResponseFrom,
@@ -23,7 +22,6 @@ const landingPageResponse = require('../../../test/resources/landingPage.json');
 const relatedContentResponse = require('../../../test/resources/relatedContent.json');
 const pdfContentResponse = require('../../../test/resources/pdfContentResponse.json');
 const searchResponse = require('../../../test/resources/rawSearchResponse.json');
-const featuredItems = require('../../../test/resources/featuredItems.json');
 
 describe('Adapters', () => {
   describe('.mediaResponseFrom', () => {
@@ -89,18 +87,6 @@ describe('Adapters', () => {
     it('returns formated data for featured series', () => {
       const result = featuredContentResponseFrom(featuredSeriesResponse);
       expect(result).toStrictEqual(featuredSeries());
-    });
-  });
-
-  describe('.featuredContentTileResponseFrom', () => {
-    featuredItems.forEach(({ scenario, input, output }) => {
-      it(scenario, () => {
-        const result = featuredContentTileResponseFrom(input);
-        expect(result.upperFeatured).toStrictEqual(output);
-        expect(result.lowerFeatured).toStrictEqual(output);
-        expect(result.smallTiles.length).toBe(input.small_tiles.length);
-        expect(result.smallTiles[0]).toStrictEqual(output);
-      });
     });
   });
 

--- a/server/utils/adapters.js
+++ b/server/utils/adapters.js
@@ -68,34 +68,6 @@ function featuredContentResponseFrom(response) {
   };
 }
 
-function featuredContentTileResponseFrom(response) {
-  const [upperFeatured, lowerFeatured] = R.prop('large_tiles', response).map(
-    item => ({
-      id: item.id,
-      contentUrl: `/content/${item.id}`,
-      contentType: item.content_type,
-      isSeries: Array.isArray(item.series) && item.series.length > 0,
-      title: item.title,
-      summary: item.summary,
-      image: imageFor(item.image),
-    }),
-  );
-
-  return {
-    smallTiles: R.prop('small_tiles', response).map(item => ({
-      id: item.id,
-      contentUrl: `/content/${item.id}`,
-      contentType: item.content_type,
-      isSeries: Array.isArray(item.series) && item.series.length > 0,
-      title: item.title,
-      summary: item.summary,
-      image: imageFor(item.image),
-    })),
-    upperFeatured,
-    lowerFeatured,
-  };
-}
-
 function contentResponseFrom(data = []) {
   return data.map(item => ({
     id: item.id,
@@ -228,7 +200,6 @@ function searchResultFrom({ _id, _source }) {
 module.exports = {
   contentResponseFrom,
   featuredContentResponseFrom,
-  featuredContentTileResponseFrom,
   mediaResponseFrom,
   seasonResponseFrom,
   termResponseFrom,

--- a/server/views/components/content-tile-large/template.njk
+++ b/server/views/components/content-tile-large/template.njk
@@ -1,13 +1,7 @@
 {% macro tileImage(params) %}
-  {% if params.isSeries %}
-    <div class="home-content-img-series home-content__feature-image">
-      <img src="{{params.image.url}}" alt="">
-    </div>
-  {% else %}
-    <div class="home-content__feature-image">
-      <img src="{{params.image.url}}" alt="{{params.image.alt}}">
-    </div>
-  {% endif %}
+  <div class="home-content__feature-image">
+    <img src="{{params.image.url}}" alt="{{params.image.alt}}">
+  </div>
 {% endmacro %}
 
 {% macro tileContent(params) %}

--- a/server/views/components/content-tile-small/template.njk
+++ b/server/views/components/content-tile-small/template.njk
@@ -1,13 +1,7 @@
 {% if params.id %}
   <a data-featured-tile-id="{{params.id}}" data-featured-id="{{params.id}}" data-featured-title="{{ params.title }}" href="{{params.contentUrl}}" {% if params.contentType === 'pdf' or  params.contentType === 'moj_pdf_item' %}target="_blank"{% endif %}>
     <div>
-      {% if params.isSeries %}
-        <div class="home-content-img-series">
-          <img src="{{params.image.url}}" alt="" class="tile-image">
-        </div>
-      {% else %}
-        <img src="{{params.image.url}}" alt="{{params.image.alt}}" class="tile-image">
-      {% endif %}
+      <img src="{{params.image.url}}" alt="{{params.image.alt}}" class="tile-image">
       <h3 class="govuk-heading-m" style="">{{params.title}}</h3>
     </div>
     <div>


### PR DESCRIPTION
It was incorrectly being shown for every tile and didn't provide a lot of usage as everything is in a series

### Context

https://trello.com/c/SdE8nrTz/270-all-tiles-on-the-homepage-currently-show-as-being-series

### Intent

Removing the series label from each tile on the home page

### Considerations

This is part of the tiles on many pages but the correct data was not being passed so would never have shown.
Removed it entirely

Also removed old response adaptor that was no longer being returned.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
