### PR TITLE
Adding single url hostname

### DIFF
--- a/helm_deploy/prisoner-content-hub-frontend/templates/ingress.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/templates/ingress.yaml
@@ -6,21 +6,24 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "prisoner-content-hub-frontend.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- range $k, $v := .Values.ingress.annotations }}
+    {{ $k }}: {{ tpl $v (dict "qualifier" $.Values.ingress.qualifier "Template" $.Template) }}
+    {{- end}}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.ingress.allowed | quote }}
 spec:
   tls:
+  - hosts:
   {{- range .Values.ingress.hosts }}
   {{- $certSecret := .cert_secret -}}
   {{- $domainPattern := .pattern }}
-  - hosts:
     {{- range $.Values.ingress.prefixes }}
       - {{ tpl $domainPattern (dict "prison" . "qualifier" $.Values.ingress.qualifier "Template" $.Template) }}
-    {{ if $certSecret }}secretName: {{ $certSecret }}{{ end }}
     {{- end }}
+  {{- end }}
+  {{- with .Values.ingress.host }}
+      - {{ tpl .pattern (dict "qualifier" $.Values.ingress.qualifier "Template" $.Template) }}
+    {{ if .cert_secret }}secretName: {{ .cert_secret }}{{ end }}
   {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
@@ -34,5 +37,14 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: http
     {{- end }}
+  {{- end }}
+  {{- with .Values.ingress.host }}
+    - host: {{ tpl .pattern (dict "qualifier" $.Values.ingress.qualifier "Template" $.Template) }}
+      http:
+        paths:
+          - path: "/"
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
   {{- end }}
 {{- end }}

--- a/helm_deploy/prisoner-content-hub-frontend/templates/ingress.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "prisoner-content-hub-frontend.labels" . | nindent 4 }}
   annotations:
     {{- range $k, $v := .Values.ingress.annotations }}
-    {{ $k }}: {{ tpl $v (dict "qualifier" $.Values.ingress.qualifier "Template" $.Template) }}
+    {{ $k }}: {{ tpl $v (dict "qualifier" $.Values.ingress.qualifier "Template" $.Template) | quote }}
     {{- end}}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.ingress.allowed | quote }}
 spec:

--- a/helm_deploy/prisoner-content-hub-frontend/values-development.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values-development.yaml
@@ -12,5 +12,10 @@ application:
 ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
+    external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-frontend-{{ .qualifier }}-prisoner-content-hub-development-blue
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+  # These are legacy, prison specific hostnames we want to deprecate  
   hosts:
     - pattern: "{{ .prison }}-prisoner-content-hub-development-{{ .qualifier }}.apps.live-1.cloud-platform.service.justice.gov.uk"
+  host: 
+      pattern: "prisoner-content-hub-development-{{ .qualifier }}.apps.live-1.cloud-platform.service.justice.gov.uk"

--- a/helm_deploy/prisoner-content-hub-frontend/values-production.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values-production.yaml
@@ -9,7 +9,13 @@ application:
 ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
+    external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-frontend-prisoner-content-hub-production-blue
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+  # These are legacy, prison specific hostnames we want to deprecate  
   hosts:
     - pattern: "{{ .prison }}.content-hub.prisoner.service.justice.gov.uk"
       cert_secret: prisoner-content-hub-frontend-certificate
     - pattern: "{{ .prison }}-prisoner-content-hub-production.apps.live-1.cloud-platform.service.justice.gov.uk"
+  host: 
+      pattern: "content-hub.prisoner.service.justice.gov.uk"
+      cert_secret: prisoner-content-hub-frontend-certificate

--- a/helm_deploy/prisoner-content-hub-frontend/values-staging.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values-staging.yaml
@@ -9,5 +9,10 @@ application:
 ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
+    external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-frontend-prisoner-content-hub-staging-blue
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+  # These are legacy, prison specific hostnames we want to deprecate  
   hosts:
     - pattern: "{{ .prison }}-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk"
+  host: 
+      pattern: "prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk"


### PR DESCRIPTION
### Context

https://trello.com/c/SPrEP9m8/394-allow-a-user-to-access-the-hub-via-a-central-url

### Intent

Adding an additional hostname for the single url

Also adding additional annotations required by cloud platform

### Considerations

Added it as a separate single item rather than trying to work with complicated system for generating hostnames from the host list as hopefully we can remove those at a (much) later date

Need to check ingress after deploying

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
