### PR TITLE
bug/reactive-homepage

### DIFF
--- a/assets/sass/components/_home-content.scss
+++ b/assets/sass/components/_home-content.scss
@@ -114,7 +114,7 @@
 }
 
 .home-content__four-items {
-  justify-content: space-between;
+  justify-content: flex-start;
   display: flex;
   flex-wrap: wrap;
   align-items: stretch;
@@ -128,6 +128,7 @@
     background-color: $real-dark-grey;
     position: relative;
     margin-bottom: govuk-spacing(1);
+    margin-right: 0.4%;
 
     @media (min-width: $desktop-breakpoint) {
       flex: 0 0 24.7%;
@@ -160,6 +161,9 @@
       }
       visibility: visible;
     }
+  }
+  & > a:last-child {
+    margin-right: 0;
   }
 
   & > div {

--- a/server/repositories/cmsQueries/homePageQuery.js
+++ b/server/repositories/cmsQueries/homePageQuery.js
@@ -49,8 +49,9 @@ class HomepageQuery {
   }
 
   transformEach(item) {
-    const [upperFeatured, lowerFeatured] =
-      item.fieldMojFeaturedTileLarge.map(getLargeTile);
+    const [upperFeatured, lowerFeatured] = item.fieldMojFeaturedTileLarge.map(
+      featured => (featured?.path?.alias ? getLargeTile(featured) : null),
+    );
 
     return {
       upperFeatured,

--- a/server/views/pages/home.html
+++ b/server/views/pages/home.html
@@ -66,13 +66,17 @@
 
 {% block content %}
   <div class="govuk-body home-content">
-    {{ contentTileLarge({content: homepage.upperFeatured, imageAlign: 'right'}) }}
+    {% if homepage.upperFeatured %}
+      {{ contentTileLarge({content: homepage.upperFeatured, imageAlign: 'right'}) }}
+    {% endif %}
     <div class="home-content__four-items">
       {% for tile in homepage.smallTiles %}
         {{ contentTileSmall(tile) }}
       {% endfor %}
     </div>
-    {{ contentTileLarge({content: homepage.lowerFeatured, imageAlign: 'left'}) }}
+    {% if homepage.lowerFeatured %}
+      {{ contentTileLarge({content: homepage.lowerFeatured, imageAlign: 'left'}) }}
+    {% endif %}
   </div>
 {% endblock %}
 


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/x92ujgoY/268-create-reactive-homepage

> If this is an issue, do we have steps to reproduce?

Find a homepage with less than four small tiles.

### Intent

> What changes are introduced by this PR that correspond to the above card?

CSS changes

> Would this PR benefit from screenshots?

### Considerations

> Is there any additional information that would help when reviewing this PR?

Currently drupal should block content from being saved with less than the four small items on the home page.

> Are there any steps required when merging/deploying this PR?

n/a

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
