### PR TITLE
bug/filter-incomplete-tile-data-on-homepage

### DIFF
--- a/server/repositories/cmsQueries/homePageQuery.js
+++ b/server/repositories/cmsQueries/homePageQuery.js
@@ -48,11 +48,12 @@ class HomepageQuery {
     const [upperFeatured, lowerFeatured] = item.fieldMojFeaturedTileLarge.map(
       featured => (featured?.path?.alias ? getLargeTile(featured) : null),
     );
-
     return {
       upperFeatured,
       lowerFeatured,
-      smallTiles: item.fieldMojFeaturedTileSmall.map(getSmallTile),
+      smallTiles: item.fieldMojFeaturedTileSmall
+        .filter(({ title = null, name = null }) => title || name)
+        .map(getSmallTile),
     };
   }
 }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
no

> If this is an issue, do we have steps to reproduce?
Go to a homepage with unavailable content in the position zero.

### Intent

> What changes are introduced by this PR that correspond to the above card?
incomplete data is filtered out.

> Would this PR benefit from screenshots?
![Screenshot 2021-11-10 at 11 41 09](https://user-images.githubusercontent.com/50403492/141106921-7b73d2e1-1d6c-427e-b3ba-0e946a256d4c.png)
![Screenshot 2021-11-10 at 11 40 41](https://user-images.githubusercontent.com/50403492/141106927-054a7bd8-aed5-4660-b346-2226737740cc.png)


### Considerations

> Is there any additional information that would help when reviewing this PR?
n/a

> Are there any steps required when merging/deploying this PR?
n/a

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
