### PR TITLE
Moving to use establishment name rather than search name

### DIFF
--- a/server/routes/__tests__/search.spec.js
+++ b/server/routes/__tests__/search.spec.js
@@ -6,7 +6,7 @@ const { setupBasicApp } = require('../../../test/test-helpers');
 
 const searchResponse = require('../../../test/resources/searchResponse.json');
 
-describe('GET /search', () => {
+describe('Search Spec', () => {
   describe('GET /search', () => {
     describe('Results page', () => {
       it('should return the correct number of search results', () => {
@@ -128,75 +128,78 @@ describe('GET /search', () => {
       });
     });
   });
-});
 
-describe('GET /suggest', () => {
-  describe('Results page', () => {
-    it('should return the correct number of search results', () => {
-      const searchService = {
-        typeAhead: jest.fn().mockReturnValue(searchResponse),
-      };
-      const analyticsService = {
-        sendPageTrack: jest.fn(),
-        sendEvent: jest.fn(),
-      };
+  describe('GET /suggest', () => {
+    describe('Results page', () => {
+      it('should return the correct number of search results', () => {
+        const searchService = {
+          typeAhead: jest.fn().mockReturnValue(searchResponse),
+        };
+        const analyticsService = {
+          sendPageTrack: jest.fn(),
+          sendEvent: jest.fn(),
+        };
 
-      const router = createSearchRouter({
-        searchService,
-        analyticsService,
-      });
-      const app = setupBasicApp();
-
-      app.use('/search', router);
-
-      const query = 'bob';
-
-      return request(app)
-        .get(`/search/suggest?query=${query}`)
-        .expect(200)
-        .then(response => {
-          expect(Array.isArray(response.body)).toBe(
-            true,
-            'The endpoint should return an array of results',
-          );
-
-          expect(response.body.length).toBe(
-            searchResponse.length,
-            'All results should be returned in the response',
-          );
+        const router = createSearchRouter({
+          searchService,
+          analyticsService,
         });
-    });
+        const app = setupBasicApp();
 
-    it('should return empty when the search fails', () => {
-      const searchService = {
-        find: jest.fn().mockRejectedValue('BOOM!'),
-      };
-      const analyticsService = {
-        sendPageTrack: jest.fn(),
-        sendEvent: jest.fn(),
-      };
+        app.use('/search', router);
 
-      const router = createSearchRouter({
-        searchService,
-        analyticsService,
+        const query = 'bob';
+
+        return request(app)
+          .get(`/search/suggest?query=${query}`)
+          .expect(200)
+          .then(response => {
+            expect(Array.isArray(response.body)).toBe(
+              true,
+              'The endpoint should return an array of results',
+            );
+
+            expect(response.body.length).toBe(
+              searchResponse.length,
+              'All results should be returned in the response',
+            );
+          });
       });
-      const app = setupBasicApp();
 
-      app.use('/search', router);
+      it('should return empty when the search fails', () => {
+        const searchService = {
+          find: jest.fn().mockRejectedValue('BOOM!'),
+        };
+        const analyticsService = {
+          sendPageTrack: jest.fn(),
+          sendEvent: jest.fn(),
+        };
 
-      const query = 'bob';
-
-      return request(app)
-        .get(`/search/suggest?query=${query}`)
-        .expect(500)
-        .then(response => {
-          expect(Array.isArray(response.body)).toBe(
-            true,
-            'The response should be an array',
-          );
-
-          expect(response.body.length).toBe(0, 'The response should be empty');
+        const router = createSearchRouter({
+          searchService,
+          analyticsService,
         });
+        const app = setupBasicApp();
+
+        app.use('/search', router);
+
+        const query = 'bob';
+
+        return request(app)
+          .get(`/search/suggest?query=${query}`)
+          .expect(500)
+          .then(response => {
+            expect(Array.isArray(response.body)).toBe(
+              true,
+              'The response should be an array',
+            );
+
+            expect(response.body.length).toBe(
+              0,
+              'The response should be empty',
+            );
+          });
+      });
     });
   });
 });

--- a/server/services/__tests__/search.spec.js
+++ b/server/services/__tests__/search.spec.js
@@ -5,48 +5,33 @@ describe('SearchService', () => {
   const cmsApi = {
     get: jest.fn(),
   };
-  const getEstablishmentSearchName = jest
-    .fn()
-    .mockReturnValue('HMP Development');
+
   let service;
 
   beforeEach(() => {
     jest.resetAllMocks();
-    getEstablishmentSearchName.mockReturnValue('HMP Development');
-
-    service = createSearchService({
-      cmsApi,
-      getEstablishmentSearchName,
-    });
+    service = createSearchService({ cmsApi });
   });
 
   describe('#find', () => {
     it('returns search results', async () => {
       cmsApi.get.mockResolvedValue(['result_1', 'result_2', 'result_3']);
 
-      const result = await service.find({
-        query: 'Test Query',
-        establishmentId: 123,
-      });
+      const result = await service.find('Test Query', 'wayland');
 
       expect(cmsApi.get).toHaveBeenCalledTimes(1);
 
       expect(cmsApi.get).toHaveBeenCalledWith(
-        new SearchQuery('HMP Development', 'Test Query', 15),
+        new SearchQuery('wayland', 'Test Query', 15),
       );
 
-      expect(getEstablishmentSearchName).toHaveBeenCalledTimes(1);
-      expect(getEstablishmentSearchName).toHaveBeenCalledWith(123);
       expect(Array.isArray(result)).toBe(true);
     });
 
     it('returns empty when there is no query', async () => {
       cmsApi.get.mockResolvedValue([]);
 
-      const results = await service.find({
-        query: '',
-        establishmentId: 123,
-      });
+      const results = await service.find('', 'wayland');
 
       expect(Array.isArray(results)).toBe(true);
       expect(results.length).toBe(0);
@@ -58,29 +43,21 @@ describe('SearchService', () => {
     it('returns search results', async () => {
       cmsApi.get.mockResolvedValue(['result_1', 'result_2', 'result_3']);
 
-      const result = await service.typeAhead({
-        query: 'Test Query',
-        establishmentId: 123,
-      });
+      const result = await service.typeAhead('Test Query', 'wayland');
 
       expect(cmsApi.get).toHaveBeenCalledTimes(1);
 
       expect(cmsApi.get).toHaveBeenCalledWith(
-        new SearchQuery('HMP Development', 'Test Query', 5),
+        new SearchQuery('wayland', 'Test Query', 5),
       );
 
-      expect(getEstablishmentSearchName).toHaveBeenCalledTimes(1);
-      expect(getEstablishmentSearchName).toHaveBeenCalledWith(123);
       expect(Array.isArray(result)).toBe(true);
     });
 
     it('returns empty when there is no query', async () => {
       cmsApi.get.mockResolvedValue([]);
 
-      const results = await service.typeAhead({
-        query: '',
-        establishmentId: 123,
-      });
+      const results = await service.typeAhead('', 'wayland');
 
       expect(cmsApi.get).not.toHaveBeenCalled();
       expect(Array.isArray(results)).toBe(true);

--- a/server/services/search.js
+++ b/server/services/search.js
@@ -1,28 +1,20 @@
-const utils = require('../utils');
 const { SearchQuery } = require('../repositories/cmsQueries/searchQuery');
 
-const createSearchService = ({
-  cmsApi,
-  getEstablishmentSearchName = utils.getEstablishmentSearchName,
-}) => {
-  function find({ query, establishmentId }) {
-    const prison = getEstablishmentSearchName(establishmentId);
-
+const createSearchService = ({ cmsApi }) => {
+  function find(query, establishmentName) {
     if (query === '') {
       return [];
     }
 
-    return cmsApi.get(new SearchQuery(prison, query, 15));
+    return cmsApi.get(new SearchQuery(establishmentName, query, 15));
   }
 
-  function typeAhead({ query, establishmentId }) {
-    const prison = getEstablishmentSearchName(establishmentId);
-
+  function typeAhead(query, establishmentName) {
     if (query === '') {
       return [];
     }
 
-    return cmsApi.get(new SearchQuery(prison, query, 5));
+    return cmsApi.get(new SearchQuery(establishmentName, query, 5));
   }
 
   return {

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -38,11 +38,6 @@ const updateSessionEstablishment = (req, agencyId) => {
   }
 };
 
-const getEstablishmentSearchName = (
-  id,
-  establishmentData = defaultEstablishmentData,
-) => establishmentData?.[id]?.name;
-
 const getEstablishmentDisplayName = (
   id,
   establishmentData = defaultEstablishmentData,
@@ -89,7 +84,6 @@ module.exports = {
   getEstablishment,
   updateSessionEstablishment,
   getEstablishmentDisplayName,
-  getEstablishmentSearchName,
   getEstablishmentHomepageLinks,
   getEstablishmentHomepageLinksTitle,
   isEmptyResponse,


### PR DESCRIPTION
### Context

No, part of the wider work around addressing tech debt to help with move to a single url

### Intent

Starting to remove reliance on Establishment ID by moving the search over to use establishment in name

(I think establishment ID might be a better name that establishment Name to represent what we call "machine name" in drupal?, but think it would be good to remove all references to ID before moving over to use it )

### Considerations

Establishment Name should always be set in the session on the search page - either from the user or from the domain name 

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
