### PR TITLE
Maint/fix pop tops

### DIFF
--- a/server/content/establishmentData.json
+++ b/server/content/establishmentData.json
@@ -53,12 +53,12 @@
     "homePageLinks": {
       "Your profile": "/profile",
       "NPR": "/tags/785",
-      "Chaplaincy": "/tags/901",
+      "PSIs & PSOs": "/tags/796",
       "Inspiration": "/tags/649",
       "Exercise": "/tags/1112",
       "Games": "/tags/647",
       "Healthy mind & body": "/tags/648",
-      "PSIs & PSOs": "/tags/796",
+      "Feltham life": "/tags/1197",
       "Facilities list & catalogues": "/tags/787"
     },
     "agencyId": "FYI"
@@ -69,12 +69,12 @@
     "homePageLinks": {
       "Your profile": "/profile",
       "NPR": "/tags/785",
-      "Chaplaincy": "/tags/901",
+      "PSIs & PSOs": "/tags/796",
       "Inspiration": "/tags/649",
       "Exercise": "/tags/1112",
       "Games": "/tags/647",
       "Healthy mind & body": "/tags/648",
-      "PSIs & PSOs": "/tags/796",
+      "Feltham life": "/tags/1198",
       "Facilities list & catalogues": "/tags/787"
     },
     "agencyId": "FMI"
@@ -229,12 +229,12 @@
     "homePageLinks": {
       "Your profile": "/profile",
       "NPR": "/tags/785",
-      "Chaplaincy": "/tags/901",
+      "PSIs & PSOs": "/tags/796",
       "Inspiration": "/tags/649",
       "Exercise": "/tags/1112",
       "Games": "/tags/647",
       "Healthy mind & body": "/tags/648",
-      "PSIs & PSOs": "/tags/796",
+      "Werrington life": "/tags/1199",
       "Facilities list & catalogues": "/tags/787"
     },
     "agencyId": "WNI"
@@ -246,12 +246,12 @@
     "homePageLinks": {
       "Your profile": "/profile",
       "NPR": "/tags/785",
-      "Chaplaincy": "/tags/901",
+      "PSIs & PSOs": "/tags/796",
       "Inspiration": "/tags/649",
       "Exercise": "/tags/1112",
       "Games": "/tags/647",
       "Healthy mind & body": "/tags/648",
-      "PSIs & PSOs": "/tags/796",
+      "Wetherby life": "/tags/1200",
       "Facilities list & catalogues": "/tags/787"
     },
     "agencyId": "WYI"

--- a/server/routes/__tests__/topics.spec.js
+++ b/server/routes/__tests__/topics.spec.js
@@ -24,7 +24,6 @@ describe('GET /topics', () => {
       jest.clearAllMocks();
 
       sessionProvider.mockReturnValue({
-        establishmentId: 123,
         establishmentName: 'berwyn',
       });
 

--- a/server/services/__tests__/cmsService.spec.js
+++ b/server/services/__tests__/cmsService.spec.js
@@ -182,7 +182,7 @@ describe('cms Service', () => {
         location: 'https://cms.org/content/1234',
       });
 
-      const result = await cmsService.getContent(ESTABLISHMENT_NAME, 793, 1234);
+      const result = await cmsService.getContent(ESTABLISHMENT_NAME, 1234);
 
       expect(result).toStrictEqual({
         id: 5923,
@@ -203,7 +203,7 @@ describe('cms Service', () => {
           type: 'node--moj_radio_item',
           location: 'https://cms.org/content/1234',
         });
-        result = await cmsService.getContent(ESTABLISHMENT_NAME, 793, 1234);
+        result = await cmsService.getContent(ESTABLISHMENT_NAME, 1234);
       });
       it('should make audio query', () => {
         expect(cmsApi.get).toHaveBeenNthCalledWith(
@@ -297,7 +297,7 @@ describe('cms Service', () => {
           type: 'node--moj_video_item',
           location: 'https://cms.org/content/1234',
         });
-        result = await cmsService.getContent(ESTABLISHMENT_NAME, 793, 1234);
+        result = await cmsService.getContent(ESTABLISHMENT_NAME, 1234);
       });
       it('should make video query', () => {
         expect(cmsApi.get).toHaveBeenNthCalledWith(

--- a/server/services/__tests__/hubContentService.spec.js
+++ b/server/services/__tests__/hubContentService.spec.js
@@ -96,7 +96,7 @@ describe('#hubContentService', () => {
         title: 'Novus',
       });
 
-      expect(cmsService.getContent).toHaveBeenCalledWith('berwyn', 794, 1);
+      expect(cmsService.getContent).toHaveBeenCalledWith('berwyn', 1);
     });
   });
 

--- a/server/services/cms.js
+++ b/server/services/cms.js
@@ -94,7 +94,7 @@ class CmsService {
     return suggestions;
   }
 
-  async getContent(establishmentName, establishmentId, contentId) {
+  async getContent(establishmentName, contentId) {
     const { type, location } = await this.#cmsApi.lookupContent(
       establishmentName,
       contentId,

--- a/server/services/hubContent.js
+++ b/server/services/hubContent.js
@@ -12,11 +12,7 @@ function createHubContentService({
       return {};
     }
 
-    const result = await cmsService.getContent(
-      establishmentName,
-      establishmentId,
-      id,
-    );
+    const result = await cmsService.getContent(establishmentName, id);
     if (result) {
       return result;
     }


### PR DESCRIPTION
### Context

Sorting out the popular topics page for 4 prisons:
* Feltham A
* Feltham B
* Werrington
* Wetherby

https://trello.com/c/mMjFYcgq

<kbd><img width="594" alt="Screenshot 2021-11-11 at 18 33 45" src="https://user-images.githubusercontent.com/1517745/141350839-b555bba7-e2ac-4eea-b9d0-c6d515d11efe.png"></kbd>

### Intent

Updated establishment data to remove chaplaincy and added prison specific "life" pages.
Moved around a bit so it looks alright as that component is a bit restrictive and requires longer topic names in last column.

### Considerations

This also includes changes to remove the establishment id from a call that didn't require it and removed usages of ramda from app.js (as separate commits)

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
