### PR TITLE
Feature/enable exclude feedback

### DIFF
--- a/server/repositories/cmsQueries/__tests__/audioPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/audioPageQuery.spec.js
@@ -5,7 +5,7 @@ describe('Audio page query', () => {
   describe('url', () => {
     it('should create correct path', async () => {
       expect(query.url()).toStrictEqual(
-        'https://cms/content/1234?include=field_moj_thumbnail_image%2Cfield_moj_series%2Cfield_moj_audio%2Cfield_moj_secondary_tags%2Cfield_moj_top_level_categories&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_audio%2Cfield_moj_description%2Cfield_moj_secondary_tags%2Cfield_moj_series%2Cfield_moj_season%2Cfield_moj_episode%2Cfield_moj_top_level_categories%2Cfield_moj_thumbnail_image%2Cfield_moj_programme_code%2Cseries_sort_value&fields%5Bfile--file%5D=uri%2Cimage_style_uri&fields%5Btaxonomy_term--series%5D=drupal_internal__tid%2Cname%2Cpath&fields%5Btaxonomy_term--tags%5D=drupal_internal__tid%2Cname%2Cpath&fields%5Btaxonomy_term--moj_categories%5D=drupal_internal__tid%2Cname',
+        'https://cms/content/1234?include=field_moj_thumbnail_image%2Cfield_moj_series%2Cfield_moj_audio%2Cfield_moj_secondary_tags%2Cfield_moj_top_level_categories&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_audio%2Cfield_moj_description%2Cfield_moj_secondary_tags%2Cfield_moj_series%2Cfield_moj_season%2Cfield_moj_episode%2Cfield_moj_top_level_categories%2Cfield_moj_thumbnail_image%2Cfield_moj_programme_code%2Cseries_sort_value%2Cfield_exclude_feedback&fields%5Bfile--file%5D=uri%2Cimage_style_uri&fields%5Btaxonomy_term--series%5D=drupal_internal__tid%2Cname%2Cpath&fields%5Btaxonomy_term--tags%5D=drupal_internal__tid%2Cname%2Cpath&fields%5Btaxonomy_term--moj_categories%5D=drupal_internal__tid%2Cname',
       );
     });
   });
@@ -18,6 +18,7 @@ describe('Audio page query', () => {
         drupalInternal_Nid: 6236,
         title: 'Buddhist reflection: 29 July',
         fieldMojDescription: { processed: 'Education content for prisoners' },
+        fieldExcludeFeedback: true,
         fieldMojEpisode: 36,
         fieldMojProgrammeCode: 'FAITH138',
         fieldMojSeason: 1,
@@ -97,6 +98,7 @@ describe('Audio page query', () => {
         contentType: 'radio',
         description: 'Education content for prisoners',
         episodeId: 1036,
+        excludeFeedback: true,
         id: 6236,
         uuid: '43eb4a97-e6ef-440c-a044-88e9bb982620',
         image: {

--- a/server/repositories/cmsQueries/__tests__/basicPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/basicPageQuery.spec.js
@@ -5,7 +5,7 @@ describe('Basic page query', () => {
   describe('url', () => {
     it('should create correct path', async () => {
       expect(query.url()).toStrictEqual(
-        'https://cms/content/1234?include=field_moj_secondary_tags%2Cfield_moj_top_level_categories&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_stand_first%2Cfield_moj_secondary_tags%2Cfield_moj_series%2Cfield_moj_top_level_categories&fields%5Btaxonomy_term--tags%5D=drupal_internal__tid%2Cname&fields%5Btaxonomy_term--moj_categories%5D=drupal_internal__tid%2Cname',
+        'https://cms/content/1234?include=field_moj_secondary_tags%2Cfield_moj_top_level_categories&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_stand_first%2Cfield_moj_secondary_tags%2Cfield_moj_series%2Cfield_moj_top_level_categories%2Cfield_exclude_feedback&fields%5Btaxonomy_term--tags%5D=drupal_internal__tid%2Cname&fields%5Btaxonomy_term--moj_categories%5D=drupal_internal__tid%2Cname',
       );
     });
   });
@@ -17,6 +17,7 @@ describe('Basic page query', () => {
         title: 'Novus',
         type: 'node--node--page',
         fieldMojDescription: { processed: 'Education content for prisoners' },
+        fieldExcludeFeedback: true,
         fieldMojStandFirst: 'Education',
         fieldMojTopLevelCategories: [
           {
@@ -32,6 +33,7 @@ describe('Basic page query', () => {
         title: 'Novus',
         contentType: 'page',
         description: 'Education content for prisoners',
+        excludeFeedback: true,
         standFirst: 'Education',
         categories: [{ id: 1234, name: 'steve' }],
         secondaryTags: [{ id: 2345, name: 'carol' }],

--- a/server/repositories/cmsQueries/__tests__/secondaryTagPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/secondaryTagPageQuery.spec.js
@@ -7,7 +7,7 @@ describe('Secondary Tag page query', () => {
   describe('path', () => {
     it('should create correct path', async () => {
       expect(query.path()).toStrictEqual(
-        `/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Bfield_moj_secondary_tags.id%5D=${UUID}&include=field_moj_thumbnail_image%2Cfield_moj_secondary_tags.field_featured_image&sort=-created&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bmoj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bfile--file%5D=image_style_uri&fields%5Btaxonomy_term--tags%5D=name%2Cdescription%2Cdrupal_internal__tid%2Cfield_featured_image%2Cpath`,
+        `/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Bfield_moj_secondary_tags.id%5D=${UUID}&include=field_moj_thumbnail_image%2Cfield_moj_secondary_tags.field_featured_image&sort=-created&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bmoj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bfile--file%5D=image_style_uri&fields%5Btaxonomy_term--tags%5D=name%2Cdescription%2Cdrupal_internal__tid%2Cfield_featured_image%2Cpath%2Cfield_exclude_feedback`,
       );
     });
   });
@@ -23,6 +23,7 @@ describe('Secondary Tag page query', () => {
         drupalInternal_Tid: `100${id}`,
         name: `name${id}`,
         description: { processed: `description${id}` },
+        fieldExcludeFeedback: true,
         fieldFeaturedImage: {
           imageStyleUri: [{ tile_large: `tile_large${id}` }],
           resourceIdObjMeta: { alt: `alt${id}` },
@@ -53,6 +54,7 @@ describe('Secondary Tag page query', () => {
           alt: `alt${id}`,
         },
         displayUrl: undefined,
+        excludeFeedback: true,
         externalContent: false,
         contentUrl: `/tags/${id}`,
       });

--- a/server/repositories/cmsQueries/__tests__/seriesPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/seriesPageQuery.spec.js
@@ -7,7 +7,7 @@ describe('Series page query', () => {
   describe('path', () => {
     it('should create correct path', async () => {
       expect(query.path()).toStrictEqual(
-        `/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Bfield_moj_series.id%5D=${UUID}&include=field_moj_thumbnail_image%2Cfield_moj_series.field_featured_image&sort=series_sort_value&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bmoj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bfile--file%5D=image_style_uri&fields%5Btaxonomy_term--series%5D=name%2Cdescription%2Cdrupal_internal__tid%2Cfield_featured_image%2Cpath`,
+        `/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Bfield_moj_series.id%5D=${UUID}&include=field_moj_thumbnail_image%2Cfield_moj_series.field_featured_image&sort=series_sort_value&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bmoj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bfile--file%5D=image_style_uri&fields%5Btaxonomy_term--series%5D=name%2Cdescription%2Cdrupal_internal__tid%2Cfield_featured_image%2Cpath%2Cfield_exclude_feedback`,
       );
     });
   });
@@ -20,6 +20,7 @@ describe('Series page query', () => {
         name: `name${UUID}`,
         type: 'taxonomy_term--series',
         description: { processed: `description${UUID}` },
+        fieldExcludeFeedback: undefined,
         fieldFeaturedImage: {
           imageStyleUri: [{ tile_large: `tile_large${UUID}` }],
           resourceIdObjMeta: { alt: `alt${UUID}` },
@@ -69,6 +70,7 @@ describe('Series page query', () => {
           alt: `alt${UUID}`,
         },
         displayUrl: undefined,
+        excludeFeedback: undefined,
         externalContent: false,
         contentUrl: `/tags/${UUID}`,
         relatedContent: {

--- a/server/repositories/cmsQueries/__tests__/videoPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/videoPageQuery.spec.js
@@ -5,7 +5,7 @@ describe('Video page query', () => {
   describe('url', () => {
     it('should create correct path', async () => {
       expect(query.url()).toStrictEqual(
-        'https://cms/content/1234?include=field_moj_thumbnail_image%2Cfield_moj_series%2Cfield_video%2Cfield_moj_secondary_tags%2Cfield_moj_top_level_categories&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_video%2Cfield_moj_description%2Cfield_moj_secondary_tags%2Cfield_moj_series%2Cfield_moj_season%2Cfield_moj_episode%2Cfield_moj_top_level_categories%2Cfield_moj_thumbnail_image%2Cseries_sort_value&fields%5Bfile--file%5D=uri%2Cimage_style_uri&fields%5Btaxonomy_term--series%5D=drupal_internal__tid%2Cname%2Cpath&fields%5Btaxonomy_term--tags%5D=drupal_internal__tid%2Cname%2Cpath&fields%5Btaxonomy_term--moj_categories%5D=drupal_internal__tid%2Cname',
+        'https://cms/content/1234?include=field_moj_thumbnail_image%2Cfield_moj_series%2Cfield_video%2Cfield_moj_secondary_tags%2Cfield_moj_top_level_categories&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_video%2Cfield_moj_description%2Cfield_moj_secondary_tags%2Cfield_moj_series%2Cfield_moj_season%2Cfield_moj_episode%2Cfield_moj_top_level_categories%2Cfield_moj_thumbnail_image%2Cseries_sort_value%2Cfield_exclude_feedback&fields%5Bfile--file%5D=uri%2Cimage_style_uri&fields%5Btaxonomy_term--series%5D=drupal_internal__tid%2Cname%2Cpath&fields%5Btaxonomy_term--tags%5D=drupal_internal__tid%2Cname%2Cpath&fields%5Btaxonomy_term--moj_categories%5D=drupal_internal__tid%2Cname',
       );
     });
   });
@@ -18,6 +18,7 @@ describe('Video page query', () => {
         drupalInternal_Nid: 6236,
         title: 'Buddhist reflection: 29 July',
         fieldMojDescription: { processed: 'Education content for prisoners' },
+        fieldExcludeFeedback: undefined,
         fieldMojEpisode: 36,
         fieldMojSeason: 1,
         seriesSortValue: 1001,
@@ -95,6 +96,7 @@ describe('Video page query', () => {
         contentType: 'video',
         description: 'Education content for prisoners',
         episodeId: 1036,
+        excludeFeedback: undefined,
         id: 6236,
         uuid: '43eb4a97-e6ef-440c-a044-88e9bb982620',
         image: {

--- a/server/repositories/cmsQueries/audioPageQuery.js
+++ b/server/repositories/cmsQueries/audioPageQuery.js
@@ -23,6 +23,7 @@ class AudioPageQuery {
         'field_moj_thumbnail_image',
         'field_moj_programme_code',
         'series_sort_value',
+        'field_exclude_feedback',
       ])
 
       .addFields('file--file', ['uri', 'image_style_uri'])
@@ -76,6 +77,7 @@ class AudioPageQuery {
       categories: getCategoryIds(item.fieldMojTopLevelCategories),
       secondaryTags: buildSecondaryTags(item.fieldMojSecondaryTags),
       image: getLargeImage(item.fieldMojThumbnailImage),
+      excludeFeedback: item.fieldExcludeFeedback,
     };
   }
 }

--- a/server/repositories/cmsQueries/basicPageQuery.js
+++ b/server/repositories/cmsQueries/basicPageQuery.js
@@ -13,6 +13,7 @@ class BasicPageQuery {
         'field_moj_secondary_tags',
         'field_moj_series',
         'field_moj_top_level_categories',
+        'field_exclude_feedback',
       ])
       .addFields('taxonomy_term--tags', ['drupal_internal__tid', 'name'])
       .addFields('taxonomy_term--moj_categories', [
@@ -56,6 +57,7 @@ class BasicPageQuery {
         item.fieldMojTopLevelCategories,
       ),
       secondaryTags: this.#buildSecondaryTags(item.fieldMojSecondaryTags),
+      excludeFeedback: item.fieldExcludeFeedback,
     };
   }
 }

--- a/server/repositories/cmsQueries/categoryPageQuery.js
+++ b/server/repositories/cmsQueries/categoryPageQuery.js
@@ -11,6 +11,7 @@ class CategoryPageQuery {
     'field_featured_image',
     'field_moj_secondary_tags',
     'path',
+    'field_exclude_feedback',
   ];
 
   constructor(establishmentName, uuid) {
@@ -45,6 +46,7 @@ class CategoryPageQuery {
       title: data?.name,
       contentType: 'category',
       description: data?.description?.processed,
+      excludeFeedback: data.fieldExcludeFeedback,
       config: {
         content: true,
         header: false,

--- a/server/repositories/cmsQueries/secondaryTagPageQuery.js
+++ b/server/repositories/cmsQueries/secondaryTagPageQuery.js
@@ -43,14 +43,15 @@ class SecondaryTagPageQuery {
 
   #getTag = fieldMojSecondaryTags => {
     const item = fieldMojSecondaryTags.find(({ id }) => id === this.uuid);
-    return getLargeTile(item);
+    return {
+      ...getLargeTile(item),
+      excludeFeedback: item.fieldExcludeFeedback,
+    };
   };
 
   transform(deserializedResponse) {
     if (deserializedResponse.length === 0) return null;
     return {
-      excludeFeedback:
-        deserializedResponse[0].fieldMojSecondaryTags[0].fieldExcludeFeedback,
       ...this.#getTag(deserializedResponse[0].fieldMojSecondaryTags),
       ...{
         relatedContent: {

--- a/server/repositories/cmsQueries/secondaryTagPageQuery.js
+++ b/server/repositories/cmsQueries/secondaryTagPageQuery.js
@@ -27,6 +27,7 @@ class SecondaryTagPageQuery {
         'drupal_internal__tid',
         'field_featured_image',
         'path',
+        'field_exclude_feedback',
       ])
       .addInclude([
         'field_moj_thumbnail_image',
@@ -48,6 +49,8 @@ class SecondaryTagPageQuery {
   transform(deserializedResponse) {
     if (deserializedResponse.length === 0) return null;
     return {
+      excludeFeedback:
+        deserializedResponse[0].fieldMojSecondaryTags[0].fieldExcludeFeedback,
       ...this.#getTag(deserializedResponse[0].fieldMojSecondaryTags),
       ...{
         relatedContent: {

--- a/server/repositories/cmsQueries/seriesPageQuery.js
+++ b/server/repositories/cmsQueries/seriesPageQuery.js
@@ -27,6 +27,7 @@ class SeriesPageQuery {
         'drupal_internal__tid',
         'field_featured_image',
         'path',
+        'field_exclude_feedback',
       ])
       .addInclude([
         'field_moj_thumbnail_image',
@@ -43,6 +44,8 @@ class SeriesPageQuery {
   transform(deserializedResponse) {
     if (deserializedResponse.length === 0) return null;
     return {
+      excludeFeedback:
+        deserializedResponse[0].fieldMojSeries.fieldExcludeFeedback,
       ...getLargeTile(deserializedResponse[0].fieldMojSeries),
       ...{
         relatedContent: {

--- a/server/repositories/cmsQueries/videoPageQuery.js
+++ b/server/repositories/cmsQueries/videoPageQuery.js
@@ -22,6 +22,7 @@ class VideoPageQuery {
         'field_moj_top_level_categories',
         'field_moj_thumbnail_image',
         'series_sort_value',
+        'field_exclude_feedback',
       ])
 
       .addFields('file--file', ['uri', 'image_style_uri'])
@@ -74,6 +75,7 @@ class VideoPageQuery {
       categories: getCategoryIds(item.fieldMojTopLevelCategories),
       secondaryTags: buildSecondaryTags(item.fieldMojSecondaryTags),
       image: getLargeImage(item.fieldMojThumbnailImage),
+      excludeFeedback: item.fieldExcludeFeedback,
     };
   }
 }

--- a/server/views/pages/audio.html
+++ b/server/views/pages/audio.html
@@ -79,17 +79,17 @@
     >
       <source src="{{ data.media }}" type="audio/mp3"/>
     </audio>
-
-    {{ hubFeedbackWidget({
-      contentId: data.id,
-      title: data.title,
-      contentType: data.contentType,
-      series: data.seriesName,
-      feedbackId: feedbackId,
-      categories: data.categories,
-      secondaryTags: data.secondaryTags | join(',', 'id')
-    }) }}
-
+      {% if not data.excludeFeedback %}
+        {{ hubFeedbackWidget({
+          contentId: data.id,
+          title: data.title,
+          contentType: data.contentType,
+          series: data.seriesName,
+          feedbackId: feedbackId,
+          categories: data.categories,
+          secondaryTags: data.secondaryTags | join(',', 'id')
+        }) }}
+      {% endif %}
     <div class="govuk-hub-media-player__description">
       <div id="body" class="govuk-body">{{ data.description | safe }}</div>
     </div>

--- a/server/views/pages/flat-content.html
+++ b/server/views/pages/flat-content.html
@@ -48,18 +48,19 @@
           </div>
         </div>
       </div>
-
-      <div class="govuk-hub-article-feedback">
-        <p class="govuk-body">Tell us what you think:</p>
-        {{ hubFeedbackWidget({
-          title: data.title,
-          contentId: data.id,
-          contentType: data.contentType,
-          feedbackId: feedbackId,
-          categories: data.categories,
-          secondaryTags: data.secondaryTags
-        })}}
-      </div>
+      {% if not data.excludeFeedback %}
+            <div class="govuk-hub-article-feedback">
+              <p class="govuk-body">Tell us what you think:</p>
+              {{ hubFeedbackWidget({
+                title: data.title,
+                contentId: data.id,
+                contentType: data.contentType,
+                feedbackId: feedbackId,
+                categories: data.categories,
+                secondaryTags: data.secondaryTags
+              })}}
+            </div>
+      {% endif %}
     </main>
   </div>
 {% endblock %}

--- a/server/views/pages/tags.html
+++ b/server/views/pages/tags.html
@@ -69,25 +69,25 @@
     data: data.relatedContent,
     lazyLoadContent: true
   }) }}
+  {% if not data.excludeFeedback %}
+    <div class="govuk-form-group govuk-!-margin-bottom-2">
+      {% if data.contentType =='series'%}
+        <p class="govuk-hub-article-feedback govuk-hub-feedback-text">Tell us what you think about this series:</p>
+      {% endif %}
 
-  <div class="govuk-form-group govuk-!-margin-bottom-2">
-    {% if data.contentType =='series'%}
-      <p class="govuk-hub-article-feedback govuk-hub-feedback-text">Tell us what you think about this series:</p>
-    {% endif %}
-
-    {% if data.contentType =='tags'%}
-      <p class="govuk-hub-article-feedback govuk-hub-feedback-text">Tell us what you think about this topic:</p>
-    {% endif %}
-    {{ hubFeedbackWidget({
-      contentId: data.id,
-      title: title,
-      name: title,
-      contentType: data.contentType,
-      series: title,
-      feedbackId: feedbackId,
-      series: title if data.contentType == 'series',
-      secondaryTags: title if data.contentType == 'tags'
-    })}}
-  </div>
-
+      {% if data.contentType =='tags'%}
+        <p class="govuk-hub-article-feedback govuk-hub-feedback-text">Tell us what you think about this topic:</p>
+      {% endif %}
+      {{ hubFeedbackWidget({
+        contentId: data.id,
+        title: title,
+        name: title,
+        contentType: data.contentType,
+        series: title,
+        feedbackId: feedbackId,
+        series: title if data.contentType == 'series',
+        secondaryTags: title if data.contentType == 'tags'
+      })}}
+    </div>
+  {% endif %}
 {% endblock %}

--- a/server/views/pages/video.html
+++ b/server/views/pages/video.html
@@ -77,15 +77,17 @@
       >
         <source src="{{ data.media }}" type="video/mp4"/>
       </video>
-      {{ hubFeedbackWidget({
-        contentId: data.id,
-        title: data.title,
-        contentType: data.contentType,
-        series: data.seriesName,
-        feedbackId: feedbackId,
-        categories: data.categories,
-        secondaryTags: data.secondaryTags | join(',', 'id')
-      })}}
+        {% if not data.excludeFeedback %}
+          {{ hubFeedbackWidget({
+            contentId: data.id,
+            title: data.title,
+            contentType: data.contentType,
+            series: data.seriesName,
+            feedbackId: feedbackId,
+            categories: data.categories,
+            secondaryTags: data.secondaryTags | join(',', 'id')
+          })}}
+        {% endif %}
     </div>
 
     <div class="govuk-hub-media-player__description">


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/OnD5Jbau

### Intent

> What changes are introduced by this PR that correspond to the above card?

Allows the user to remove the feedback component on article, video, audio, series and secondary tag content types so that this does not appear on the Front end.

> Would this PR benefit from screenshots?

![Screenshot 2021-12-07 at 14 36 32](https://user-images.githubusercontent.com/29005413/145049026-23579d6c-e404-45a9-b69f-07cefc70888c.png)

![Screenshot 2021-12-07 at 14 39 29](https://user-images.githubusercontent.com/29005413/145049412-28a6376b-804e-42a0-883d-387e80a2aaf3.png)

### Considerations

> Is there any additional information that would help when reviewing this PR?

Testing the secondary tag behaviour is important, due to content being allowed to be tagged across multiple secondary tags

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
