### PR TITLE
Feature/enable user preference for viewing interstitial page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "axios": "0.24.0",
         "compression": "^1.7.4",
         "cookie-session": "^2.0.0-rc.1",
+        "cookies": "^0.8.0",
         "date-fns": "^2.25.0",
         "dotenv": "^10.0.0",
         "drupal-jsonapi-params": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "axios": "0.24.0",
     "compression": "^1.7.4",
     "cookie-session": "^2.0.0-rc.1",
+    "cookies": "^0.8.0",
     "date-fns": "^2.25.0",
     "dotenv": "^10.0.0",
     "drupal-jsonapi-params": "^1.2.2",

--- a/server/routes/__tests__/externalLink.spec.js
+++ b/server/routes/__tests__/externalLink.spec.js
@@ -1,0 +1,100 @@
+const request = require('supertest');
+const cheerio = require('cheerio');
+
+jest.mock('@sentry/node');
+
+const { createExternalLinkRouter } = require('../externalLink');
+const { setupBasicApp } = require('../../../test/test-helpers');
+
+describe('GET /external-link', () => {
+  describe('/:id', () => {
+    describe('on error', () => {
+      beforeEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it('passes caught exceptions to next', async () => {
+        const cmsService = {
+          getTag: jest.fn().mockRejectedValue('💥'),
+        };
+        const router = createExternalLinkRouter({ cmsService });
+        const app = setupBasicApp();
+
+        app.use('/external-link', router);
+
+        await request(app).get('/external-link/1').expect(500);
+      });
+      it('returns a 500 when incorrect data is returned', async () => {
+        const cmsService = {
+          getTag: jest.fn().mockRejectedValue('error'),
+        };
+        const router = createExternalLinkRouter({ cmsService });
+        const app = setupBasicApp();
+
+        app.use('/external-link', router);
+
+        await request(app).get('/external-link/1').expect(500);
+      });
+    });
+
+    describe('on success', () => {
+      const data = {
+        title: 'foo bar',
+        url: 'foo.url.com',
+      };
+
+      const getSessionMiddleware = cookie => (req, res, next) => {
+        req.session = {
+          establishmentId: 123,
+          establishmentName: 'berwyn',
+        };
+        req.headers.cookie = cookie;
+        next();
+      };
+
+      let app;
+      let router;
+
+      beforeEach(() => {
+        const cmsService = {
+          getExternalLink: jest.fn().mockReturnValue(data),
+        };
+        router = createExternalLinkRouter({ cmsService });
+        app = setupBasicApp();
+      });
+
+      describe('external link with the cookie', () => {
+        it('redirects to the external link', () => {
+          app.use(getSessionMiddleware(`externalLink_${data.url}=true`));
+          app.use('/external-link', router);
+          return request(app)
+            .get('/external-link/1')
+            .expect('Location', data.url);
+        });
+      });
+
+      describe('external link with no cookie', () => {
+        beforeEach(() => {
+          app.use(getSessionMiddleware(''));
+          app.use('/external-link', router);
+        });
+        it('correctly renders the external link page text', () =>
+          request(app)
+            .get('/external-link/1')
+            .then(response => {
+              const $ = cheerio.load(response.text);
+              expect($('[data-test="external-link-content"]').text()).toContain(
+                `You are being taken to foo bar. You are allowed to visit this website.`,
+              );
+            }));
+        it('correctly renders the external link page link', () =>
+          request(app)
+            .get('/external-link/1')
+            .then(response => {
+              const $ = cheerio.load(response.text);
+              expect($('.govuk-button')[0].attribs.href).toEqual(data.url);
+            }));
+      });
+    });
+  });
+});

--- a/server/routes/externalLink.js
+++ b/server/routes/externalLink.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const Cookies = require('cookies');
 
 const createExternalLinkRouter = ({ cmsService }) => {
   const router = express.Router();
@@ -21,6 +22,9 @@ const createExternalLinkRouter = ({ cmsService }) => {
         req.session.establishmentName,
         id,
       );
+      const cookies = new Cookies(req, res);
+      if (cookies.get(`externalLink_${url}`) === 'true')
+        return res.redirect(url);
 
       return res.render(`pages/externalLink`, {
         title,

--- a/server/views/pages/externalLink.html
+++ b/server/views/pages/externalLink.html
@@ -64,11 +64,10 @@
           <img class="hub-logo" src="/public/images/icons/content-hub-invert.png" alt="logo">
           <h1 class="govuk-heading-xl govuk-!-margin-0 govuk-!-padding-left-4">Content Hub</h1>
         </div>
-        <section class="govuk-!-text-align-centre">
+        <section class="govuk-!-text-align-centre" data-test="external-link-content">
           <h2 class="govuk-heading-l">You're leaving the Hub</h2>
-          <p >You are being taken to {{ title }}.</p>
-          <p >Access to the internet is <strong>blocked</strong> on the in cell laptops.</p>
-          <p >Links to other sites from {{ title }} have been disabled.</p>
+          <p>You are being taken to {{ title }}. You are <strong>allowed</strong> to visit this website.</p>
+          <p>Internet access is restricted in prisons so links to other websites are blocked.</p>
           {{ govukButton({
             text: "Continue",
             href: url
@@ -87,7 +86,8 @@
           </div>
         </section>
         
-
+        <script src="/public/jquery.min.js"></script>
+        <script src="/public/javascript/all.js"></script>
         <script>
           sendPageTrack({
             hostname: document.location.hostname,
@@ -97,6 +97,11 @@
             screen: window.screen.width + 'x' + window.screen.height,
             viewport: Math.max(document.documentElement.clientWidth, window.innerWidth || 0) + 'x' + Math.max(document.documentElement.clientHeight, window.innerHeight || 0)
           });
+
+          $('#doNotShowMessage').change(
+            function(){
+                document.cookie = `externalLink_{{ url }}=${$(this).is(':checked') ? 'true; Max-Age=315600000000' : 'false; Max-Age=0'}; SameSite=Lax; Secure; path=/;`;
+            });
         </script>
       </main>
     </div>


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/ffdSx9Av/454-enable-user-preference-for-viewing-interstitial-page

> If this is an issue, do we have steps to reproduce?

n/a

### Intent

> What changes are introduced by this PR that correspond to the above card?

cookie controlled url navigation

> Would this PR benefit from screenshots?

<img width="739" alt="Screenshot 2021-12-14 at 07 57 29" src="https://user-images.githubusercontent.com/50403492/145956523-7ac2d6c4-e2ac-4468-a0af-c3a2fc9c2d45.png">


### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
