### PR TITLE
Add pagination to series secondary tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .port.tmp
 public
 assets/stylesheets
+assets/generated
 lib/govuk_template.html
 govuk_modules
 node_modules/*

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ assets/javascript/games
 package.json
 package-lock.json
 assets/stylesheets
+assets/generated
 assets/javascript/all.js
 assets/javascript/search.js
 assets/javascript/feedback-tracking.js

--- a/assets/javascript/showMore.js
+++ b/assets/javascript/showMore.js
@@ -17,7 +17,7 @@ function disableShowMore() {
 }
 
 let page = 1;
-showMore.on('click', () => {
+showMore.on('click', function () {
   page++;
   const nextPage = `${location.pathname}.json?page=${page}`;
   disableShowMore();

--- a/assets/javascript/showMore.js
+++ b/assets/javascript/showMore.js
@@ -7,10 +7,12 @@ function updateButton(isLastPage) {
 }
 
 function enableShowMore() {
+  showMore.html('Show more');
   showMore.attr('disabled', false);
 }
 
 function disableShowMore() {
+  showMore.html('Loading');
   showMore.attr('disabled', true);
 }
 

--- a/assets/javascript/showMore.js
+++ b/assets/javascript/showMore.js
@@ -1,4 +1,4 @@
-const showMore = $('.showMoreTiles');
+const showMore = $('.show-more-tiles');
 const smallTiles = $('#small-tiles');
 function updateButton(isLastPage) {
   if (isLastPage) {

--- a/assets/javascript/showMore.js
+++ b/assets/javascript/showMore.js
@@ -1,0 +1,33 @@
+const showMore = $('.showMoreTiles');
+const smallTiles = $('#small-tiles');
+function updateButton(isLastPage) {
+  if (isLastPage) {
+    showMore.remove();
+  }
+}
+
+function enableShowMore() {
+  showMore.attr('disabled', false);
+}
+
+function disableShowMore() {
+  showMore.attr('disabled', true);
+}
+
+let page = 1;
+showMore.on('click', () => {
+  page++;
+  const nextPage = `${location.pathname}.json?page=${page}`;
+  disableShowMore();
+
+  $.getJSON(nextPage, function (data) {
+    const res = data.relatedContent.data.map(item =>
+      nunjucks.render('content-tile-small', { params: item }),
+    );
+    smallTiles.append(res);
+    enableShowMore();
+    updateButton(data.relatedContent.isLastPage);
+  }).fail(function () {
+    enableShowMore();
+  });
+});

--- a/assets/sass/components/_page-navigation.scss
+++ b/assets/sass/components/_page-navigation.scss
@@ -53,10 +53,3 @@
   align-items: center;
   margin-top: 51px;
 }
-
-.showMoreTiles,
-.showMoreTiles:hover,
-.showMoreTiles:disabled {
-  color: govuk-colour('black') !important;
-  background-color: govuk-colour('light-grey') !important;
-}

--- a/assets/sass/components/_page-navigation.scss
+++ b/assets/sass/components/_page-navigation.scss
@@ -46,3 +46,17 @@
   background-image: url('/public/images/icons/chevron-right.svg');
   background-position: 8px 50%;
 }
+
+.show-more {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 51px;
+}
+
+.showMoreTiles,
+.showMoreTiles:hover,
+.showMoreTiles:disabled {
+  color: govuk-colour('black') !important;
+  background-color: govuk-colour('light-grey') !important;
+}

--- a/nodemon.json
+++ b/nodemon.json
@@ -3,6 +3,7 @@
   "ignore": [
     ".git",
     "node_modules/**/node_modules",
+    "assets/generated",
     "assets/stylesheets",
     "**/__tests__/**",
     ".circleci/*",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "postinstall": "husky install",
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "build": "npm run css-build",
+    "build": "npm run css-build && npm run precompile-templates",
     "css-build": "./bin/build-css",
     "clean": "rm -rf public/* .port.tmp *.log build/* uploads/* test-results.xml",
     "lint": "eslint . --cache --max-warnings 0",
@@ -18,7 +18,8 @@
     "prettier": "prettier \"**/*.+(js|jsx|json|css|scss|md)\"",
     "verify": "npm run lint && npm run prettier -- --list-different && npm run test",
     "format": "npm run prettier -- --write",
-    "security_audit": "npx audit-ci --config audit-ci.json"
+    "security_audit": "npx audit-ci --config audit-ci.json",
+    "precompile-templates": "mkdir -p assets/generated && nunjucks-precompile -n content-tile-small server/views/components/content-tile-small/template.njk > assets/generated/templates.js"
   },
   "repository": {
     "type": "git",

--- a/server/app.js
+++ b/server/app.js
@@ -116,6 +116,7 @@ const createApp = services => {
     '../assets/stylesheets',
     '../node_modules/govuk-frontend/govuk/',
     '../node_modules/jquery/dist',
+    '../node_modules/nunjucks/browser',
     '../node_modules/@ministryofjustice/frontend/moj/',
     '../node_modules/video.js/dist',
   ].forEach(dir => {

--- a/server/repositories/__tests__/cmsApi.spec.js
+++ b/server/repositories/__tests__/cmsApi.spec.js
@@ -11,13 +11,14 @@ class TestPathTransformQuery {
     return path;
   }
 
-  transform(item) {
+  transform(item, links) {
     const { name, description, fieldLegacyLandingPage } = item;
     const id =
       fieldLegacyLandingPage?.resourceIdObjMeta?.drupal_internal__target_id;
     return {
       id,
       linkText: name,
+      self: links?.self,
       description: description?.processed,
       href: `/content/${id}`,
     };
@@ -129,6 +130,9 @@ describe('CmsApi', () => {
         description: 'Desc 1',
         href: '/content/1',
         id: '1',
+        self: {
+          href: 'http://cms.prg/jsonapi/node/not-used',
+        },
         linkText: 'One',
       });
     });

--- a/server/repositories/cmsApi.js
+++ b/server/repositories/cmsApi.js
@@ -49,7 +49,7 @@ class CmsApi {
       const deserializedResponse = dataFormatter.deserialize(response);
       return query.transformEach
         ? deserializedResponse.map(item => query.transformEach(item))
-        : query.transform(deserializedResponse);
+        : query.transform(deserializedResponse, response.links);
     });
   }
 

--- a/server/repositories/cmsQueries/__tests__/secondaryTagPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/secondaryTagPageQuery.spec.js
@@ -8,7 +8,7 @@ describe('Secondary Tag page query', () => {
   describe('path', () => {
     it('should create correct path', async () => {
       expect(query.path()).toStrictEqual(
-        `/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Bfield_moj_secondary_tags.id%5D=${UUID}&include=field_moj_thumbnail_image%2Cfield_moj_secondary_tags.field_featured_image&sort=-created&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cpath%2Cfield_moj_secondary_tags&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cpath%2Cfield_moj_secondary_tags&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cpath%2Cfield_moj_secondary_tags&fields%5Bmoj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cpath%2Cfield_moj_secondary_tags&fields%5Bfile--file%5D=image_style_uri&fields%5Btaxonomy_term--tags%5D=name%2Cdescription%2Cdrupal_internal__tid%2Cfield_featured_image%2Cpath%2Cfield_exclude_feedback&${getPagination(
+        `/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Bfield_moj_secondary_tags.id%5D=${UUID}&include=field_moj_thumbnail_image%2Cfield_moj_secondary_tags.field_featured_image&sort=-created&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bmoj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bfile--file%5D=image_style_uri&fields%5Btaxonomy_term--tags%5D=name%2Cdescription%2Cdrupal_internal__tid%2Cfield_featured_image%2Cpath%2Cfield_exclude_feedback&${getPagination(
           10,
         )}`,
       );
@@ -16,64 +16,66 @@ describe('Secondary Tag page query', () => {
   });
 
   describe('transform', () => {
+    const createSecondaryTag = id => ({
+      id,
+      type: 'taxonomy_term--tags',
+      drupalInternal_Tid: `100${id}`,
+      name: `name${id}`,
+      description: { processed: `description${id}` },
+      fieldExcludeFeedback: true,
+      fieldFeaturedImage: {
+        imageStyleUri: [{ tile_large: `tile_large${id}` }],
+        resourceIdObjMeta: { alt: `alt${id}` },
+      },
+      path: { alias: `/tags/${id}` },
+    });
+    const createContent = (id, fieldMojSecondaryTags) => ({
+      drupalInternal_Nid: id,
+      title: `title${id}`,
+      type: 'node--moj_video_item',
+      fieldMojDescription: { summary: `summary${id}` },
+      fieldMojThumbnailImage: {
+        imageStyleUri: [{}, { tile_small: `tile_small${id}` }],
+        resourceIdObjMeta: { alt: `alt${id}` },
+      },
+      fieldMojSecondaryTags,
+      path: { alias: `/content/${id}` },
+      displayUrl: undefined,
+      externalContent: false,
+    });
+    const createTransformedSecondaryTag = id => ({
+      id: `100${id}`,
+      contentType: 'tags',
+      title: `name${id}`,
+      summary: `description${id}`,
+      image: {
+        url: `tile_large${id}`,
+        alt: `alt${id}`,
+      },
+      displayUrl: undefined,
+      excludeFeedback: true,
+      externalContent: false,
+      contentUrl: `/tags/${id}`,
+    });
+    const createTransformedContent = id => ({
+      id,
+      title: `title${id}`,
+      contentType: 'video',
+      summary: `summary${id}`,
+      contentUrl: `/content/${id}`,
+      image: {
+        url: `tile_small${id}`,
+        alt: `alt${id}`,
+      },
+      displayUrl: undefined,
+      externalContent: false,
+    });
+
     it('should return null if the Array is empty', async () => {
       expect(query.transform([])).toBeNull();
     });
+
     it('should list the content', async () => {
-      const createSecondaryTag = id => ({
-        id,
-        type: 'taxonomy_term--tags',
-        drupalInternal_Tid: `100${id}`,
-        name: `name${id}`,
-        description: { processed: `description${id}` },
-        fieldExcludeFeedback: true,
-        fieldFeaturedImage: {
-          imageStyleUri: [{ tile_large: `tile_large${id}` }],
-          resourceIdObjMeta: { alt: `alt${id}` },
-        },
-        path: { alias: `/tags/${id}` },
-      });
-      const createContent = (id, fieldMojSecondaryTags) => ({
-        drupalInternal_Nid: id,
-        title: `title${id}`,
-        type: 'node--moj_video_item',
-        fieldMojDescription: { summary: `summary${id}` },
-        fieldMojThumbnailImage: {
-          imageStyleUri: [{}, { tile_small: `tile_small${id}` }],
-          resourceIdObjMeta: { alt: `alt${id}` },
-        },
-        fieldMojSecondaryTags,
-        path: { alias: `/content/${id}` },
-        displayUrl: undefined,
-        externalContent: false,
-      });
-      const createTransformedSecondaryTag = id => ({
-        id: `100${id}`,
-        contentType: 'tags',
-        title: `name${id}`,
-        summary: `description${id}`,
-        image: {
-          url: `tile_large${id}`,
-          alt: `alt${id}`,
-        },
-        displayUrl: undefined,
-        excludeFeedback: true,
-        externalContent: false,
-        contentUrl: `/tags/${id}`,
-      });
-      const createTransformedContent = id => ({
-        id,
-        title: `title${id}`,
-        contentType: 'video',
-        summary: `summary${id}`,
-        contentUrl: `/content/${id}`,
-        image: {
-          url: `tile_small${id}`,
-          alt: `alt${id}`,
-        },
-        displayUrl: undefined,
-        externalContent: false,
-      });
       const SECONDARYTAG1 = createSecondaryTag(1);
       const SECONDARYTAG2 = createSecondaryTag(UUID);
       const SECONDARYTAGS = [SECONDARYTAG1, SECONDARYTAG2];
@@ -82,16 +84,35 @@ describe('Secondary Tag page query', () => {
       const CONTENT3 = createContent('C', SECONDARYTAGS);
       const response = [CONTENT1, CONTENT2, CONTENT3];
 
-      expect(query.transform(response)).toStrictEqual({
+      expect(query.transform(response, { next: 'NextPageURL' })).toStrictEqual({
         ...createTransformedSecondaryTag(UUID),
         ...{
           relatedContent: {
             contentType: 'default',
+            isLastPage: false,
             data: [
               createTransformedContent('A'),
               createTransformedContent('B'),
               createTransformedContent('C'),
             ],
+          },
+        },
+      });
+    });
+
+    it('should not display next content link on last page', async () => {
+      const SECONDARYTAG1 = createSecondaryTag(UUID);
+      const SECONDARYTAGS = [SECONDARYTAG1];
+      const CONTENT1 = createContent('A', SECONDARYTAGS);
+      const response = [CONTENT1];
+
+      expect(query.transform(response, {})).toStrictEqual({
+        ...createTransformedSecondaryTag(UUID),
+        ...{
+          relatedContent: {
+            contentType: 'default',
+            isLastPage: true,
+            data: [createTransformedContent('A')],
           },
         },
       });

--- a/server/repositories/cmsQueries/__tests__/secondaryTagPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/secondaryTagPageQuery.spec.js
@@ -1,13 +1,16 @@
+const { getPagination } = require('../../../utils/jsonApi');
 const { SecondaryTagPageQuery } = require('../secondaryTagPageQuery');
 
 describe('Secondary Tag page query', () => {
   const ESTABLISHMENTNAME = 'Wayland';
   const UUID = `42`;
-  const query = new SecondaryTagPageQuery(ESTABLISHMENTNAME, UUID);
+  const query = new SecondaryTagPageQuery(ESTABLISHMENTNAME, UUID, 10);
   describe('path', () => {
     it('should create correct path', async () => {
       expect(query.path()).toStrictEqual(
-        `/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Bfield_moj_secondary_tags.id%5D=${UUID}&include=field_moj_thumbnail_image%2Cfield_moj_secondary_tags.field_featured_image&sort=-created&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bmoj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bfile--file%5D=image_style_uri&fields%5Btaxonomy_term--tags%5D=name%2Cdescription%2Cdrupal_internal__tid%2Cfield_featured_image%2Cpath%2Cfield_exclude_feedback`,
+        `/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Bfield_moj_secondary_tags.id%5D=${UUID}&include=field_moj_thumbnail_image%2Cfield_moj_secondary_tags.field_featured_image&sort=-created&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cpath%2Cfield_moj_secondary_tags&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cpath%2Cfield_moj_secondary_tags&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cpath%2Cfield_moj_secondary_tags&fields%5Bmoj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cpath%2Cfield_moj_secondary_tags&fields%5Bfile--file%5D=image_style_uri&fields%5Btaxonomy_term--tags%5D=name%2Cdescription%2Cdrupal_internal__tid%2Cfield_featured_image%2Cpath%2Cfield_exclude_feedback&${getPagination(
+          10,
+        )}`,
       );
     });
   });

--- a/server/repositories/cmsQueries/__tests__/seriesPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/seriesPageQuery.spec.js
@@ -1,66 +1,69 @@
+const { getPagination } = require('../../../utils/jsonApi');
 const { SeriesPageQuery } = require('../seriesPageQuery');
 
 describe('Series page query', () => {
   const ESTABLISHMENTNAME = 'Wayland';
   const UUID = `42`;
-  const query = new SeriesPageQuery(ESTABLISHMENTNAME, UUID);
+  const query = new SeriesPageQuery(ESTABLISHMENTNAME, UUID, 2);
   describe('path', () => {
     it('should create correct path', async () => {
       expect(query.path()).toStrictEqual(
-        `/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Bfield_moj_series.id%5D=${UUID}&include=field_moj_thumbnail_image%2Cfield_moj_series.field_featured_image&sort=series_sort_value&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bmoj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bfile--file%5D=image_style_uri&fields%5Btaxonomy_term--series%5D=name%2Cdescription%2Cdrupal_internal__tid%2Cfield_featured_image%2Cpath%2Cfield_exclude_feedback`,
+        `/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Bfield_moj_series.id%5D=${UUID}&include=field_moj_thumbnail_image%2Cfield_moj_series.field_featured_image&sort=series_sort_value&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bmoj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bfile--file%5D=image_style_uri&fields%5Btaxonomy_term--series%5D=name%2Cdescription%2Cdrupal_internal__tid%2Cfield_featured_image%2Cpath%2Cfield_exclude_feedback&${getPagination(
+          2,
+        )}`,
       );
     });
   });
 
   describe('transform', () => {
+    const fieldMojSeries = {
+      UUID,
+      drupalInternal_Tid: `100${UUID}`,
+      name: `name${UUID}`,
+      type: 'taxonomy_term--series',
+      description: { processed: `description${UUID}` },
+      fieldExcludeFeedback: undefined,
+      fieldFeaturedImage: {
+        imageStyleUri: [{ tile_large: `tile_large${UUID}` }],
+        resourceIdObjMeta: { alt: `alt${UUID}` },
+      },
+      path: { alias: `/tags/${UUID}` },
+    };
+    const createContent = id => ({
+      drupalInternal_Nid: id,
+      title: `title${id}`,
+      fieldMojDescription: { summary: `summary${id}` },
+      fieldMojThumbnailImage: {
+        imageStyleUri: [{}, { tile_small: `tile_small${id}` }],
+        resourceIdObjMeta: { alt: `alt${id}` },
+      },
+      type: 'node--moj_video_item',
+      fieldMojSeries,
+      path: { alias: `/content/${id}` },
+      displayUrl: undefined,
+      externalContent: false,
+    });
+    const createTransformedContent = id => ({
+      id,
+      title: `title${id}`,
+      summary: `summary${id}`,
+      contentUrl: `/content/${id}`,
+      image: {
+        url: `tile_small${id}`,
+        alt: `alt${id}`,
+      },
+      displayUrl: undefined,
+      externalContent: false,
+      contentType: 'video',
+    });
     it('should list the content', async () => {
-      const fieldMojSeries = {
-        UUID,
-        drupalInternal_Tid: `100${UUID}`,
-        name: `name${UUID}`,
-        type: 'taxonomy_term--series',
-        description: { processed: `description${UUID}` },
-        fieldExcludeFeedback: undefined,
-        fieldFeaturedImage: {
-          imageStyleUri: [{ tile_large: `tile_large${UUID}` }],
-          resourceIdObjMeta: { alt: `alt${UUID}` },
-        },
-        path: { alias: `/tags/${UUID}` },
-      };
-      const createContent = id => ({
-        drupalInternal_Nid: id,
-        title: `title${id}`,
-        fieldMojDescription: { summary: `summary${id}` },
-        fieldMojThumbnailImage: {
-          imageStyleUri: [{}, { tile_small: `tile_small${id}` }],
-          resourceIdObjMeta: { alt: `alt${id}` },
-        },
-        type: 'node--moj_video_item',
-        fieldMojSeries,
-        path: { alias: `/content/${id}` },
-        displayUrl: undefined,
-        externalContent: false,
-      });
-      const createTransformedContent = id => ({
-        id,
-        title: `title${id}`,
-        summary: `summary${id}`,
-        contentUrl: `/content/${id}`,
-        image: {
-          url: `tile_small${id}`,
-          alt: `alt${id}`,
-        },
-        displayUrl: undefined,
-        externalContent: false,
-        contentType: 'video',
-      });
       const response = [
         createContent('A'),
         createContent('B'),
         createContent('C'),
       ];
 
-      expect(query.transform(response)).toStrictEqual({
+      expect(query.transform(response, { next: 'URL' })).toStrictEqual({
         id: `100${UUID}`,
         contentType: 'series',
         title: `name${UUID}`,
@@ -75,11 +78,36 @@ describe('Series page query', () => {
         contentUrl: `/tags/${UUID}`,
         relatedContent: {
           contentType: 'default',
+          isLastPage: false,
           data: [
             createTransformedContent('A'),
             createTransformedContent('B'),
             createTransformedContent('C'),
           ],
+        },
+      });
+    });
+
+    it('should not display next content link on last page', async () => {
+      const response = [createContent('A')];
+
+      expect(query.transform(response, {})).toStrictEqual({
+        id: `100${UUID}`,
+        contentType: 'series',
+        title: `name${UUID}`,
+        summary: `description${UUID}`,
+        image: {
+          url: `tile_large${UUID}`,
+          alt: `alt${UUID}`,
+        },
+        displayUrl: undefined,
+        excludeFeedback: undefined,
+        externalContent: false,
+        contentUrl: `/tags/${UUID}`,
+        relatedContent: {
+          contentType: 'default',
+          isLastPage: true,
+          data: [createTransformedContent('A')],
         },
       });
     });

--- a/server/repositories/cmsQueries/secondaryTagPageQuery.js
+++ b/server/repositories/cmsQueries/secondaryTagPageQuery.js
@@ -1,5 +1,9 @@
 const { DrupalJsonApiParams: Query } = require('drupal-jsonapi-params');
-const { getSmallTile, getLargeTile } = require('../../utils/jsonApi');
+const {
+  getSmallTile,
+  getLargeTile,
+  getPagination,
+} = require('../../utils/jsonApi');
 
 class SecondaryTagPageQuery {
   static #TILE_FIELDS = [
@@ -8,9 +12,10 @@ class SecondaryTagPageQuery {
     'field_moj_description',
     'field_moj_thumbnail_image',
     'path',
+    'field_moj_secondary_tags',
   ];
 
-  constructor(establishmentName, uuid) {
+  constructor(establishmentName, uuid, page) {
     this.establishmentName = establishmentName;
     this.uuid = uuid;
     const queryWithoutOffset = new Query()
@@ -33,9 +38,8 @@ class SecondaryTagPageQuery {
         'field_moj_secondary_tags.field_featured_image',
       ])
       .addSort('created', 'DESC')
-      .addPageLimit(10)
       .getQueryString();
-    this.query = `${queryWithoutOffset}`;
+    this.query = `${queryWithoutOffset}&${getPagination(page)}`;
   }
 
   path() {

--- a/server/repositories/cmsQueries/secondaryTagPageQuery.js
+++ b/server/repositories/cmsQueries/secondaryTagPageQuery.js
@@ -11,8 +11,8 @@ class SecondaryTagPageQuery {
     'title',
     'field_moj_description',
     'field_moj_thumbnail_image',
-    'path',
     'field_moj_secondary_tags',
+    'path',
   ];
 
   constructor(establishmentName, uuid, page) {
@@ -54,13 +54,14 @@ class SecondaryTagPageQuery {
     };
   };
 
-  transform(deserializedResponse) {
+  transform(deserializedResponse, links) {
     if (deserializedResponse.length === 0) return null;
     return {
       ...this.#getTag(deserializedResponse[0].fieldMojSecondaryTags),
       ...{
         relatedContent: {
           contentType: 'default',
+          isLastPage: !links.next,
           data: deserializedResponse.map(item => getSmallTile(item)),
         },
       },

--- a/server/repositories/cmsQueries/secondaryTagPageQuery.js
+++ b/server/repositories/cmsQueries/secondaryTagPageQuery.js
@@ -7,14 +7,13 @@ class SecondaryTagPageQuery {
     'title',
     'field_moj_description',
     'field_moj_thumbnail_image',
-    'field_moj_secondary_tags',
     'path',
   ];
 
   constructor(establishmentName, uuid) {
     this.establishmentName = establishmentName;
     this.uuid = uuid;
-    this.query = new Query()
+    const queryWithoutOffset = new Query()
       .addFilter('field_moj_secondary_tags.id', uuid)
       .addFields('node--page', SecondaryTagPageQuery.#TILE_FIELDS)
       .addFields('node--moj_video_item', SecondaryTagPageQuery.#TILE_FIELDS)
@@ -34,7 +33,9 @@ class SecondaryTagPageQuery {
         'field_moj_secondary_tags.field_featured_image',
       ])
       .addSort('created', 'DESC')
+      .addPageLimit(10)
       .getQueryString();
+    this.query = `${queryWithoutOffset}`;
   }
 
   path() {

--- a/server/routes/__tests__/money.spec.js
+++ b/server/routes/__tests__/money.spec.js
@@ -339,14 +339,14 @@ describe('Prisoner Money', () => {
       const spy = jest.spyOn(prisonerInformationService, 'getTransactionsFor');
 
       await request(app)
-        .get('/money/transactions/spends?selectedDate=2021-01-01')
+        .get('/money/transactions/spends?selectedDate=2021-12-01')
         .expect(200)
         .then(() => {
           expect(spy).toHaveBeenCalledWith(
             testUser,
             'spends',
-            new Date('2021-01-01T00:00:00.000'),
-            new Date('2021-01-31T23:59:59.999'),
+            new Date('2021-12-01T00:00:00.000'),
+            new Date('2021-12-31T23:59:59.999'),
           );
         });
     });
@@ -676,13 +676,13 @@ describe('Prisoner Money', () => {
       );
 
       await request(app)
-        .get('/money/transactions/private?selectedDate=2021-01-01')
+        .get('/money/transactions/private?selectedDate=2021-12-01')
         .expect(200)
         .then(() => {
           expect(spy).toHaveBeenCalledWith(
             testUser,
-            new Date('2021-01-01T00:00:00.000'),
-            new Date('2021-01-31T23:59:59.999'),
+            new Date('2021-12-01T00:00:00.000'),
+            new Date('2021-12-31T23:59:59.999'),
           );
         });
     });
@@ -903,14 +903,14 @@ describe('Prisoner Money', () => {
       const spy = jest.spyOn(prisonerInformationService, 'getTransactionsFor');
 
       await request(app)
-        .get('/money/transactions/savings?selectedDate=2021-01-01')
+        .get('/money/transactions/savings?selectedDate=2021-12-01')
         .expect(200)
         .then(() => {
           expect(spy).toHaveBeenCalledWith(
             testUser,
             'savings',
-            new Date('2021-01-01T00:00:00.000'),
-            new Date('2021-01-31T23:59:59.999'),
+            new Date('2021-12-01T00:00:00.000'),
+            new Date('2021-12-31T23:59:59.999'),
           );
         });
     });

--- a/server/routes/content.js
+++ b/server/routes/content.js
@@ -22,7 +22,10 @@ const createContentRouter = ({ cmsService, analyticsService }) => {
     const { establishmentName } = req.session;
 
     try {
-      const data = await cmsService.getContent(establishmentName, id);
+      const data = await cmsService.getContent(
+        establishmentName,
+        parseInt(id, 10),
+      );
 
       const contentType = prop('contentType', data);
       const sessionId = path(['session', 'id'], req);

--- a/server/routes/tags.js
+++ b/server/routes/tags.js
@@ -6,7 +6,12 @@ const createTagRouter = ({ cmsService }) => {
   router.get('/:id.json', async (req, res, next) => {
     try {
       const { id } = req.params;
-      const data = await cmsService.getTag(req.session.establishmentName, id);
+      const { page } = req.query;
+      const data = await cmsService.getPage(
+        req.session.establishmentName,
+        parseInt(id, 10),
+        parseInt(page || '1', 10),
+      );
       return res.json(data);
     } catch (e) {
       return next(e);
@@ -27,7 +32,10 @@ const createTagRouter = ({ cmsService }) => {
         returnUrl: req.originalUrl,
       };
 
-      const data = await cmsService.getTag(req.session.establishmentName, id);
+      const data = await cmsService.getTag(
+        req.session.establishmentName,
+        parseInt(id, 10),
+      );
 
       const pageType = ['tags', 'series'].includes(data.contentType)
         ? 'tags'

--- a/server/routes/tags.js
+++ b/server/routes/tags.js
@@ -3,6 +3,16 @@ const express = require('express');
 const createTagRouter = ({ cmsService }) => {
   const router = express.Router();
 
+  router.get('/:id.json', async (req, res, next) => {
+    try {
+      const { id } = req.params;
+      const data = await cmsService.getTag(req.session.establishmentName, id);
+      return res.json(data);
+    } catch (e) {
+      return next(e);
+    }
+  });
+
   router.get('/:id', async (req, res, next) => {
     try {
       const { id } = req.params;

--- a/server/services/__tests__/cmsService.spec.js
+++ b/server/services/__tests__/cmsService.spec.js
@@ -622,7 +622,7 @@ describe('cms Service', () => {
         it('returns the series', async () => {
           expect(cmsApi.get).toHaveBeenCalledTimes(1);
           expect(cmsApi.get).toHaveBeenCalledWith(
-            new SeriesPageQuery(ESTABLISHMENT_NAME, uuid),
+            new SeriesPageQuery(ESTABLISHMENT_NAME, uuid, 1),
           );
           expect(result).toBe(populatedSeries);
         });
@@ -644,7 +644,7 @@ describe('cms Service', () => {
         it('returns the series', async () => {
           expect(cmsApi.get).toHaveBeenNthCalledWith(
             1,
-            new SeriesPageQuery(ESTABLISHMENT_NAME, uuid),
+            new SeriesPageQuery(ESTABLISHMENT_NAME, uuid, 1),
           );
           expect(cmsApi.get).toHaveBeenNthCalledWith(
             2,
@@ -802,7 +802,7 @@ describe('cms Service', () => {
         it('returns the series', async () => {
           expect(cmsApi.get).toHaveBeenCalledTimes(1);
           expect(cmsApi.get).toHaveBeenCalledWith(
-            new SeriesPageQuery(ESTABLISHMENT_NAME, uuid),
+            new SeriesPageQuery(ESTABLISHMENT_NAME, uuid, 2),
           );
           expect(result).toBe(populatedSeries);
         });
@@ -824,7 +824,7 @@ describe('cms Service', () => {
         it('returns the series', async () => {
           expect(cmsApi.get).toHaveBeenNthCalledWith(
             1,
-            new SeriesPageQuery(ESTABLISHMENT_NAME, uuid),
+            new SeriesPageQuery(ESTABLISHMENT_NAME, uuid, 2),
           );
           expect(cmsApi.get).toHaveBeenNthCalledWith(
             2,

--- a/server/services/__tests__/cmsService.spec.js
+++ b/server/services/__tests__/cmsService.spec.js
@@ -564,7 +564,7 @@ describe('cms Service', () => {
         it('returns the tag', async () => {
           expect(cmsApi.get).toHaveBeenCalledTimes(1);
           expect(cmsApi.get).toHaveBeenCalledWith(
-            new SecondaryTagPageQuery(ESTABLISHMENT_NAME, uuid),
+            new SecondaryTagPageQuery(ESTABLISHMENT_NAME, uuid, 1),
           );
           expect(result).toBe(populatedSecondaryTag);
         });
@@ -586,7 +586,7 @@ describe('cms Service', () => {
         it('returns the tag', async () => {
           expect(cmsApi.get).toHaveBeenNthCalledWith(
             1,
-            new SecondaryTagPageQuery(ESTABLISHMENT_NAME, uuid),
+            new SecondaryTagPageQuery(ESTABLISHMENT_NAME, uuid, 1),
           );
           expect(cmsApi.get).toHaveBeenNthCalledWith(
             2,
@@ -715,7 +715,126 @@ describe('cms Service', () => {
       });
     });
   });
+  describe('getPage', () => {
+    const TAG_ID = 9;
+    const uuid = 42;
 
+    describe('with a secondary tag', () => {
+      const location = 'https://cms.org/tag/1234';
+      beforeEach(() => {
+        cmsApi.lookupTag.mockResolvedValue({
+          type: 'taxonomy_term--tags',
+          location,
+          uuid,
+        });
+      });
+      describe('which contains related content', () => {
+        let result;
+        const populatedSecondaryTag = { title: 'le name' };
+        beforeEach(async () => {
+          cmsApi.get.mockResolvedValue(populatedSecondaryTag);
+          result = await cmsService.getPage(ESTABLISHMENT_NAME, TAG_ID, 2);
+        });
+        it('looks up the tag', () => {
+          expect(cmsApi.lookupTag).toHaveBeenCalledWith(
+            ESTABLISHMENT_NAME,
+            TAG_ID,
+          );
+        });
+        it('returns the tag', async () => {
+          expect(cmsApi.get).toHaveBeenCalledTimes(1);
+          expect(cmsApi.get).toHaveBeenCalledWith(
+            new SecondaryTagPageQuery(ESTABLISHMENT_NAME, uuid, 2),
+          );
+          expect(result).toBe(populatedSecondaryTag);
+        });
+      });
+      describe('which has no related content', () => {
+        let result;
+        const populatedSecondaryTag = {};
+        beforeEach(async () => {
+          cmsApi.get.mockResolvedValueOnce({});
+          cmsApi.get.mockResolvedValue(populatedSecondaryTag);
+          result = await cmsService.getPage(ESTABLISHMENT_NAME, TAG_ID, 2);
+        });
+        it('looks up the tag', () => {
+          expect(cmsApi.lookupTag).toHaveBeenCalledWith(
+            ESTABLISHMENT_NAME,
+            TAG_ID,
+          );
+        });
+        it('returns the tag', async () => {
+          expect(cmsApi.get).toHaveBeenNthCalledWith(
+            1,
+            new SecondaryTagPageQuery(ESTABLISHMENT_NAME, uuid, 2),
+          );
+          expect(cmsApi.get).toHaveBeenNthCalledWith(
+            2,
+            new SecondaryTagHeaderPageQuery(location),
+          );
+          expect(result).toBe(populatedSecondaryTag);
+        });
+      });
+    });
+
+    describe('with a series', () => {
+      const location = 'https://cms.org/tag/1234';
+      beforeEach(() => {
+        cmsApi.lookupTag.mockResolvedValue({
+          type: 'taxonomy_term--series',
+          location,
+          uuid,
+        });
+      });
+      describe('which contains related content', () => {
+        let result;
+        const populatedSeries = { title: 'le name' };
+        beforeEach(async () => {
+          cmsApi.get.mockResolvedValue(populatedSeries);
+          result = await cmsService.getPage(ESTABLISHMENT_NAME, TAG_ID, 2);
+        });
+        it('looks up the series', () => {
+          expect(cmsApi.lookupTag).toHaveBeenCalledWith(
+            ESTABLISHMENT_NAME,
+            TAG_ID,
+          );
+        });
+        it('returns the series', async () => {
+          expect(cmsApi.get).toHaveBeenCalledTimes(1);
+          expect(cmsApi.get).toHaveBeenCalledWith(
+            new SeriesPageQuery(ESTABLISHMENT_NAME, uuid),
+          );
+          expect(result).toBe(populatedSeries);
+        });
+      });
+      describe('which has no related content', () => {
+        let result;
+        const populatedSeries = {};
+        beforeEach(async () => {
+          cmsApi.get.mockResolvedValueOnce({});
+          cmsApi.get.mockResolvedValue(populatedSeries);
+          result = await cmsService.getPage(ESTABLISHMENT_NAME, TAG_ID, 2);
+        });
+        it('looks up the series', () => {
+          expect(cmsApi.lookupTag).toHaveBeenCalledWith(
+            ESTABLISHMENT_NAME,
+            TAG_ID,
+          );
+        });
+        it('returns the series', async () => {
+          expect(cmsApi.get).toHaveBeenNthCalledWith(
+            1,
+            new SeriesPageQuery(ESTABLISHMENT_NAME, uuid),
+          );
+          expect(cmsApi.get).toHaveBeenNthCalledWith(
+            2,
+            new SeriesHeaderPageQuery(location),
+          );
+          expect(result).toBe(populatedSeries);
+        });
+      });
+    });
+  });
   describe('getExternalLink', () => {
     const EXTERNAL_LINK = 'bob';
     const LOCATION = 'https://cms.org/content/1234';

--- a/server/services/cms.js
+++ b/server/services/cms.js
@@ -39,9 +39,9 @@ class CmsService {
     this.#cmsApi = cmsApi;
   }
 
-  async getSecondaryTag(establishmentName, uuid, location) {
+  async getSecondaryTag(establishmentName, uuid, location, page = 1) {
     const result = await this.#cmsApi.get(
-      new SecondaryTagPageQuery(establishmentName, uuid),
+      new SecondaryTagPageQuery(establishmentName, uuid, page),
     );
     if (result?.title) return result;
     const tagResult = await this.#cmsApi.get(
@@ -90,6 +90,19 @@ class CmsService {
         return this.getSeries(establishmentName, uuid, location);
       case 'taxonomy_term--moj_categories':
         return this.getCategory(establishmentName, uuid);
+      default:
+        throw new Error(`Unknown tag type: ${type} with content id: ${id}`);
+    }
+  }
+
+  async getPage(establishmentName, id, page) {
+    const lookupData = await this.#cmsApi.lookupTag(establishmentName, id);
+    const { type, uuid, location } = lookupData;
+    switch (type) {
+      case 'taxonomy_term--tags':
+        return this.getSecondaryTag(establishmentName, uuid, location, page);
+      case 'taxonomy_term--series':
+        return this.getSeries(establishmentName, uuid, location, page);
       default:
         throw new Error(`Unknown tag type: ${type} with content id: ${id}`);
     }

--- a/server/services/cms.js
+++ b/server/services/cms.js
@@ -50,9 +50,9 @@ class CmsService {
     return tagResult;
   }
 
-  async getSeries(establishmentName, uuid, location) {
+  async getSeries(establishmentName, uuid, location, page = 1) {
     const result = await this.#cmsApi.get(
-      new SeriesPageQuery(establishmentName, uuid),
+      new SeriesPageQuery(establishmentName, uuid, page),
     );
     if (result?.title) return result;
     const tagResult = await this.#cmsApi.get(

--- a/server/utils/__tests__/jsonApi.spec.js
+++ b/server/utils/__tests__/jsonApi.spec.js
@@ -1,4 +1,5 @@
 const {
+  getPagination,
   getLargeImage,
   getLargeTile,
   getSmallTile,
@@ -294,6 +295,83 @@ describe('.typeFrom', () => {
     expect(typeFrom('tags')).toStrictEqual({
       contentType: 'tags',
       externalContent: false,
+    });
+  });
+});
+
+describe('with content tile data', () => {
+  const tileData = {
+    drupalInternal_Nid: 42,
+    type: 'moj_video_item',
+    title: 'title',
+    fieldDisplayUrl: 'link',
+    fieldMojDescription: { summary: 'summary' },
+    fieldMojThumbnailImage: {
+      imageStyleUri: [
+        {
+          tile_small: 'tile_small',
+          tile_large: 'tile_large',
+        },
+      ],
+      resourceIdObjMeta: { alt: 'alt' },
+    },
+    path: { alias: '/content/42' },
+  };
+  describe('getSmallTile', () => {
+    it('should return the small tile data', () => {
+      expect(getSmallTile(tileData)).toEqual({
+        id: 42,
+        contentType: 'video',
+        title: 'title',
+        summary: 'summary',
+        contentUrl: '/content/42',
+        displayUrl: 'link',
+        externalContent: false,
+        image: { url: 'tile_small', alt: 'alt' },
+      });
+    });
+
+    it('PDF website content type opens in a new tab', () => {
+      expect(getSmallTile({ ...tileData, type: 'moj_pdf_item' })).toEqual({
+        id: 42,
+        contentType: 'pdf',
+        title: 'title',
+        summary: 'summary',
+        contentUrl: '/content/42',
+        displayUrl: 'link',
+        externalContent: true,
+        image: { url: 'tile_small', alt: 'alt' },
+      });
+    });
+
+    it(' External website content type opens in a new tab', () => {
+      expect(getSmallTile({ ...tileData, type: 'external_link' })).toEqual({
+        id: 42,
+        contentType: 'external_link',
+        title: 'title',
+        summary: 'summary',
+        contentUrl: '/content/42',
+        displayUrl: 'link',
+        externalContent: true,
+        image: { url: 'tile_small', alt: 'alt' },
+      });
+    });
+  });
+  describe('getPagination', () => {
+    it('should return the correct pagination for page zero', () => {
+      expect(getPagination(0)).toEqual('page[offset]=0&page[limit]=40');
+    });
+
+    it('should return the correct pagination for page one', () => {
+      expect(getPagination(1)).toEqual('page[offset]=0&page[limit]=40');
+    });
+
+    it('should return the correct pagination for page two', () => {
+      expect(getPagination(2)).toEqual('page[offset]=40&page[limit]=40');
+    });
+
+    it('should return the correct pagination for page three', () => {
+      expect(getPagination(3)).toEqual('page[offset]=80&page[limit]=40');
     });
   });
 });

--- a/server/utils/jsonApi.js
+++ b/server/utils/jsonApi.js
@@ -1,3 +1,6 @@
+const getPagination = (page, size = 40) =>
+  `page[offset]=${Math.max(page - 1, 0) * size}&page[limit]=${size}`;
+
 const getImage = (data, type) => {
   if (!data) return null;
   return {
@@ -105,6 +108,7 @@ const typeFrom = type => {
 };
 
 module.exports = {
+  getPagination,
   getSmallTile,
   getLargeTile,
   getLargeImage,

--- a/server/views/components/related-content/related-content.njk
+++ b/server/views/components/related-content/related-content.njk
@@ -1,3 +1,0 @@
-{% from "related-content/macro.njk" import hubRelatatedContent %}
-
-{{ relatedContent() }}

--- a/server/views/components/related-content/template.njk
+++ b/server/views/components/related-content/template.njk
@@ -19,8 +19,7 @@
       <div class="show-more">
         {{ govukButton({
           text: "Show more",
-          id: 'showMore',
-          classes: 'showMoreTiles'
+          classes: 'show-more-tiles govuk-button--secondary'
         }) }}
       </div>
     {% endif %}

--- a/server/views/components/related-content/template.njk
+++ b/server/views/components/related-content/template.njk
@@ -16,7 +16,7 @@
       {% endfor %}
     </div>
     {% if not params.data.isLastPage %}
-      <div>
+      <div class="show-more">
         {{ govukButton({
           text: "Show 40 more",
           id: 'showMore',

--- a/server/views/components/related-content/template.njk
+++ b/server/views/components/related-content/template.njk
@@ -18,7 +18,7 @@
     {% if not params.data.isLastPage %}
       <div class="show-more">
         {{ govukButton({
-          text: "Show 40 more",
+          text: "Show more",
           id: 'showMore',
           classes: 'showMoreTiles'
         }) }}

--- a/server/views/components/related-content/template.njk
+++ b/server/views/components/related-content/template.njk
@@ -1,16 +1,32 @@
 {% from "../content-tile-small/macro.njk" import contentTileSmall %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
-<div data-content-type="{{params.data.contentType}}" data-content-id="{{params.id}}" class="tags-content__four-items">
-  {% for item in params.data.data %}
-    {{ contentTileSmall({
-      id: item.id,
-      title: item.title,
-      contentType: item.contentType,
-      image: item.image,
-      contentUrl: item.contentUrl,
-      displayUrl: item.displayUrl,
-      externalContent: item.externalContent
-    }) }}
-  {% endfor %}
+<div data-content-type="{{params.data.contentType}}" data-content-id="{{params.id}}" >
+
+    <div class="tags-content__four-items {{ 'hidden' if loop.index > 1 }}">
+      {% for item in params.data.data %}
+        {{ contentTileSmall ({
+          id: item.id,
+          title: item.title,
+          contentType: item.contentType,
+          image: item.image,
+          contentUrl: item.contentUrl,
+          displayUrl: item.displayUrl,
+          externalContent: item.externalContent
+        }) }}
+      {% endfor %}
+      <div>
+        {{ govukButton({
+          text: "Show 40 more",
+          id: 'showMore'+loop.index,
+          classes: 'showMoreTiles'
+        }) }}
+
+      </div>
+    </div>
 </div>
-
+<script>
+  $( window ).on( "load", function(){
+    $('.showMoreTiles').click(alert('BOOM!'))
+  });
+</script>

--- a/server/views/components/related-content/template.njk
+++ b/server/views/components/related-content/template.njk
@@ -2,8 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 <div data-content-type="{{params.data.contentType}}" data-content-id="{{params.id}}" >
-
-    <div class="tags-content__four-items {{ 'hidden' if loop.index > 1 }}">
+    <div id="small-tiles" class="tags-content__four-items {{ 'hidden' if loop.index > 1 }}">
       {% for item in params.data.data %}
         {{ contentTileSmall ({
           id: item.id,
@@ -15,18 +14,14 @@
           externalContent: item.externalContent
         }) }}
       {% endfor %}
+    </div>
+    {% if not params.data.isLastPage %}
       <div>
         {{ govukButton({
           text: "Show 40 more",
-          id: 'showMore'+loop.index,
+          id: 'showMore',
           classes: 'showMoreTiles'
         }) }}
       </div>
-    </div>
+    {% endif %}
 </div>
-<script>
-const showMore = document.querySelector('.showMoreTiles');
-showMore.addEventListener('click', event => {
- alert('boom!');
-});
-</script>

--- a/server/views/components/related-content/template.njk
+++ b/server/views/components/related-content/template.njk
@@ -21,12 +21,12 @@
           id: 'showMore'+loop.index,
           classes: 'showMoreTiles'
         }) }}
-
       </div>
     </div>
 </div>
 <script>
-  $( window ).on( "load", function(){
-    $('.showMoreTiles').click(alert('BOOM!'))
-  });
+const showMore = document.querySelector('.showMoreTiles');
+showMore.addEventListener('click', event => {
+ alert('boom!');
+});
 </script>

--- a/server/views/pages/tags.html
+++ b/server/views/pages/tags.html
@@ -69,6 +69,8 @@
     data: data.relatedContent,
     lazyLoadContent: true
   }) }}
+
+
   {% if not data.excludeFeedback %}
     <div class="govuk-form-group govuk-!-margin-bottom-2">
       {% if data.contentType =='series'%}

--- a/server/views/pages/tags.html
+++ b/server/views/pages/tags.html
@@ -93,3 +93,9 @@
     </div>
   {% endif %}
 {% endblock %}
+{% block bodyEnd %}
+<script src="/public/generated/templates.js"></script>
+<script src="/public/nunjucks-slim.js"></script>
+<script src="/public/javascript/showMore.js"></script>
+{% endblock %}
+


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/w9ODRIv3

### Intent

> What changes are introduced by this PR that correspond to the above card?

When showing the full results of a secondary tag or series, paginate them to allow more than 40 results to be shown (the current limit)

> Would this PR benefit from screenshots?

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
