### PR TITLE
Send correct hostname to google analytics

### DIFF
--- a/helm_deploy/prisoner-content-hub-frontend/templates/_envs.tpl
+++ b/helm_deploy/prisoner-content-hub-frontend/templates/_envs.tpl
@@ -93,5 +93,9 @@ env:
         secretKeyRef:
           name: {{ include "prisoner-content-hub-frontend.fullname" . }}
           key: azureAdClientSecret
-
+      
+    - name: SINGLE_HOST_NAME
+    {{- with .Values.ingress.host }}
+      value: {{ tpl .pattern (dict "qualifier" $.Values.ingress.qualifier "Template" $.Template) }}
+    {{- end }}
 {{- end -}}

--- a/server/config.js
+++ b/server/config.js
@@ -1,26 +1,19 @@
-const { getEnv, isProduction } = require('../utils/index');
+const { getEnv, getRequiredEnv, isProduction } = require('../utils/index');
 
-const hubEndpoint = getEnv('HUB_API_ENDPOINT', { requireInProduction: true });
-const hmppsAuthBaseUrl = getEnv('HMPPS_AUTH_BASE_URL', 'https://api.nomis', {
-  requireInProduction: true,
-});
-const elasticsearchEndpoint = getEnv(
+const hubEndpoint = getRequiredEnv('HUB_API_ENDPOINT', 'http://localhost:9090');
+const hmppsAuthBaseUrl = getRequiredEnv(
+  'HMPPS_AUTH_BASE_URL',
+  'https://api.nomis',
+);
+const elasticsearchEndpoint = getRequiredEnv(
   'ELASTICSEARCH_ENDPOINT',
   'http://localhost:9200',
-  {
-    requireInProduction: true,
-  },
 );
-const elasticsearchIndexName = getEnv(
+const elasticsearchIndexName = getRequiredEnv(
   'ELASTICSEARCH_INDEX_NAME',
   'content_index',
-  {
-    requireInProduction: true,
-  },
 );
-const drupalDatabaseName = getEnv('DRUPAL_DATABASE_NAME', 'hubdb', {
-  requireInProduction: true,
-});
+const drupalDatabaseName = getRequiredEnv('DRUPAL_DATABASE_NAME', 'hubdb');
 
 module.exports = {
   isProduction,
@@ -30,11 +23,10 @@ module.exports = {
     gitDate: getEnv('GIT_DATE', '2020-06-21 12:12:12'),
   },
   cookieSecret: getEnv('COOKIE_SECRET', 'keyboard cat'),
+  singleHostName: getRequiredEnv('SINGLE_HOST_NAME', 'localhost'),
   auth: {
-    clientId: getEnv('AZURE_AD_CLIENT_ID', { requireInProduction: true }),
-    clientSecret: getEnv('AZURE_AD_CLIENT_SECRET', {
-      requireInProduction: true,
-    }),
+    clientId: getRequiredEnv('AZURE_AD_CLIENT_ID', 'client-1'),
+    clientSecret: getRequiredEnv('AZURE_AD_CLIENT_SECRET', 'secret-1'),
     callbackPath: '/auth/provider/callback',
   },
   api: {
@@ -47,7 +39,7 @@ module.exports = {
     tags: `${hubEndpoint}/v1/api/vocabulary/tags`,
   },
   caching: {
-    secret: getEnv('CACHE_SECRET', { requireInProduction: true }),
+    secret: getRequiredEnv('CACHE_SECRET', 'secret-2'),
     redis: {
       host: getEnv('REDIS_HOST', '127.0.0.1'),
       port: getEnv('REDIS_PORT', 6379),
@@ -61,9 +53,7 @@ module.exports = {
       clientSecret: getEnv('HMPPS_AUTH_CLIENT_SECRET', 'UNSET'),
       authUrl: `${hmppsAuthBaseUrl}/oauth/token?grant_type=client_credentials`,
     },
-    baseUrl: getEnv('PRISON_API_BASE_URL', 'https://api.nomis', {
-      requireInProduction: true,
-    }),
+    baseUrl: getRequiredEnv('PRISON_API_BASE_URL', 'https://api.nomis'),
   },
   elasticsearch: {
     search: `${elasticsearchEndpoint}/elasticsearch_index_${drupalDatabaseName}_${elasticsearchIndexName}/_search`,
@@ -82,10 +72,9 @@ module.exports = {
     siteId: getEnv('ANALYTICS_SITE_ID', 'UA-152065860-4'),
   },
   feedback: {
-    endpoint: getEnv(
+    endpoint: getRequiredEnv(
       'FEEDBACK_URL',
       'http://localhost:9200/local-feedback/_doc',
-      { requireInProduction: true },
     ),
   },
   npr: {

--- a/server/routes/__tests__/analytics.spec.js
+++ b/server/routes/__tests__/analytics.spec.js
@@ -1,0 +1,86 @@
+const request = require('supertest');
+
+jest.mock('@sentry/node');
+
+const { createAnalyticsRouter } = require('../analytics');
+const { setupBasicApp } = require('../../../test/test-helpers');
+const config = require('../../config');
+
+describe('analytics', () => {
+  describe('POST /page', () => {
+    describe('on error', () => {
+      beforeEach(() => {
+        config.singleHostName = 'localhost';
+        jest.clearAllMocks();
+      });
+
+      it('passes caught exceptions to next', async () => {
+        const analyticsService = {
+          sendPageTrack: jest.fn().mockRejectedValue('💥'),
+        };
+        const router = createAnalyticsRouter({ analyticsService });
+        const app = setupBasicApp();
+
+        app.use('/analytics', router);
+
+        await request(app).post('/analytics/page').expect(500);
+      });
+    });
+
+    describe('on success', () => {
+      const getSessionMiddleware = (req, res, next) => {
+        req.session = {
+          establishmentId: 123,
+          establishmentName: 'berwyn',
+          id: 'abc123',
+        };
+        next();
+      };
+
+      let app;
+      let router;
+      const analyticsService = {
+        sendPageTrack: jest.fn().mockResolvedValue({}),
+      };
+
+      beforeEach(() => {
+        router = createAnalyticsRouter({ analyticsService });
+        app = setupBasicApp();
+      });
+
+      it('raises page track', () => {
+        app.use(getSessionMiddleware);
+        app.use('/analytics/', router);
+        return request(app)
+          .post('/analytics/page')
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json')
+          .send({
+            page: '/content/12114',
+            title: 'D&amp;I Wayland | Sam Plays Joplin',
+            userAgent: 'Mozilla/5.0',
+            screen: '1680x1050',
+            viewport: '1680x882',
+            categories: 'Informational',
+            secondaryTags: 'Black lives',
+            series: 'Diversity and Inclusion',
+          })
+          .expect(200)
+          .expect(() => {
+            expect(analyticsService.sendPageTrack).toHaveBeenCalledWith({
+              categories: 'Informational',
+              hostname: 'berwyn.localhost',
+              page: '/content/12114',
+              screen: '1680x1050',
+              secondaryTags: 'Black lives',
+              series: 'Diversity and Inclusion',
+              sessionId: 'abc123',
+              title: 'D&amp;I Wayland | Sam Plays Joplin',
+              userAgent: 'Mozilla/5.0',
+              viewport: '1680x882',
+            });
+          });
+      });
+    });
+  });
+});

--- a/server/routes/analytics.js
+++ b/server/routes/analytics.js
@@ -1,5 +1,6 @@
 const { path } = require('ramda');
 const express = require('express');
+const config = require('../config');
 
 const createAnalyticsRouter = ({ analyticsService }) => {
   const router = express.Router();
@@ -20,10 +21,11 @@ const createAnalyticsRouter = ({ analyticsService }) => {
   });
 
   router.post('/page', (req, res) => {
-    const sessionId = path(['session', 'id'], req);
+    const sessionId = req.session.id;
+    const hostname = `${req.session.establishmentName}.${config.singleHostName}`;
 
     analyticsService.sendPageTrack({
-      hostname: path(['body', 'hostname'], req),
+      hostname,
       page: path(['body', 'page'], req),
       title: path(['body', 'title'], req),
       sessionId,

--- a/server/views/components/template.njk
+++ b/server/views/components/template.njk
@@ -146,7 +146,6 @@
     {% block analytics %}
       <script>
         sendPageTrack({
-          hostname: document.location.hostname,
           page: document.location.pathname + document.location.search,
           title: "{{title}}",
           userAgent: navigator.userAgent,

--- a/server/views/pages/externalLink.html
+++ b/server/views/pages/externalLink.html
@@ -90,7 +90,6 @@
         <script src="/public/javascript/all.js"></script>
         <script>
           sendPageTrack({
-            hostname: document.location.hostname,
             page: document.location.pathname + document.location.search,
             title: "External Link",
             userAgent: navigator.userAgent,

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -4,6 +4,8 @@ const nunjucksSetup = require('../server/utils/nunjucksSetup');
 function setupBasicApp(config = {}) {
   const app = express();
   app.set('view engine', 'html');
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: true }));
 
   nunjucksSetup(app);
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -28,6 +28,9 @@ const getEnv = (name, fallback, options = {}) => {
   throw new Error(`Missing env var ${name}`);
 };
 
+const getRequiredEnv = (name, fallback) =>
+  getEnv(name, fallback, { requireInProduction: true });
+
 const getEnvironmentVariableOrThrow = name => {
   if (process.env[name]) {
     return process.env[name];
@@ -39,5 +42,6 @@ module.exports = {
   isProduction: production,
   recordBuildInfoTo,
   getEnv,
+  getRequiredEnv,
   getEnvironmentVariableOrThrow,
 };


### PR DESCRIPTION
Fix case when single url is used

### Context

https://trello.com/c/j68vCqlK

When we are using the single prison agnostic url we still want to be able to track per establishment usage via google analytics.

### Intent

This builds up the url based on the session derived establishment id and the single host url. 

### Considerations

URL pattern differs between dev/staging and prod: `-` vs `.` separated.

This doesn't take that into account so will start to report different urls in dev and staging.
I don't think this matters but need to check

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
