### PR TITLE
Fix detecting establishment name when developing locally

### DIFF
--- a/server/middleware/__tests__/getEstablishmentFromUrl.spec.js
+++ b/server/middleware/__tests__/getEstablishmentFromUrl.spec.js
@@ -30,6 +30,15 @@ describe('getEstablishmentFromUrl', () => {
   describe('for localhost urls', () => {
     getTests('development', 'cookhamwood.localhost:3000', 'localhost:3000');
   });
+
+  describe('for local urls', () => {
+    getTests(
+      'local',
+      'cookhamwood.prisoner-content-hub.local:3000',
+      'localhost:3000',
+    );
+  });
+
   describe('for development urls', () => {
     getTests(
       'development',

--- a/server/middleware/getEstablishmentFromUrl.js
+++ b/server/middleware/getEstablishmentFromUrl.js
@@ -1,7 +1,7 @@
 module.exports = (req, _res, next) => {
   if (!req.session?.establishmentName) {
     const matchEstablishment =
-      /^[A-Z,a-z]{1,20}(?=(\.localhost|-prisoner-content-hub|\.content-hub))/;
+      /^[A-Z,a-z]{1,20}(?=(\.localhost|-prisoner-content-hub|\.content-hub|\.prisoner-content-hub.local))/;
 
     const [establishmentName] = req.headers?.host.match(matchEstablishment) || [
       '',


### PR DESCRIPTION
### Context

Nope, small fix for when developing locally

### Intent

When developing locally some developers use the following in /etc/hosts file:
`cookhamwood.prisoner-content-hub.local`

rather than

`cookhamwood.localhost`

and the service cannot determine which establishment the user is trying to access. This fixes that

### Considerations

existing behaviour for other environments should be maintained

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
