### PR TITLE
bug/feedback_missing_on_white_bg

### DIFF
--- a/assets/sass/_general.scss
+++ b/assets/sass/_general.scss
@@ -17,15 +17,15 @@
   text-underline-offset: 2px;
 }
 
-.govuk-hub-comment .govuk-body,
-.govuk-hub-comment .govuk-body a,
-.govuk-hub-comment .govuk-heading-m,
-.govuk-hub-comment .govuk-hint {
-  color: govuk-colour('white');
-}
-
 .govuk-hub-comment__sidebar .govuk-hint {
   color: govuk-colour('black');
+}
+
+.govuk-hub-tags-feedback .govuk-body,
+.govuk-hub-tags-feedback .govuk-body a,
+.govuk-hub-tags-feedback .govuk-heading-m,
+.govuk-hub-tags-feedback .govuk-hint {
+  color: govuk-colour('white');
 }
 
 .govuk-hub-comment-counter {
@@ -48,7 +48,7 @@
   border: 0;
 }
 
-.govuk-hub-thumbs--up {
+.govuk-hub-tags-feedback .govuk-hub-thumbs--up {
   background-image: url('/public/images/icon-thumbs/thumbs-up-white.svg');
   background-color: transparent;
 }
@@ -57,7 +57,7 @@
   background-image: url('/public/images/icon-thumbs/thumbs-up-black.svg');
 }
 
-.govuk-hub-thumbs--down {
+.govuk-hub-tags-feedback .govuk-hub-thumbs--down {
   background-image: url('/public/images/icon-thumbs/thumbs-down-white.svg');
   background-color: transparent;
   margin-top: 12px;
@@ -98,12 +98,14 @@
   margin-top: govuk-spacing(4);
 }
 
-.govuk-hub-comment__sidebar .govuk-hub-thumbs--up {
+.govuk-hub-thumbs--up {
   background-image: url('/public/images/icon-thumbs/thumbs-up-grey.svg');
+  background-color: transparent;
 }
 
-.govuk-hub-comment__sidebar .govuk-hub-thumbs--down {
+.govuk-hub-thumbs--down {
   background-image: url('/public/images/icon-thumbs/thumbs-down-grey.svg');
+  background-color: transparent;
 }
 
 .govuk-hub-thumbs--down.is-selected {

--- a/server/views/pages/tags.html
+++ b/server/views/pages/tags.html
@@ -72,7 +72,7 @@
 
 
   {% if not data.excludeFeedback %}
-    <div class="govuk-form-group govuk-hub-article-feedback">
+    <div class="govuk-form-group govuk-hub-article-feedback govuk-hub-tags-feedback">
       {% set tagHeading %}
         Tell us what you think about this {{'series' if data.contentType == 'series' else 'topic'}}:
       {% endset %}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/XklaKEdv/597-feedback-bug-games-pages-not-displaying-feedback-widget-correctly

> If this is an issue, do we have steps to reproduce?
navigate to a games page

### Intent

> What changes are introduced by this PR that correspond to the above card?
css colours applied to correct pages

> Would this PR benefit from screenshots?
yeah

### Considerations

> Is there any additional information that would help when reviewing this PR?
n/a

> Are there any steps required when merging/deploying this PR?
n/a

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
