### PR TITLE
bug/feedback_audio_video_page_fix

### DIFF
--- a/assets/sass/_general.scss
+++ b/assets/sass/_general.scss
@@ -17,14 +17,15 @@
   text-underline-offset: 2px;
 }
 
-.govuk-hub-comment__sidebar .govuk-hint {
+.govuk-hub-comment__sidebar .govuk-hint,
+.govuk-hub-comment .govuk-hint {
   color: govuk-colour('black');
 }
 
-.govuk-hub-tags-feedback .govuk-body,
-.govuk-hub-tags-feedback .govuk-body a,
-.govuk-hub-tags-feedback .govuk-heading-m,
-.govuk-hub-tags-feedback .govuk-hint {
+.govuk-hub-on-black-feedback .govuk-body,
+.govuk-hub-on-black-feedback .govuk-body a,
+.govuk-hub-on-black-feedback .govuk-heading-m,
+.govuk-hub-on-black-feedback .govuk-hint {
   color: govuk-colour('white');
 }
 
@@ -48,7 +49,7 @@
   border: 0;
 }
 
-.govuk-hub-tags-feedback .govuk-hub-thumbs--up {
+.govuk-hub-on-black-feedback .govuk-hub-thumbs--up {
   background-image: url('/public/images/icon-thumbs/thumbs-up-white.svg');
   background-color: transparent;
 }
@@ -57,7 +58,7 @@
   background-image: url('/public/images/icon-thumbs/thumbs-up-black.svg');
 }
 
-.govuk-hub-tags-feedback .govuk-hub-thumbs--down {
+.govuk-hub-on-black-feedback .govuk-hub-thumbs--down {
   background-image: url('/public/images/icon-thumbs/thumbs-down-white.svg');
   background-color: transparent;
   margin-top: 12px;

--- a/server/views/pages/audio.html
+++ b/server/views/pages/audio.html
@@ -80,16 +80,18 @@
       <source src="{{ data.media }}" type="audio/mp3"/>
     </audio>
       {% if not data.excludeFeedback %}
-        {{ hubFeedbackWidget({
-          heading: '',
-          contentId: data.id,
-          title: data.title,
-          contentType: data.contentType,
-          series: data.seriesName,
-          feedbackId: feedbackId,
-          categories: data.categories,
-          secondaryTags: data.secondaryTags | join(',', 'id')
-        }) }}
+        <div class="govuk-hub-on-black-feedback">
+          {{ hubFeedbackWidget({
+            heading: '',
+            contentId: data.id,
+            title: data.title,
+            contentType: data.contentType,
+            series: data.seriesName,
+            feedbackId: feedbackId,
+            categories: data.categories,
+            secondaryTags: data.secondaryTags | join(',', 'id')
+          }) }}
+        </div>
       {% endif %}
     <div class="govuk-hub-media-player__description">
       <div id="body" class="govuk-body">{{ data.description | safe }}</div>

--- a/server/views/pages/tags.html
+++ b/server/views/pages/tags.html
@@ -72,7 +72,7 @@
 
 
   {% if not data.excludeFeedback %}
-    <div class="govuk-form-group govuk-hub-article-feedback govuk-hub-tags-feedback">
+    <div class="govuk-form-group govuk-hub-article-feedback govuk-hub-on-black-feedback">
       {% set tagHeading %}
         Tell us what you think about this {{'series' if data.contentType == 'series' else 'topic'}}:
       {% endset %}

--- a/server/views/pages/video.html
+++ b/server/views/pages/video.html
@@ -78,16 +78,18 @@
         <source src="{{ data.media }}" type="video/mp4"/>
       </video>
         {% if not data.excludeFeedback %}
-          {{ hubFeedbackWidget({
-            contentId: data.id,
-            title: data.title,
-            heading: '',
-            contentType: data.contentType,
-            series: data.seriesName,
-            feedbackId: feedbackId,
-            categories: data.categories,
-            secondaryTags: data.secondaryTags | join(',', 'id')
-          })}}
+          <div class="govuk-hub-on-black-feedback">
+            {{ hubFeedbackWidget({
+              contentId: data.id,
+              title: data.title,
+              heading: '',
+              contentType: data.contentType,
+              series: data.seriesName,
+              feedbackId: feedbackId,
+              categories: data.categories,
+              secondaryTags: data.secondaryTags | join(',', 'id')
+            })}}
+          </div>
         {% endif %}
     </div>
 


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
Feedback bug - games pages not displaying feedback widget correctly

> If this is an issue, do we have steps to reproduce?
navigate to audio or video pages

### Intent

> What changes are introduced by this PR that correspond to the above card?
black on white thumbs up

> Would this PR benefit from screenshots?
<img width="1253" alt="Screenshot 2022-01-18 at 10 32 17" src="https://user-images.githubusercontent.com/50403492/149920583-25ae3804-9aad-494a-8b11-cfe41e711b1c.png">
<img width="972" alt="Screenshot 2022-01-18 at 10 30 33" src="https://user-images.githubusercontent.com/50403492/149920589-732baee1-95a6-425c-8647-82874d238a73.png">
<img width="972" alt="Screenshot 2022-01-18 at 10 31 19" src="https://user-images.githubusercontent.com/50403492/149920598-e482db9e-b66c-44ef-a365-980d8bff4a79.png">
<img width="1253" alt="Screenshot 2022-01-18 at 10 31 53" src="https://user-images.githubusercontent.com/50403492/149920602-f7d43e3c-8d01-46e6-99f3-8ce7ea62e6a2.png">


### Considerations

> Is there any additional information that would help when reviewing this PR?
n/a

> Are there any steps required when merging/deploying this PR?
n/a

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
