### PR TITLE
Removing health endpoints from request logging

### DIFF
--- a/server/utils/azureAppInsights.js
+++ b/server/utils/azureAppInsights.js
@@ -7,7 +7,7 @@ const { setup, DistributedTracingModes, Contracts } = appInsights;
 const defaultName = () => applicationVersion?.packageData?.name;
 const version = () => applicationVersion.buildNumber;
 
-const prefixesToIgnore = ['GET /public/', 'GET /assets/'];
+const prefixesToIgnore = ['GET /public/', 'GET /assets/', 'GET /health'];
 
 function ignoreStaticAssetsProcessor(envelope) {
   if (envelope.data.baseType === Contracts.TelemetryTypeString.Request) {


### PR DESCRIPTION
### Context

Logging lots of health requests, 230  in 5 minutes. 

This will remove them 