### PR TITLE
bug/category_empty_highlight_and_content_images

### DIFF
--- a/assets/sass/_general.scss
+++ b/assets/sass/_general.scss
@@ -17,7 +17,6 @@
   text-underline-offset: 2px;
 }
 
-.govuk-hub-comment__sidebar .govuk-hint,
 .govuk-hub-comment .govuk-hint {
   color: govuk-colour('black');
 }
@@ -78,6 +77,10 @@
 }
 
 .govuk-hub-comment-form__footer::after,
+.govuk-hub-feedback-padding {
+  padding-top: govuk-spacing(5);
+}
+
 .govuk-hub-feedback::after {
   content: '';
   display: table;

--- a/server/repositories/cmsQueries/categoryOtherQuery.js
+++ b/server/repositories/cmsQueries/categoryOtherQuery.js
@@ -19,6 +19,7 @@ class CategoryOtherQuery {
       .addFields('node--moj_video_item', CategoryOtherQuery.#TILE_FIELDS)
       .addFields('node--moj_radio_item', CategoryOtherQuery.#TILE_FIELDS)
       .addFields('moj_pdf_item', CategoryOtherQuery.#TILE_FIELDS)
+      .addInclude(['field_moj_thumbnail_image'])
       .getQueryString();
     this.query = `${queryWithoutOffset}&${getPagination(page, limit)}`;
   }

--- a/server/views/components/feedback-widget/template.njk
+++ b/server/views/components/feedback-widget/template.njk
@@ -6,14 +6,11 @@
       data-item-tags="{{params.secondaryTags}}"
       data-item-categories="{{params.categories}}"
       data-item-feedback-id="{{params.feedbackId}}"
-      class="{{ 'govuk-!-padding-top-2 govuk-hub-comment__sidebar' if params.sidebar else 'govuk-!-padding-top-5 govuk-hub-comment' }}"
+      class="govuk-hub-feedback-padding govuk-hub-comment {{params.classes}}"
   >
-  {% set headingClass %}
-    {{ 'govuk-heading-m' if params.sidebar else 'govuk-body' }}
-  {% endset %}
   <div class="govuk-hub-feedback-ui">
     {% if params.heading != '' %}
-      <h3 class="{{ headingClass }} govuk-hub-feedback-heading">{{ params.heading|default('Give us feedback') }}</h3>
+      <h3 class="govuk-body govuk-hub-feedback-heading">{{ params.heading|default('Give us feedback') }}</h3>
     {% endif %}
     <div class="govuk-hub-feedback">
       <button data-feedback-sentiment
@@ -48,7 +45,7 @@
     </form>
   </div>
   <div class="govuk-hub-feedback-confirmation govuk-u-hidden">
-    <h3 class="{{ headingClass }} govuk-!-font-weight-bold">Thanks for your feedback</h3>
+    <h3 class="govuk-body govuk-!-font-weight-bold">Thanks for your feedback</h3>
     <p class="govuk-body">
       You can read more about what we do with it <a href="{{ knownPages.feedback }}" class="{{ 'govuk-link' if params.sidebar }}">here</a>.
     </p>

--- a/server/views/pages/tagsCategories.html
+++ b/server/views/pages/tagsCategories.html
@@ -49,15 +49,17 @@
 {% endblock %}
 {% block content %}
   <div class="govuk-body">
-    <section class="govuk-!-margin-bottom-9">
-      <h2 class="govuk-heading-l govuk-hub-white-heading">Highlights</h2>
-      {{ hubRelatedContent({
-        data: { contentType:"default",isLastPage:true, data:data.categoryFeaturedContent },
-        lazyLoadContent: true
-      }) }}
-    </section>
-    {% if data.categorySeries.data.length > 0 %}
+    {% if data.categoryFeaturedContent.length > 0 %}
+      <section class="govuk-!-margin-bottom-9">
+        <h2 class="govuk-heading-l govuk-hub-white-heading">Highlights</h2>
+        {{ hubRelatedContent({
+          data: { contentType:"default",isLastPage:true, data:data.categoryFeaturedContent },
+          lazyLoadContent: true
+        }) }}
+      </section>
       <hr>
+    {% endif %}
+    {% if data.categorySeries.data.length > 0 %}
       <section id="seriesTiles"class="govuk-!-margin-bottom-9 govuk-!-margin-top-5">
         <h2 class="govuk-heading-l  govuk-hub-white-heading">All series</h2>
         {{ hubRelatedContent({
@@ -65,22 +67,23 @@
           lazyLoadContent: true
         }) }}
       </section>
+      <hr>
     {% endif %}
     {% if data.categoryOther.data.length > 0 %}
-      <hr>
       <section id="otherContentTiles" class="govuk-!-margin-bottom-9 govuk-!-margin-top-5">
-        <h2 class="govuk-heading-l  govuk-hub-white-heading">Other</h2>
+        <h2 class="govuk-heading-l  govuk-hub-white-heading">Content</h2>
         {{ hubRelatedContent({
           data: { contentType:data.categoryOther.contentType ,isLastPage:data.categoryOther.isLastPage, data:data.categoryOther.data },
           lazyLoadContent: true
         }) }}
       </section>
+      <hr>
     {% endif %}
   </div>
 
   
   {% if not data.excludeFeedback %}
-    <div class="govuk-form-group govuk-hub-article-feedback govuk-hub-on-black-feedback">
+    <div class="govuk-form-group govuk-hub-on-black-feedback">
       {% set tagHeading %}
         Tell us what you think about this {{'series' if data.contentType == 'series' else 'topic'}}:
       {% endset %}
@@ -93,7 +96,8 @@
         series: title,
         feedbackId: feedbackId,
         series: title if data.contentType == 'series',
-        secondaryTags: title if data.contentType == 'tags'
+        secondaryTags: title if data.contentType == 'tags',
+        classes: 'govuk-!-padding-top-0'
       })}}
     </div>
   {% endif %}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/8B2Ygfag/567-show-all-content-in-a-category-and-paginate-it

> If this is an issue, do we have steps to reproduce?

navigate to a category with content and no highlights.
https://wayland.content-hub.prisoner.service.justice.gov.uk/tags/787

### Intent

> What changes are introduced by this PR that correspond to the above card?

Various bug fixes

> Would this PR benefit from screenshots?

<img width="833" alt="Screenshot 2022-02-24 at 00 50 48" src="https://user-images.githubusercontent.com/50403492/155435976-b8cd367e-446c-4cd8-a46f-12f9964020f5.png">

### Considerations

> Is there any additional information that would help when reviewing this PR?
n/a

> Are there any steps required when merging/deploying this PR?
n/a

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
