### PR TITLE
feature/breadcrumbs

### DIFF
--- a/server/repositories/cmsQueries/__tests__/audioPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/audioPageQuery.spec.js
@@ -5,7 +5,7 @@ describe('Audio page query', () => {
   describe('url', () => {
     it('should create correct path', async () => {
       expect(query.url()).toStrictEqual(
-        'https://cms/content/1234?include=field_moj_thumbnail_image%2Cfield_moj_series%2Cfield_moj_audio%2Cfield_moj_secondary_tags%2Cfield_moj_top_level_categories&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Ccreated%2Cfield_moj_audio%2Cfield_moj_description%2Cfield_moj_secondary_tags%2Cfield_moj_series%2Cfield_moj_season%2Cfield_moj_episode%2Cfield_moj_top_level_categories%2Cfield_moj_thumbnail_image%2Cfield_moj_programme_code%2Cseries_sort_value%2Cfield_exclude_feedback&fields%5Bfile--file%5D=uri%2Cimage_style_uri&fields%5Btaxonomy_term--series%5D=drupal_internal__tid%2Cname%2Cpath&fields%5Btaxonomy_term--tags%5D=drupal_internal__tid%2Cname%2Cpath&fields%5Btaxonomy_term--moj_categories%5D=drupal_internal__tid%2Cname',
+        'https://cms/content/1234?include=field_moj_thumbnail_image%2Cfield_moj_series%2Cfield_moj_audio%2Cfield_moj_secondary_tags%2Cfield_moj_top_level_categories&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Ccreated%2Cfield_moj_audio%2Cfield_moj_description%2Cfield_moj_secondary_tags%2Cfield_moj_series%2Cfield_moj_season%2Cfield_moj_episode%2Cfield_moj_top_level_categories%2Cfield_moj_thumbnail_image%2Cfield_moj_programme_code%2Cseries_sort_value%2Cfield_exclude_feedback%2Cbreadcrumbs&fields%5Bfile--file%5D=uri%2Cimage_style_uri&fields%5Btaxonomy_term--series%5D=drupal_internal__tid%2Cname%2Cpath&fields%5Btaxonomy_term--tags%5D=drupal_internal__tid%2Cname%2Cpath&fields%5Btaxonomy_term--moj_categories%5D=drupal_internal__tid%2Cname',
       );
     });
   });
@@ -24,6 +24,11 @@ describe('Audio page query', () => {
         fieldMojProgrammeCode: 'FAITH138',
         fieldMojSeason: 1,
         seriesSortValue: 1001,
+
+        breadcrumbs: [
+          { uri: 'parent1Url', title: 'parent1' },
+          { uri: 'parent2Url', title: 'parent2' },
+        ],
 
         fieldMojAudio: {
           type: 'file--file',
@@ -92,6 +97,11 @@ describe('Audio page query', () => {
           uuid: '8d9eaf09-a53e-42d9-a7be-2a2f04a0f315',
           name: 'steve',
         },
+        breadcrumbs: [
+          { href: 'parent1Url', text: 'parent1' },
+          { href: 'parent2Url', text: 'parent2' },
+          { href: '', text: 'Buddhist reflection: 29 July' },
+        ],
         contentType: 'radio',
         created: '2020-01-03T01:02:30',
         description: 'Education content for prisoners',

--- a/server/repositories/cmsQueries/__tests__/basicPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/basicPageQuery.spec.js
@@ -5,7 +5,7 @@ describe('Basic page query', () => {
   describe('url', () => {
     it('should create correct path', async () => {
       expect(query.url()).toStrictEqual(
-        'https://cms/content/1234?include=field_moj_secondary_tags%2Cfield_moj_top_level_categories&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Ccreated%2Cfield_moj_description%2Cfield_moj_stand_first%2Cfield_moj_secondary_tags%2Cfield_moj_series%2Cfield_moj_top_level_categories%2Cfield_exclude_feedback&fields%5Btaxonomy_term--tags%5D=drupal_internal__tid%2Cname&fields%5Btaxonomy_term--moj_categories%5D=drupal_internal__tid%2Cname',
+        'https://cms/content/1234?include=field_moj_secondary_tags%2Cfield_moj_top_level_categories&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Ccreated%2Cfield_moj_description%2Cfield_moj_stand_first%2Cfield_moj_secondary_tags%2Cfield_moj_series%2Cfield_moj_top_level_categories%2Cfield_exclude_feedback%2Cbreadcrumbs&fields%5Btaxonomy_term--tags%5D=drupal_internal__tid%2Cname&fields%5Btaxonomy_term--moj_categories%5D=drupal_internal__tid%2Cname',
       );
     });
   });
@@ -16,6 +16,7 @@ describe('Basic page query', () => {
         drupalInternal_Nid: 5923,
         title: 'Novus',
         type: 'node--node--page',
+        breadcrumbs: [{ uri: 'parent1Url', title: 'parent1' }],
         created: '2020-01-03T01:02:30',
         fieldMojDescription: { processed: 'Education content for prisoners' },
         fieldExcludeFeedback: true,
@@ -35,6 +36,10 @@ describe('Basic page query', () => {
         title: 'Novus',
         created: '2020-01-03T01:02:30',
         contentType: 'page',
+        breadcrumbs: [
+          { href: 'parent1Url', text: 'parent1' },
+          { href: '', text: 'Novus' },
+        ],
         description: 'Education content for prisoners',
         excludeFeedback: true,
         standFirst: 'Education',
@@ -49,6 +54,7 @@ describe('Basic page query', () => {
         created: '2020-01-03T01:02:30',
         title: 'Novus',
         type: 'node--node--page',
+        breadcrumbs: [{ uri: 'parent1Url', title: 'parent1' }],
         fieldExcludeFeedback: true,
         fieldMojStandFirst: 'Education',
         fieldMojTopLevelCategories: {
@@ -66,6 +72,10 @@ describe('Basic page query', () => {
         created: '2020-01-03T01:02:30',
         title: 'Novus',
         contentType: 'page',
+        breadcrumbs: [
+          { href: 'parent1Url', text: 'parent1' },
+          { href: '', text: 'Novus' },
+        ],
         description: undefined,
         excludeFeedback: true,
         standFirst: 'Education',

--- a/server/repositories/cmsQueries/__tests__/secondaryTagPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/secondaryTagPageQuery.spec.js
@@ -8,7 +8,7 @@ describe('Secondary Tag page query', () => {
   describe('path', () => {
     it('should create correct path', async () => {
       expect(query.path()).toStrictEqual(
-        `/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Bfield_moj_secondary_tags.id%5D=${UUID}&include=field_moj_thumbnail_image%2Cfield_moj_secondary_tags.field_featured_image&sort=-created&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bnode--moj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bfile--file%5D=image_style_uri&fields%5Btaxonomy_term--tags%5D=name%2Cdescription%2Cdrupal_internal__tid%2Cfield_featured_image%2Cpath%2Cfield_exclude_feedback&${getPagination(
+        `/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Bfield_moj_secondary_tags.id%5D=${UUID}&include=field_moj_thumbnail_image%2Cfield_moj_secondary_tags.field_featured_image&sort=-created&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bnode--moj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_secondary_tags%2Cpath&fields%5Bfile--file%5D=image_style_uri&fields%5Btaxonomy_term--tags%5D=name%2Cdescription%2Cdrupal_internal__tid%2Cfield_featured_image%2Cpath%2Cfield_exclude_feedback%2Cbreadcrumbs&${getPagination(
           10,
         )}`,
       );
@@ -19,6 +19,7 @@ describe('Secondary Tag page query', () => {
     const createSecondaryTag = id => ({
       id,
       type: 'taxonomy_term--tags',
+      breadcrumbs: [{ uri: 'parent1Url', title: 'parent1' }],
       drupalInternal_Tid: `100${id}`,
       name: `name${id}`,
       description: { processed: `description${id}` },
@@ -52,6 +53,10 @@ describe('Secondary Tag page query', () => {
         url: `tile_large${id}`,
         alt: `alt${id}`,
       },
+      breadcrumbs: [
+        { href: 'parent1Url', text: 'parent1' },
+        { href: '', text: `name${id}` },
+      ],
       displayUrl: undefined,
       excludeFeedback: true,
       externalContent: false,

--- a/server/repositories/cmsQueries/__tests__/seriesPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/seriesPageQuery.spec.js
@@ -8,7 +8,7 @@ describe('Series page query', () => {
   describe('path', () => {
     it('should create correct path', async () => {
       expect(query.path()).toStrictEqual(
-        `/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Bfield_moj_series.id%5D=${UUID}&include=field_moj_thumbnail_image%2Cfield_moj_series.field_featured_image&sort=series_sort_value%2Ccreated&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bnode--moj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bfile--file%5D=image_style_uri&fields%5Btaxonomy_term--series%5D=name%2Cdescription%2Cdrupal_internal__tid%2Cfield_featured_image%2Cpath%2Cfield_exclude_feedback&${getPagination(
+        `/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Bfield_moj_series.id%5D=${UUID}&include=field_moj_thumbnail_image%2Cfield_moj_series.field_featured_image&sort=series_sort_value%2Ccreated&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bnode--moj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cfield_moj_series%2Cpath&fields%5Bfile--file%5D=image_style_uri&fields%5Btaxonomy_term--series%5D=name%2Cdescription%2Cdrupal_internal__tid%2Cfield_featured_image%2Cpath%2Cfield_exclude_feedback%2Cbreadcrumbs&${getPagination(
           2,
         )}`,
       );
@@ -21,6 +21,7 @@ describe('Series page query', () => {
       drupalInternal_Tid: `100${UUID}`,
       name: `name${UUID}`,
       type: 'taxonomy_term--series',
+      breadcrumbs: [{ uri: 'parent1Url', title: 'parent1' }],
       description: { processed: `description${UUID}` },
       fieldExcludeFeedback: undefined,
       fieldFeaturedImage: {
@@ -66,6 +67,10 @@ describe('Series page query', () => {
       expect(query.transform(response, { next: 'URL' })).toStrictEqual({
         id: `100${UUID}`,
         contentType: 'series',
+        breadcrumbs: [
+          { href: 'parent1Url', text: 'parent1' },
+          { href: '', text: `name${UUID}` },
+        ],
         title: `name${UUID}`,
         summary: `description${UUID}`,
         image: {
@@ -94,6 +99,10 @@ describe('Series page query', () => {
       expect(query.transform(response, {})).toStrictEqual({
         id: `100${UUID}`,
         contentType: 'series',
+        breadcrumbs: [
+          { href: 'parent1Url', text: 'parent1' },
+          { href: '', text: `name${UUID}` },
+        ],
         title: `name${UUID}`,
         summary: `description${UUID}`,
         image: {

--- a/server/repositories/cmsQueries/__tests__/videoPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/videoPageQuery.spec.js
@@ -5,7 +5,7 @@ describe('Video page query', () => {
   describe('url', () => {
     it('should create correct path', async () => {
       expect(query.url()).toStrictEqual(
-        'https://cms/content/1234?include=field_moj_thumbnail_image%2Cfield_moj_series%2Cfield_video%2Cfield_moj_secondary_tags%2Cfield_moj_top_level_categories&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Ccreated%2Cfield_video%2Cfield_moj_description%2Cfield_moj_secondary_tags%2Cfield_moj_series%2Cfield_moj_season%2Cfield_moj_episode%2Cfield_moj_top_level_categories%2Cfield_moj_thumbnail_image%2Cseries_sort_value%2Cfield_exclude_feedback&fields%5Bfile--file%5D=uri%2Cimage_style_uri&fields%5Btaxonomy_term--series%5D=drupal_internal__tid%2Cname%2Cpath&fields%5Btaxonomy_term--tags%5D=drupal_internal__tid%2Cname%2Cpath&fields%5Btaxonomy_term--moj_categories%5D=drupal_internal__tid%2Cname',
+        'https://cms/content/1234?include=field_moj_thumbnail_image%2Cfield_moj_series%2Cfield_video%2Cfield_moj_secondary_tags%2Cfield_moj_top_level_categories&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Ccreated%2Cfield_video%2Cfield_moj_description%2Cfield_moj_secondary_tags%2Cfield_moj_series%2Cfield_moj_season%2Cfield_moj_episode%2Cfield_moj_top_level_categories%2Cfield_moj_thumbnail_image%2Cseries_sort_value%2Cfield_exclude_feedback%2Cbreadcrumbs&fields%5Bfile--file%5D=uri%2Cimage_style_uri&fields%5Btaxonomy_term--series%5D=drupal_internal__tid%2Cname%2Cpath&fields%5Btaxonomy_term--tags%5D=drupal_internal__tid%2Cname%2Cpath&fields%5Btaxonomy_term--moj_categories%5D=drupal_internal__tid%2Cname',
       );
     });
   });
@@ -23,6 +23,7 @@ describe('Video page query', () => {
         fieldMojEpisode: 36,
         fieldMojSeason: 1,
         seriesSortValue: 1001,
+        breadcrumbs: [{ uri: 'parent1Url', title: 'parent1' }],
 
         fieldVideo: {
           type: 'file--file',
@@ -91,6 +92,10 @@ describe('Video page query', () => {
           name: 'steve',
         },
         contentType: 'video',
+        breadcrumbs: [
+          { href: 'parent1Url', text: 'parent1' },
+          { href: '', text: 'Buddhist reflection: 29 July' },
+        ],
         description: 'Education content for prisoners',
         episodeId: 1036,
         excludeFeedback: undefined,

--- a/server/repositories/cmsQueries/audioPageQuery.js
+++ b/server/repositories/cmsQueries/audioPageQuery.js
@@ -3,6 +3,7 @@ const {
   getLargeImage,
   getCategoryId,
   buildSecondaryTags,
+  mapBreadcrumbs,
 } = require('../../utils/jsonApi');
 
 class AudioPageQuery {
@@ -25,6 +26,7 @@ class AudioPageQuery {
         'field_moj_programme_code',
         'series_sort_value',
         'field_exclude_feedback',
+        'breadcrumbs',
       ])
 
       .addFields('file--file', ['uri', 'image_style_uri'])
@@ -64,6 +66,7 @@ class AudioPageQuery {
       created: item.created,
       title: item.title,
       contentType: 'radio',
+      breadcrumbs: mapBreadcrumbs(item.breadcrumbs, item.title),
       description: item.fieldMojDescription?.processed,
       programmeCode: item.fieldMojProgrammeCode,
       episodeId:

--- a/server/repositories/cmsQueries/basicPageQuery.js
+++ b/server/repositories/cmsQueries/basicPageQuery.js
@@ -1,5 +1,9 @@
 const { DrupalJsonApiParams: Query } = require('drupal-jsonapi-params');
-const { getCategoryId, buildSecondaryTags } = require('../../utils/jsonApi');
+const {
+  mapBreadcrumbs,
+  getCategoryId,
+  buildSecondaryTags,
+} = require('../../utils/jsonApi');
 
 class BasicPageQuery {
   constructor(location) {
@@ -16,6 +20,7 @@ class BasicPageQuery {
         'field_moj_series',
         'field_moj_top_level_categories',
         'field_exclude_feedback',
+        'breadcrumbs',
       ])
       .addFields('taxonomy_term--tags', ['drupal_internal__tid', 'name'])
       .addFields('taxonomy_term--moj_categories', [
@@ -40,6 +45,7 @@ class BasicPageQuery {
       title: item.title,
       created: item.created,
       contentType: 'page',
+      breadcrumbs: mapBreadcrumbs(item.breadcrumbs, item.title),
       description: item.fieldMojDescription?.processed,
       standFirst: item.fieldMojStandFirst,
       categories: getCategoryId(item.fieldMojTopLevelCategories),

--- a/server/repositories/cmsQueries/categoryPageQuery.js
+++ b/server/repositories/cmsQueries/categoryPageQuery.js
@@ -1,5 +1,5 @@
 const { DrupalJsonApiParams: Query } = require('drupal-jsonapi-params');
-const { getSmallTile } = require('../../utils/jsonApi');
+const { getSmallTile, mapBreadcrumbs } = require('../../utils/jsonApi');
 
 class CategoryPageQuery {
   static #TILE_FIELDS = [
@@ -44,16 +44,12 @@ class CategoryPageQuery {
 
   transform(data) {
     const { name: categoryName = '', breadcrumbs = [] } = data;
-    breadcrumbs.push({ title: categoryName });
     return {
       title: categoryName,
       contentType: 'category',
       description: data?.description?.processed,
       excludeFeedback: data.fieldExcludeFeedback,
-      breadcrumbs: breadcrumbs.map(({ uri: href = '', title: text }) => ({
-        href,
-        text,
-      })),
+      breadcrumbs: mapBreadcrumbs(breadcrumbs, categoryName),
       config: {
         content: true,
         header: false,

--- a/server/repositories/cmsQueries/secondaryTagPageQuery.js
+++ b/server/repositories/cmsQueries/secondaryTagPageQuery.js
@@ -3,6 +3,7 @@ const {
   getSmallTile,
   getLargeTile,
   getPagination,
+  mapBreadcrumbs,
 } = require('../../utils/jsonApi');
 
 class SecondaryTagPageQuery {
@@ -32,6 +33,7 @@ class SecondaryTagPageQuery {
         'field_featured_image',
         'path',
         'field_exclude_feedback',
+        'breadcrumbs',
       ])
       .addInclude([
         'field_moj_thumbnail_image',
@@ -51,6 +53,7 @@ class SecondaryTagPageQuery {
     return {
       ...getLargeTile(item),
       excludeFeedback: item.fieldExcludeFeedback,
+      breadcrumbs: mapBreadcrumbs(item.breadcrumbs, item.name),
     };
   };
 

--- a/server/repositories/cmsQueries/seriesPageQuery.js
+++ b/server/repositories/cmsQueries/seriesPageQuery.js
@@ -3,6 +3,7 @@ const {
   getLargeTile,
   getSmallTile,
   getPagination,
+  mapBreadcrumbs,
 } = require('../../utils/jsonApi');
 
 class SeriesPageQuery {
@@ -32,6 +33,7 @@ class SeriesPageQuery {
         'field_featured_image',
         'path',
         'field_exclude_feedback',
+        'breadcrumbs',
       ])
       .addInclude([
         'field_moj_thumbnail_image',
@@ -48,10 +50,11 @@ class SeriesPageQuery {
 
   transform(deserializedResponse, links) {
     if (deserializedResponse.length === 0) return null;
+    const series = deserializedResponse[0].fieldMojSeries;
     return {
-      excludeFeedback:
-        deserializedResponse[0].fieldMojSeries.fieldExcludeFeedback,
-      ...getLargeTile(deserializedResponse[0].fieldMojSeries),
+      excludeFeedback: series.fieldExcludeFeedback,
+      ...getLargeTile(series),
+      breadcrumbs: mapBreadcrumbs(series?.breadcrumbs, series.name),
       ...{
         relatedContent: {
           contentType: 'default',

--- a/server/repositories/cmsQueries/videoPageQuery.js
+++ b/server/repositories/cmsQueries/videoPageQuery.js
@@ -3,6 +3,7 @@ const {
   getLargeImage,
   getCategoryId,
   buildSecondaryTags,
+  mapBreadcrumbs,
 } = require('../../utils/jsonApi');
 
 class VideoPageQuery {
@@ -24,6 +25,7 @@ class VideoPageQuery {
         'field_moj_thumbnail_image',
         'series_sort_value',
         'field_exclude_feedback',
+        'breadcrumbs',
       ])
 
       .addFields('file--file', ['uri', 'image_style_uri'])
@@ -63,6 +65,7 @@ class VideoPageQuery {
       created: item.created,
       title: item.title,
       contentType: 'video',
+      breadcrumbs: mapBreadcrumbs(item.breadcrumbs, item.title),
       description: item.fieldMojDescription?.processed,
       episodeId:
         item.fieldMojSeason !== undefined && item.fieldMojEpisode !== undefined

--- a/server/utils/jsonApi.js
+++ b/server/utils/jsonApi.js
@@ -71,7 +71,7 @@ const getCategoryId = categories => {
   };
 };
 
-const buildSecondaryTags = arr =>
+const buildSecondaryTags = (arr = []) =>
   arr.map(({ drupalInternal_Tid: id, name, id: uuid }) => ({
     id,
     uuid,
@@ -135,6 +135,16 @@ const isBottomCategory = ({
   sub_series_count: subSeriesCount = 0,
 } = {}) => subCategoriesCount === 0 && subSeriesCount === 0;
 
+const mapBreadcrumbs = (rawBreadcrumbs = [], self = '') => {
+  const breadcrumbs = self
+    ? [...rawBreadcrumbs, { title: self }]
+    : rawBreadcrumbs;
+  return breadcrumbs.map(({ uri: href = '', title: text }) => ({
+    href,
+    text,
+  }));
+};
+
 module.exports = {
   getPagination,
   getSmallTile,
@@ -144,4 +154,5 @@ module.exports = {
   buildSecondaryTags,
   typeFrom,
   isBottomCategory,
+  mapBreadcrumbs,
 };

--- a/server/views/components/template.njk
+++ b/server/views/components/template.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}
 {% from "govuk/components/footer/macro.njk" import govukFooter %}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "./search/macro.njk" import hubSearch %}
 {% from "./top-bar/macro.njk" import topBar %}
 {% from "./user-details/macro.njk" import userDetails %}
@@ -75,7 +76,9 @@
         showBar: false
       }) }}
     {% endblock %}
-    {% block pageNavigation %}{% endblock %}
+    {% block pageNavigation %}
+      {{ pageNavigation({ title: title, hideHomePage: data.breadcrumbs  }) }}
+    {% endblock %}
 
     {% block notification %}{% endblock %}
 

--- a/server/views/pages/404.html
+++ b/server/views/pages/404.html
@@ -1,4 +1,3 @@
-{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../components/user-details/macro.njk" import userDetails %}
 
 {% extends "../components/template.njk" %}
@@ -9,10 +8,6 @@
 
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/approvedVisitors.html
+++ b/server/views/pages/approvedVisitors.html
@@ -1,5 +1,4 @@
 {% from "moj/components/pagination/macro.njk" import mojPagination %}
-{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../components/user-details/macro.njk" import userDetails %}
 {% from "../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
 
@@ -12,10 +11,6 @@
 
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/audio.html
+++ b/server/views/pages/audio.html
@@ -1,7 +1,6 @@
 {% from "../components/next-episodes-content/macro.njk" import nextEpisodesContent %}
 {% from "../components/suggested-content/macro.njk" import hubSuggestedContent %}
 {% from "../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
-{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../components/user-details/macro.njk" import userDetails %}
 
 {% extends "../components/template.njk" %}
@@ -13,10 +12,6 @@
 {% block head %}
   <link href="/public/video-js.min.css" rel="stylesheet"/>
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}
@@ -88,7 +83,7 @@
             contentType: data.contentType,
             series: data.seriesName,
             feedbackId: feedbackId,
-            categories: data.categories,
+            categories: data.categories.id,
             secondaryTags: data.secondaryTags | join(',', 'id')
           }) }}
         </div>

--- a/server/views/pages/authError.html
+++ b/server/views/pages/authError.html
@@ -1,4 +1,3 @@
-{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../components/user-details/macro.njk" import userDetails %}
 
 {% extends "../components/template.njk" %}
@@ -9,10 +8,6 @@
 
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/category.html
+++ b/server/views/pages/category.html
@@ -1,6 +1,5 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
-{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../components/user-details/macro.njk" import userDetails %}
 {% from "../components/content-tile-large/macro.njk" import contentTileLarge %}
 {% from "../components/content-tile-small/macro.njk" import contentTileSmall %}
@@ -14,10 +13,6 @@
 
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/damage-obligations.html
+++ b/server/views/pages/damage-obligations.html
@@ -3,7 +3,6 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../components/user-details/macro.njk" import userDetails %}
 {% from "../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
 {% from "../components/personal-damage-obligations/macro.njk" import personalDamageObligations %}
@@ -16,10 +15,6 @@
 
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/flat-content.html
+++ b/server/views/pages/flat-content.html
@@ -1,5 +1,4 @@
 {% from "../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
-{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../components/user-details/macro.njk" import userDetails %}
 {% extends "../components/template.njk" %}
 
@@ -9,10 +8,6 @@
 
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/games/2048.html
+++ b/server/views/pages/games/2048.html
@@ -1,6 +1,5 @@
 {% from "../../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "../../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../../components/user-details/macro.njk" import userDetails %}
 {% extends "../../components/template.njk" %}
 
@@ -11,10 +10,6 @@
 {% block head %}
   <link href="/public/javascript/games/2048/stylesheets/main.css" rel="stylesheet" type="text/css"/>
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/games/anagramica.html
+++ b/server/views/pages/games/anagramica.html
@@ -1,7 +1,6 @@
 {% from "../../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "../../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../../components/user-details/macro.njk" import userDetails %}
 {% extends "../../components/template.njk" %}
 
@@ -13,10 +12,6 @@
 {% block head %}
 	<link href="/public/javascript/games/anagramica/stylesheets/style.css" rel="stylesheet"/>
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/games/chess.html
+++ b/server/views/pages/games/chess.html
@@ -1,6 +1,5 @@
 {% from "../../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "../../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../../components/user-details/macro.njk" import userDetails %}
 {% extends "../../components/template.njk" %}
 
@@ -15,10 +14,6 @@
   <script src="/public/javascript/games/chess/jquery.min.js"></script>
   <script src="/public/javascript/games/chess/chess.min.js"></script>
   <script src="/public/javascript/games/chess/chessboard-1.0.0.min.js"></script>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/games/christmas-crossword.html
+++ b/server/views/pages/games/christmas-crossword.html
@@ -1,7 +1,6 @@
 {% from "../../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
-{% from "../../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../../components/user-details/macro.njk" import userDetails %}
 {% extends "../../components/template.njk" %}
 
@@ -11,10 +10,6 @@
 
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/games/crossword.html
+++ b/server/views/pages/games/crossword.html
@@ -1,7 +1,6 @@
 {% from "../../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
-{% from "../../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../../components/user-details/macro.njk" import userDetails %}
 {% extends "../../components/template.njk" %}
 
@@ -11,10 +10,6 @@
 
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/games/fadingsnake.html
+++ b/server/views/pages/games/fadingsnake.html
@@ -1,6 +1,5 @@
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 {% from "../../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
-{% from "../../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../../components/user-details/macro.njk" import userDetails %}
 {% extends "../../components/template.njk" %}
 
@@ -11,10 +10,6 @@
 {% block head %}
   <link href="/public/javascript/games/fadingsnake/stylesheets/main.css" rel="stylesheet"/>
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/games/invadersfromspace.html
+++ b/server/views/pages/games/invadersfromspace.html
@@ -1,6 +1,5 @@
 {% from "../../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "../../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../../components/user-details/macro.njk" import userDetails %}
 {% extends "../../components/template.njk" %}
 
@@ -11,10 +10,6 @@
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
   <link href="/public/javascript/games/invadersfromspace/css/index.css" rel="stylesheet" type="text/css"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/games/mimstris.html
+++ b/server/views/pages/games/mimstris.html
@@ -1,6 +1,5 @@
 {% from "../../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "../../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../../components/user-details/macro.njk" import userDetails %}
 {% extends "../../components/template.njk" %}
 
@@ -11,10 +10,6 @@
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
   <link href="/public/javascript/games/mimstris/main.css" rel="stylesheet" type="text/css"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/games/neontroids.html
+++ b/server/views/pages/games/neontroids.html
@@ -1,4 +1,3 @@
-{% from "../../components/page-navigation/macro.njk" import pageNavigation %}
 {% extends "../../components/template.njk" %}
 
 {% block pageTitle %}
@@ -8,10 +7,6 @@
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
   <link href="/public/javascript/games/neontroids/neontroids.css" rel="stylesheet" type="text/css"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/games/smashout.html
+++ b/server/views/pages/games/smashout.html
@@ -1,6 +1,5 @@
 {% from "../../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "../../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../../components/user-details/macro.njk" import userDetails %}
 {% extends "../../components/template.njk" %}
 
@@ -16,10 +15,6 @@
     background-color: #f3f2f1;
   }
   </style>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/games/sn4ke.html
+++ b/server/views/pages/games/sn4ke.html
@@ -1,5 +1,4 @@
 {% from "../../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
-{% from "../../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../../components/user-details/macro.njk" import userDetails %}
 {% extends "../../components/template.njk" %}
 
@@ -10,10 +9,6 @@
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
   <link href="/public/javascript/games/sn4ke/main.css" rel="stylesheet" type="text/css"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/games/solitaire.html
+++ b/server/views/pages/games/solitaire.html
@@ -1,6 +1,5 @@
 {% from "../../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "../../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../../components/user-details/macro.njk" import userDetails %}
 {% extends "../../components/template.njk" %}
 
@@ -11,10 +10,6 @@
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
   <link href="/public/javascript/games/solitaire/main.css" rel="stylesheet" type="text/css"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/games/sudoku.html
+++ b/server/views/pages/games/sudoku.html
@@ -1,6 +1,5 @@
 {% from "../../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "../../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../../components/user-details/macro.njk" import userDetails %}
 {% extends "../../components/template.njk" %}
 
@@ -11,10 +10,6 @@
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
   <link href="/public/javascript/games/sudoku/sudokuJS.css" rel="stylesheet" type="text/css"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/home.html
+++ b/server/views/pages/home.html
@@ -22,6 +22,9 @@
     returnUrl: config.returnUrl
   }) }}
 {% endblock %}
+{% block pageNavigation %}
+  {# Do not display the page navigation on the home page #}
+{% endblock %}
 
 {% block userDetails %}
   <div class="govuk-width-container">

--- a/server/views/pages/npr.html
+++ b/server/views/pages/npr.html
@@ -1,7 +1,6 @@
 {% from "../components/next-episodes-content/macro.njk" import nextEpisodesContent %}
 {% from "../components/suggested-content/macro.njk" import hubSuggestedContent %}
 {% from "../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
-{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../components/user-details/macro.njk" import userDetails %}
 
 {% extends "../components/template.njk" %}
@@ -13,10 +12,6 @@
 {% block head %}
   <link href="/public/video-js.min.css" rel="stylesheet"/>
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/profile.html
+++ b/server/views/pages/profile.html
@@ -2,7 +2,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
-{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../components/user-details/macro.njk" import userDetails %}
 {% from "../components/card/macro.njk" import card, imageCard, cardSensitiveData %}
 {% from "../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
@@ -15,10 +14,6 @@
 
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/search.html
+++ b/server/views/pages/search.html
@@ -3,7 +3,6 @@
 {% extends "../components/template.njk" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../components/user-details/macro.njk" import userDetails %}
 
 {% block pageTitle %}
@@ -12,10 +11,6 @@
 
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/signin.html
+++ b/server/views/pages/signin.html
@@ -3,7 +3,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "../components/topics/macro.njk" import hubTopics %}
-{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../components/user-details/macro.njk" import userDetails %}
 
 {% extends "../components/template.njk" %}
@@ -27,10 +26,6 @@
       </div>
     </div>
   {% endif %}
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/tags.html
+++ b/server/views/pages/tags.html
@@ -1,16 +1,11 @@
 {% from "../components/related-content/macro.njk" import hubRelatedContent %}
 {% from "../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
-{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../components/user-details/macro.njk" import userDetails %}
 
 {% extends "../components/template.njk" %}
 
 {% block pageTitle %}
   {{ title }}
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/tagsCategories.html
+++ b/server/views/pages/tagsCategories.html
@@ -1,6 +1,5 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
-{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../components/user-details/macro.njk" import userDetails %}
 {% from "../components/content-tile-large/macro.njk" import contentTileLarge %}
 {% from "../components/content-tile-small/macro.njk" import contentTileSmall %}
@@ -17,10 +16,6 @@
 
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title, hideHomePage: data.breadcrumbs }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/timetable.html
+++ b/server/views/pages/timetable.html
@@ -2,7 +2,6 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "../components/personal-schedule-one-day/macro.njk" import personalScheduleOneDay %}
 {% from "../components/personal-schedule-nav/macro.njk" import personalScheduleNav %}
-{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../components/user-details/macro.njk" import userDetails %}
 {% from "../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
 
@@ -14,10 +13,6 @@
 
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/topics.html
+++ b/server/views/pages/topics.html
@@ -1,6 +1,5 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "../components/topics/macro.njk" import hubTopics %}
-{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../components/user-details/macro.njk" import userDetails %}
 
 {% extends "../components/template.njk" %}
@@ -11,10 +10,6 @@
 
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/transactions-private.html
+++ b/server/views/pages/transactions-private.html
@@ -3,7 +3,6 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../components/user-details/macro.njk" import userDetails %}
 {% from "../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
 {% from "../components/personal-transactions-private/macro.njk" import personalTransactionsPrivate %}
@@ -16,10 +15,6 @@
 
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/transactions.html
+++ b/server/views/pages/transactions.html
@@ -3,7 +3,6 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../components/user-details/macro.njk" import userDetails %}
 {% from "../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
 {% from "../components/personal-transactions/macro.njk" import personalTransactions %}
@@ -16,10 +15,6 @@
 
 {% block head %}
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}

--- a/server/views/pages/video.html
+++ b/server/views/pages/video.html
@@ -1,7 +1,6 @@
 {% from "../components/next-episodes-content/macro.njk" import nextEpisodesContent %}
 {% from "../components/suggested-content/macro.njk" import hubSuggestedContent %}
 {% from "../components/feedback-widget/macro.njk" import hubFeedbackWidget %}
-{% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "../components/user-details/macro.njk" import userDetails %}
 
 {% extends "../components/template.njk" %}
@@ -13,10 +12,6 @@
 {% block head %}
   <link href="/public/video-js.min.css" rel="stylesheet"/>
   <link href="/public/stylesheets/application.css" rel="stylesheet"/>
-{% endblock %}
-
-{% block pageNavigation %}
-  {{ pageNavigation({ title: title }) }}
 {% endblock %}
 
 {% block topBar %}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/Q74RwuL2/735-extend-breadcrumb-to-all-pages-on-hub

> If this is an issue, do we have steps to reproduce?
all pages should now have breadcrumbs

### Intent

> What changes are introduced by this PR that correspond to the above card?
all pages should now have breadcrumbs

> Would this PR benefit from screenshots?
<img width="1250" alt="Screenshot 2022-03-16 at 11 48 52" src="https://user-images.githubusercontent.com/50403492/158583896-61f4dfee-53ad-4019-a05f-d7b1567b8cca.png">
<img width="1250" alt="Screenshot 2022-03-16 at 11 50 18" src="https://user-images.githubusercontent.com/50403492/158583906-32c5a12a-c1ba-4324-847f-f38455e86b03.png">


### Considerations

> Is there any additional information that would help when reviewing this PR?
The main page template has changed, so we need to check all the pages

> Are there any steps required when merging/deploying this PR?
n/a

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
