### PR TITLE
bug/media_description_all_white

### DIFF
--- a/assets/sass/components/_media-player.scss
+++ b/assets/sass/components/_media-player.scss
@@ -44,11 +44,7 @@
 .govuk-hub-media-player__description {
   margin: govuk-spacing(6) 0;
 
-  p {
-    color: govuk-colour('white');
-  }
-
-  a {
+  * {
     color: govuk-colour('white');
   }
 }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/kqXahelR/799-fe-bug-black-text-on-npr-feedback-and-titles-in-media-descriptions

> If this is an issue, do we have steps to reproduce?
navigate to a media page with a heading in the description

### Intent

> What changes are introduced by this PR that correspond to the above card?
Changing the colour of all child tags to white for media descriptions.

> Would this PR benefit from screenshots?
<img width="1036" alt="Screenshot 2022-03-22 at 12 26 48" src="https://user-images.githubusercontent.com/50403492/159481832-09ee6e60-17ef-48bb-8f21-9f6619f2b397.png">


### Considerations

> Is there any additional information that would help when reviewing this PR?
n/a

> Are there any steps required when merging/deploying this PR?
n/a

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
