### PR TITLE
Sanitising and limiting search input

### DIFF
--- a/server/services/__tests__/search.spec.js
+++ b/server/services/__tests__/search.spec.js
@@ -37,6 +37,16 @@ describe('SearchService', () => {
       expect(results.length).toBe(0);
       expect(cmsApi.get).not.toHaveBeenCalled();
     });
+
+    it('returns empty when invalid', async () => {
+      cmsApi.get.mockResolvedValue([]);
+
+      const results = await service.find('a'.repeat(51), 'wayland');
+
+      expect(Array.isArray(results)).toBe(true);
+      expect(results.length).toBe(0);
+      expect(cmsApi.get).not.toHaveBeenCalled();
+    });
   });
 
   describe('#typeAhead', () => {
@@ -62,6 +72,51 @@ describe('SearchService', () => {
       expect(cmsApi.get).not.toHaveBeenCalled();
       expect(Array.isArray(results)).toBe(true);
       expect(results.length).toBe(0);
+    });
+
+    it('returns empty when invalid', async () => {
+      cmsApi.get.mockResolvedValue([]);
+
+      const results = await service.typeAhead('a'.repeat(51), 'wayland');
+
+      expect(cmsApi.get).not.toHaveBeenCalled();
+      expect(Array.isArray(results)).toBe(true);
+      expect(results.length).toBe(0);
+    });
+  });
+
+  describe('#isInvalid', () => {
+    ['a', 'a hat', 'a'.repeat(50)].forEach(test => {
+      it(`${test} should be valid input to search`, () => {
+        expect(service.isInvalid(test)).toBe(false);
+      });
+    });
+    ['', 'a'.repeat(51)].forEach(test => {
+      it(`'${test}' should be valid input to search`, () => {
+        expect(service.isInvalid(test)).toBe(true);
+      });
+    });
+  });
+
+  describe('#sanitise', () => {
+    [
+      ['a', 'a'],
+      ['a hat', 'a hat'],
+      ["Somebody's hat", "Somebody's hat"],
+      ['The: thing', 'The thing'],
+      ['The / thing', 'The thing'],
+      ['The (large) thing', 'The (large) thing'],
+      ['Weird ~ stuff', 'Weird stuff'],
+      ['Weird + stuff', 'Weird stuff'],
+      ['fine-stuff', 'fine-stuff'],
+      ['fine,', 'fine,'],
+      ['fi;ne', 'fi;ne'],
+      ['fine!', 'fine!'],
+      ['"fine"', '"fine"'],
+    ].forEach(([test, expected]) => {
+      it(`'${test}' should be sanitised to '${expected}'`, () => {
+        expect(service.sanitise(test)).toBe(expected);
+      });
     });
   });
 });

--- a/server/services/search.js
+++ b/server/services/search.js
@@ -1,23 +1,28 @@
 const { SearchQuery } = require('../repositories/cmsQueries/searchQuery');
 
 const createSearchService = ({ cmsApi }) => {
+  const isInvalid = query => query === '' || query.length > 50;
+  const sanitise = query => query.replace(/[^a-zA-Z0-9';,\-()!"]+/g, ' ');
+
   function find(query, establishmentName) {
-    if (query === '') {
+    if (isInvalid(query)) {
       return [];
     }
 
-    return cmsApi.get(new SearchQuery(establishmentName, query, 15));
+    return cmsApi.get(new SearchQuery(establishmentName, sanitise(query), 15));
   }
 
   function typeAhead(query, establishmentName) {
-    if (query === '') {
+    if (isInvalid(query)) {
       return [];
     }
 
-    return cmsApi.get(new SearchQuery(establishmentName, query, 5));
+    return cmsApi.get(new SearchQuery(establishmentName, sanitise(query), 5));
   }
 
   return {
+    isInvalid,
+    sanitise,
     find,
     typeAhead,
   };

--- a/server/views/components/search/template.njk
+++ b/server/views/components/search/template.njk
@@ -1,7 +1,7 @@
 <div id="search-wrapper">
   <form method="GET" action="/search">
     <label class="govuk-label" for="event-name">Search</label>
-    <input class="govuk-search-input search-box {% if params.small %}search-box-small{% endif %}" id="search" name="query" type="text" value="{{params.query}}" autocomplete="off" placeholder="Search the Content Hub">
+    <input class="govuk-search-input search-box {% if params.small %}search-box-small{% endif %}" id="search" name="query" type="text" value="{{params.query}}" maxlength="50" autocomplete="off" placeholder="Search the Content Hub">
     <button type="submit" class="govuk-button search-button {% if params.small %}search-button-small{% endif %}">
       Search
     </button>


### PR DESCRIPTION
### Context

https://trello.com/c/hYbFqugJ/

### Intent

The following changes:
1.) limit frontend and typeahead search to only allow queries of up to 50 characters.
2.) Backend, never execute queries of over 50 characters, just return empty list instead
3.) Remove any character in a query which doesn't match one of the following characters a-zA-Z0-9';,\-()!"

### Considerations

We noticed that the search: `Using Unilink: Shopping / canteen` currently throws an error on the backend and shows no results on the frontend. If we strip out the `/` then it works and shows the correct result.

(This also works if we strip out both the / and the : which is why I'm not allowing : either) (edited)

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
