### PR TITLE
Add category content sort query

### DIFF
--- a/server/repositories/cmsQueries/__tests__/categoryContentQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/categoryContentQuery.spec.js
@@ -10,7 +10,7 @@ describe('Category collection query', () => {
   describe('path', () => {
     it('should create correct path', () => {
       expect(query.path()).toStrictEqual(
-        `/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Bfield_moj_top_level_categories.id%5D=${UUID}&filter%5Bfield_not_in_series%5D=1&include=field_moj_thumbnail_image&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cpath&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cpath&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cpath&fields%5Bmoj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cpath&${getPagination(
+        `/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Bfield_moj_top_level_categories.id%5D=${UUID}&filter%5Bfield_not_in_series%5D=1&include=field_moj_thumbnail_image&sort=-created&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cpath&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cpath&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cpath&fields%5Bmoj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_description%2Cfield_moj_thumbnail_image%2Cpath&${getPagination(
           PAGE,
           LIMIT,
         )}`,

--- a/server/repositories/cmsQueries/categoryContentQuery.js
+++ b/server/repositories/cmsQueries/categoryContentQuery.js
@@ -20,6 +20,7 @@ class CategoryContentQuery {
       .addFields('node--moj_radio_item', CategoryContentQuery.#TILE_FIELDS)
       .addFields('moj_pdf_item', CategoryContentQuery.#TILE_FIELDS)
       .addInclude(['field_moj_thumbnail_image'])
+      .addSort('created', 'DESC')
       .getQueryString();
     this.query = `${queryWithoutOffset}&${getPagination(page, limit)}`;
   }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/NKbqKG0z

### Intent

> What changes are introduced by this PR that correspond to the above card?

What
At least one page is showing recently added or updated content at the end of the of the content, rather than at the beginning

Why
It is a bug that affects how content is being displayed, producing the opposite to the intended effect

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
