### PR TITLE
Add correct links for content

### DIFF
--- a/server/repositories/cmsQueries/__tests__/searchQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/searchQuery.spec.js
@@ -16,6 +16,23 @@ describe('search query', () => {
         title: 'Prisoners in Prison',
         drupalInternal_Nid: 1234,
         fieldMojDescription: { summary: 'Lived experiences in prison' },
+        path: {
+          alias: '/content/2345',
+        },
+      };
+
+      expect(query.transformEach(item)).toStrictEqual({
+        summary: 'Lived experiences in prison',
+        title: 'Prisoners in Prison',
+        url: '/content/2345',
+      });
+    });
+
+    it('should create correct structure when missing alias', async () => {
+      const item = {
+        title: 'Prisoners in Prison',
+        drupalInternal_Nid: 1234,
+        fieldMojDescription: { summary: 'Lived experiences in prison' },
       };
 
       expect(query.transformEach(item)).toStrictEqual({

--- a/server/repositories/cmsQueries/searchQuery.js
+++ b/server/repositories/cmsQueries/searchQuery.js
@@ -17,7 +17,7 @@ class SearchQuery {
     return {
       title: item.title,
       summary: item.fieldMojDescription?.summary,
-      url: `/content/${item.drupalInternal_Nid}`,
+      url: item.path?.alias || `/content/${item.drupalInternal_Nid}`,
     };
   }
 }


### PR DESCRIPTION
This fixes the link to links

### Context

https://trello.com/c/EwL0hwwC

### Intent

Rather than trying to guess the content that the url will be present in the hub, instead use the path as provided from drupal.

### Considerations

Think the search index needs rebuilding on dev, so might be easier to test elsewhere.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
