### PR TITLE
bug/feedback-passing-categories-topics-array

### DIFF
--- a/assets/javascript/feedback-tracking.js
+++ b/assets/javascript/feedback-tracking.js
@@ -13,18 +13,18 @@
     radio: 'podcast',
     page: 'article',
     game: 'game',
-    'landing-page': 'topic',
     series: 'series',
-    topic: 'topic'
+    topic: 'topic',
+    category: 'category'
   };
   var types = {
     video: 'VIDEO',
     radio: 'AUDIO',
     page: 'ARTICLE',
     game: 'GAME',
-    'landing-page': 'TOPIC',
     series: 'SERIES',
-    topic: 'TOPIC'
+    topic: 'TOPIC',
+    category: 'CATEGORY'
   };
 
   window._feedback = {};
@@ -38,8 +38,8 @@
     window._feedback.title = widget.data('item-title');
     window._feedback.url = window.location.pathname;
     window._feedback.contentType = types[contentType] || contentType;
-    window._feedback.categories = categories ? ('' + categories).split(',') : [];
-    window._feedback.topics = topics ? ('' + topics).split(',') : [];
+    window._feedback.categories = categories || '';
+    window._feedback.topics = topics || '';
     window._feedback.id = widget.data('item-feedback-id');
 
     var series = widget.data('item-series');

--- a/server/routes/content.js
+++ b/server/routes/content.js
@@ -1,4 +1,3 @@
-const { prop, path } = require('ramda');
 const express = require('express');
 
 const createContentRouter = ({ cmsService, analyticsService }) => {
@@ -17,7 +16,7 @@ const createContentRouter = ({ cmsService, analyticsService }) => {
       postscript: false,
     };
 
-    const userAgent = path(['headers', 'user-agent'], req);
+    const userAgent = req?.headers?.['user-agent'];
     const { establishmentName } = req.session;
 
     try {
@@ -26,10 +25,10 @@ const createContentRouter = ({ cmsService, analyticsService }) => {
         parseInt(id, 10),
       );
 
-      const contentType = prop('contentType', data);
-      const sessionId = path(['session', 'id'], req);
+      const contentType = data?.contentType;
+      const sessionId = req?.session?.id;
       const categories = data?.categories || [];
-      const topics = data?.topics || [];
+      const topics = data?.topics?.filter(topic => topic?.name) || [];
 
       switch (contentType) {
         case 'radio':


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/hIwIkzr9/940-bug-categories-and-topics-being-passed-through-as-arrays-missing-deleted-topics-not-being-filtered-out

> If this is an issue, do we have steps to reproduce?
push feedback. Categories and Topics being pushed as Arrays.

### Intent

> What changes are introduced by this PR that correspond to the above card?
Filter out "_missing/deleted_" content.
Flatten Arrays to strings.

> Would this PR benefit from screenshots?
n/a

### Considerations

> Is there any additional information that would help when reviewing this PR?
n/a

> Are there any steps required when merging/deploying this PR?
no

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
