### PR TITLE
feature/recently-added-on-homepage

### DIFF
--- a/assets/sass/components/_home-content.scss
+++ b/assets/sass/components/_home-content.scss
@@ -246,3 +246,9 @@
   content: url('/public/images/icons/audio.svg');
   background-color: govuk-colour('green');
 }
+
+.hub-content-block__title-bar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -42,8 +42,10 @@ const createHomepageRouter = ({ cmsService, offenderService }) => {
         throw new Error('Could not determine establishment!');
       }
 
-      const homepage = await cmsService.getHomepage(establishmentName);
-
+      const [homepage, recentlyAddedContent] = await Promise.all([
+        cmsService.getHomepage(establishmentName),
+        cmsService.getRecentlyAddedContent(establishmentName),
+      ]);
       const currentEvents = res.locals.isSignedIn
         ? await offenderService.getCurrentEvents(req.user)
         : {};
@@ -58,6 +60,7 @@ const createHomepageRouter = ({ cmsService, offenderService }) => {
         hideSignInLink: true,
         title: 'Home',
         homepage,
+        recentlyAddedContent,
         currentEvents,
       });
     } catch (error) {

--- a/server/views/components/hub-content-block/macro.njk
+++ b/server/views/components/hub-content-block/macro.njk
@@ -1,0 +1,3 @@
+{% macro hubContentBlock(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/components/hub-content-block/template.njk
+++ b/server/views/components/hub-content-block/template.njk
@@ -1,0 +1,18 @@
+{% from "../hub-content/macro.njk" import hubContent %}
+
+{% if params.data|length %}
+<section id="{{ params.id }}">
+  <div class="hub-content-block__title-bar govuk-!-margin-bottom-3">
+    <h2 class="govuk-heading-l  govuk-hub-white-heading govuk-!-margin-bottom-0">{{ params.title }}</h2>
+    {% if params.viewAllUrl %}
+      <a class="govuk-body govuk-link govuk-link--no-visited-state" href="{{ params.viewAllUrl }}">View all</a>
+    {% endif %}
+  </div>
+  {{ hubContent({
+    data: params.data.data
+  }) }}
+  {% if not params.hideHorizontalRule %}
+    <hr class="govuk-!-margin-top-5">
+  {% endif %}
+</section>
+{% endif %}

--- a/server/views/components/hub-content-show-more/macro.njk
+++ b/server/views/components/hub-content-show-more/macro.njk
@@ -1,0 +1,3 @@
+{% macro hubContentShowMore(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/components/hub-content-show-more/template.njk
+++ b/server/views/components/hub-content-show-more/template.njk
@@ -1,0 +1,16 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../hub-content/macro.njk" import hubContent %}
+
+<div data-content-type="{{params.data.contentType}}" data-content-id="{{params.id}}" >
+  {{ hubContent({
+    data: params.data.data
+  }) }}
+  {% if not params.data.isLastPage %}
+    <div class="show-more govuk-!-margin-top-9">
+      {{ govukButton({
+        text: "Show more",
+        classes: 'show-more-tiles govuk-button--secondary'
+      }) }}
+    </div>
+  {% endif %}
+</div>

--- a/server/views/components/hub-content/template.njk
+++ b/server/views/components/hub-content/template.njk
@@ -1,26 +1,16 @@
 {% from "../content-tile-small/macro.njk" import contentTileSmall %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-<div data-content-type="{{params.data.contentType}}" data-content-id="{{params.id}}" >
-    <div class="small-tiles tags-content__four-items {{ 'hidden' if loop.index > 1 }}">
-      {% for item in params.data.data %}
-        {{ contentTileSmall ({
-          id: item.id,
-          title: item.title,
-          contentType: item.contentType,
-          image: item.image,
-          contentUrl: item.contentUrl,
-          displayUrl: item.displayUrl,
-          externalContent: item.externalContent
-        }) }}
-      {% endfor %}
-    </div>
-    {% if not params.data.isLastPage %}
-      <div class="show-more govuk-!-margin-top-9">
-        {{ govukButton({
-          text: "Show more",
-          classes: 'show-more-tiles govuk-button--secondary'
-        }) }}
-      </div>
-    {% endif %}
+<div class="small-tiles tags-content__four-items {{ 'hidden' if loop.index > 1 }}">
+  {% for item in params.data %}
+    {{ contentTileSmall ({
+      id: item.id,
+      title: item.title,
+      contentType: item.contentType,
+      image: item.image,
+      contentUrl: item.contentUrl,
+      displayUrl: item.displayUrl,
+      externalContent: item.externalContent
+    }) }}
+  {% endfor %}
 </div>

--- a/server/views/pages/collections.html
+++ b/server/views/pages/collections.html
@@ -1,4 +1,4 @@
-{% from "../components/hub-content/macro.njk" import hubContent %}
+{% from "../components/hub-content-show-more/macro.njk" import hubContentShowMore %}
 
 {% extends "../components/basicTemplate.njk" %}
 
@@ -32,7 +32,7 @@
 
 {% block content %}
   {% if data.hubContentData|length %}
-    {{ hubContent({
+    {{ hubContentShowMore({
       id: tagId,
       data: data.hubContentData,
       lazyLoadContent: true

--- a/server/views/pages/home-new.html
+++ b/server/views/pages/home-new.html
@@ -1,5 +1,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "../components/personal-schedule-today/macro.njk" import personalScheduleToday %}
+{% from "../components/hub-content-block/macro.njk" import hubContentBlock %}
 
 {% extends "../components/basicTemplate.njk" %}
 
@@ -23,9 +24,12 @@
 {% endblock %}
 
 {% block content %}
-<div class="govuk-body home-content">
-  <p>New homepage</p>
-</div>
+  {{ hubContentBlock({
+    title: 'Recently added',
+    viewAllUrl: '/recently-added',
+    id: 'recentlyAdded',
+    data: recentlyAddedContent
+  }) }}
 {% endblock %}
 
 {% block feedback %}

--- a/server/views/pages/tagsCategories.html
+++ b/server/views/pages/tagsCategories.html
@@ -1,3 +1,4 @@
+{% from "../components/hub-content-show-more/macro.njk" import hubContentShowMore %}
 {% from "../components/hub-content/macro.njk" import hubContent %}
 
 {% extends "../components/basicTemplate.njk" %}
@@ -10,8 +11,7 @@
     <section class="govuk-!-margin-bottom-9">
       <h2 class="govuk-heading-l govuk-hub-white-heading">Featured</h2>
       {{ hubContent({
-        data: { contentType:"default",isLastPage:true, data:data.categoryFeaturedContent },
-        lazyLoadContent: true
+        data: data.categoryFeaturedContent
       }) }}
     </section>
     <hr>
@@ -19,8 +19,8 @@
   {% if data.categorySeries.data.length > 0 %}
     <section id="seriesTiles"class="govuk-!-margin-bottom-9 govuk-!-margin-top-5">
       <h2 class="govuk-heading-l  govuk-hub-white-heading">In this section</h2>
-      {{ hubContent({
-        data: { contentType:data.categorySeries.contentType ,isLastPage:data.categorySeries.isLastPage, data:data.categorySeries.data },
+      {{ hubContentShowMore({
+        data: data.categorySeries,
         lazyLoadContent: true
       }) }}
     </section>
@@ -29,8 +29,8 @@
   {% if data.categoryContent.data.length > 0 %}
     <section id="otherContentTiles" class="govuk-!-margin-bottom-9 govuk-!-margin-top-5">
       <h2 class="govuk-heading-l  govuk-hub-white-heading">Content</h2>
-      {{ hubContent({
-        data: { contentType:data.categoryContent.contentType ,isLastPage:data.categoryContent.isLastPage, data:data.categoryContent.data },
+      {{ hubContentShowMore({
+        data: data.categoryContent,
         lazyLoadContent: true
       }) }}
     </section>


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/LjGu2N1C/920-allow-users-to-see-all-recently-added-content-on-the-homepage

> If this is an issue, do we have steps to reproduce?
n/a

### Intent

> What changes are introduced by this PR that correspond to the above card?
_hub-content_ components re-vamped

> Would this PR benefit from screenshots?
<img width="1320" alt="Screenshot 2022-06-09 at 10 39 36" src="https://user-images.githubusercontent.com/50403492/172817270-5b9afd57-b2b1-4aa0-8eef-24db88082514.png">

### Considerations

> Is there any additional information that would help when reviewing this PR?
_View all_ link and _hr_ tag are optional.

> Are there any steps required when merging/deploying this PR?
n/a

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
