### PR TITLE
feature/998-homepage-updates-sections

### DIFF
--- a/assets/sass/_general.scss
+++ b/assets/sass/_general.scss
@@ -21,7 +21,9 @@
 
 .black-background .govuk-body,
 .black-background .govuk-body a,
+.black-background .govuk-heading-s,
 .black-background .govuk-heading-m,
+.black-background .govuk-heading-l,
 .black-background .govuk-hint,
 .black-background .govuk-hint a,
 .black-background .govuk-hub-comment-counter {
@@ -93,7 +95,8 @@
   color: govuk-colour('white');
 }
 
-.black-background #feedback-widget .govuk-link {
+.black-background #feedback-widget .govuk-link,
+.black-background .govuk-hub-content-tile-featured {
   @extend .govuk-link--inverse;
 }
 

--- a/assets/sass/components/_content-tile-featured.scss
+++ b/assets/sass/components/_content-tile-featured.scss
@@ -1,0 +1,26 @@
+.govuk-hub-content-tile-featured {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background-color: $real-dark-grey;
+  text-decoration: none;
+  box-sizing: border-box;
+  & p,
+  & h3 {
+    margin: 0;
+    overflow: hidden;
+  }
+  & .govuk-hub-content-tile-featured_content {
+    & img {
+      width: 100%;
+    }
+    & div {
+      padding: govuk-spacing(2) govuk-spacing(3) govuk-spacing(1)
+        govuk-spacing(3);
+    }
+  }
+  > p {
+    padding: govuk-spacing(2) govuk-spacing(3);
+  }
+}

--- a/assets/sass/components/_home-content.scss
+++ b/assets/sass/components/_home-content.scss
@@ -88,7 +88,9 @@
 .home-content > :last-child,
 .home-content__four-items > a,
 .tags-content__four-items > a,
-.key-info-item {
+.key-info-item,
+.govuk-hub-content-tile-featured,
+.govuk-hub-update-items-link {
   position: relative;
   transition: transform 0.5s ease;
 }
@@ -113,19 +115,22 @@
 .home-content > a:hover,
 .home-content > a:focus,
 .key-info-item:hover,
-.key-info-item:focus {
+.key-info-item:focus,
+.govuk-hub-content-tile-featured:hover,
+.govuk-hub-content-tile-featured:focus,
+.govuk-hub-update-items-link:hover,
+.govuk-hub-update-items-link:focus {
   @include scale-tile;
   outline: none;
   @include tile-shadow;
-  & > div {
-    background-color: $govuk-focus-colour;
-    & h3,
-    & p {
-      color: govuk-colour('black');
-    }
-    ::after {
-      filter: brightness(0);
-    }
+
+  background-color: $govuk-focus-colour;
+  & h3,
+  & p {
+    color: govuk-colour('black');
+  }
+  ::after {
+    filter: brightness(0);
   }
 }
 
@@ -279,12 +284,9 @@
 
 .key-info-item {
   display: block;
-
-  .key-info-item-container {
-    height: 90px;
-    background-color: $real-dark-grey;
-    overflow: hidden;
-  }
+  height: 90px;
+  background-color: $real-dark-grey;
+  overflow: hidden;
 
   .govuk-heading-s {
     color: govuk-colour('white');
@@ -294,4 +296,8 @@
     width: 100%;
     height: 90px;
   }
+}
+
+.govuk-hub-home-updates {
+  display: flex;
 }

--- a/assets/sass/components/_update-items.scss
+++ b/assets/sass/components/_update-items.scss
@@ -1,0 +1,37 @@
+.govuk-hub-update-items {
+  box-sizing: border-box;
+  height: 100%;
+  display: block;
+  background-color: $real-dark-grey;
+  padding: govuk-spacing(2) govuk-spacing(3);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  & .govuk-hub-update-items-link {
+    display: block;
+    text-decoration: none;
+    width: 100%;
+    & .govuk-hub-update-items-link_content {
+      display: flex;
+
+      & .govuk-hub-update-items-link_text {
+        padding: 0 govuk-spacing(2) govuk-spacing(1) govuk-spacing(2);
+        & p {
+          width: 100%;
+          margin: 0;
+          text-decoration: underline;
+        }
+        & h3 {
+          margin: 0;
+        }
+      }
+
+      & img {
+        min-width: 96px;
+        height: 54px;
+        object-fit: cover;
+        object-position: 50% 50%;
+      }
+    }
+  }
+}

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -29,6 +29,8 @@ $real-dark-grey: #232425;
 @import 'components/page-navigation';
 @import 'components/timetable-one-day';
 @import 'components/category';
+@import 'components/content-tile-featured';
+@import 'components/update-items';
 @import 'components/personalised';
 @import 'components/signin';
 @import 'components/card';

--- a/server/repositories/cmsQueries/__tests__/homepageContentQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/homepageContentQuery.spec.js
@@ -12,7 +12,7 @@ describe('HomepageContent query', () => {
   describe('path', () => {
     it('should return correct path', () => {
       expect(query.path()).toStrictEqual(
-        `/jsonapi/prison/${ESTABLISHMENTNAME}/node/homepage?include=field_featured_tiles.field_moj_thumbnail_image%2Cfield_featured_tiles%2Cfield_large_update_tile%2Cfield_key_info_tiles%2Cfield_key_info_tiles.field_moj_thumbnail_image&page%5Blimit%5D=4&fields%5Bnode--field_featured_tiles%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_thumbnail_image%2Cfield_moj_description%2Cfield_moj_series%2Cpath%2Ctype.meta.drupal_internal__target_id%2Cpublished_at&fields%5Bnode--field_key_info_tiles%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_thumbnail_image%2Cfield_moj_description%2Cfield_moj_series%2Cpath%2Ctype.meta.drupal_internal__target_id%2Cpublished_at&fields%5Bfile--file%5D=drupal_internal__fid%2Cid%2Cimage_style_uri`,
+        `/jsonapi/prison/${ESTABLISHMENTNAME}/node/homepage?include=field_featured_tiles.field_moj_thumbnail_image%2Cfield_featured_tiles%2Cfield_large_update_tile%2Cfield_key_info_tiles%2Cfield_key_info_tiles.field_moj_thumbnail_image%2Cfield_large_update_tile.field_moj_thumbnail_image&page%5Blimit%5D=4&fields%5Bnode--field_featured_tiles%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_thumbnail_image%2Cfield_moj_description%2Cfield_moj_series%2Cpath%2Ctype.meta.drupal_internal__target_id%2Cpublished_at&fields%5Bnode--field_key_info_tiles%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_thumbnail_image%2Cfield_moj_description%2Cfield_moj_series%2Cpath%2Ctype.meta.drupal_internal__target_id%2Cpublished_at&fields%5Bfile--file%5D=drupal_internal__fid%2Cid%2Cimage_style_uri`,
       );
     });
 

--- a/server/repositories/cmsQueries/__tests__/homepageUpdatesContentQuery.js
+++ b/server/repositories/cmsQueries/__tests__/homepageUpdatesContentQuery.js
@@ -1,0 +1,102 @@
+const {
+  HomepageUpdatesContentQuery,
+} = require('../homepageUpdatesContentQuery');
+
+describe('Recently Added Content page query', () => {
+  const ESTABLISHMENTNAME = 'Wayland';
+  let query;
+
+  beforeEach(() => {
+    query = new HomepageUpdatesContentQuery(ESTABLISHMENTNAME, 1, 40);
+  });
+
+  describe('path', () => {
+    it('should return correct path', () => {
+      expect(query.path()).toStrictEqual(
+        `/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Bcategories_group%5D%5Bgroup%5D%5Bconjunction%5D=OR&filter%5Bfield_moj_top_level_categories.field_is_homepage_updates%5D%5Bcondition%5D%5Bpath%5D=field_moj_top_level_categories.field_is_homepage_updates&filter%5Bfield_moj_top_level_categories.field_is_homepage_updates%5D%5Bcondition%5D%5Bvalue%5D=true&filter%5Bfield_moj_top_level_categories.field_is_homepage_updates%5D%5Bcondition%5D%5BmemberOf%5D=categories_group&filter%5Bfield_moj_series.field_is_homepage_updates%5D%5Bcondition%5D%5Bpath%5D=field_moj_series.field_is_homepage_updates&filter%5Bfield_moj_series.field_is_homepage_updates%5D%5Bcondition%5D%5Bvalue%5D=true&filter%5Bfield_moj_series.field_is_homepage_updates%5D%5Bcondition%5D%5BmemberOf%5D=categories_group&include=field_moj_thumbnail_image&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_thumbnail_image%2Cfield_moj_description%2Cfield_moj_series%2Cpath%2Ctype.meta.drupal_internal__target_id%2Cpublished_at&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_thumbnail_image%2Cfield_moj_description%2Cfield_moj_series%2Cpath%2Ctype.meta.drupal_internal__target_id%2Cpublished_at&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_thumbnail_image%2Cfield_moj_description%2Cfield_moj_series%2Cpath%2Ctype.meta.drupal_internal__target_id%2Cpublished_at&fields%5Bnode--moj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_thumbnail_image%2Cfield_moj_description%2Cfield_moj_series%2Cpath%2Ctype.meta.drupal_internal__target_id%2Cpublished_at&fields%5Bfile--file%5D=drupal_internal__fid%2Cid%2Cimage_style_uri&page[offset]=0&page[limit]=40`,
+      );
+    });
+  });
+
+  describe('transform', () => {
+    let links;
+    let responseItem;
+    let responseItemProcessed;
+    let responseLargeItemProcessed;
+
+    beforeEach(() => {
+      links = {
+        next: 'URL',
+      };
+      responseItem = {
+        type: 'node--moj_video_item',
+        drupalInternal_Nid: 111111,
+        published_at: '2022-07-09T14:53:27+00:00',
+        title: 'A Title',
+        path: {
+          alias: '/content/111111',
+        },
+        fieldMojDescription: {
+          summary: 'A Summary',
+        },
+        fieldMojThumbnailImage: {
+          imageStyleUri: [
+            {
+              tile_large: 'AWS_URL',
+            },
+            {
+              tile_small: 'AWS_URL',
+            },
+          ],
+          resourceIdObjMeta: {
+            alt: 'IMAGE_ALT_TEXT',
+          },
+        },
+      };
+      responseLargeItemProcessed = {
+        id: 111111,
+        contentType: 'video',
+        externalContent: false,
+        title: 'A Title',
+        summary: 'A Summary',
+        contentUrl: '/content/111111',
+        displayUrl: undefined,
+        image: {
+          url: 'AWS_URL',
+          alt: 'IMAGE_ALT_TEXT',
+        },
+        isNew: false,
+      };
+      responseItemProcessed = {
+        ...responseLargeItemProcessed,
+        publishedAt: '',
+      };
+    });
+
+    it('should return null when an empty array is provided', () => {
+      const result = query.transform([], links);
+
+      expect(result).toBeNull();
+    });
+
+    it('should create correct structure', () => {
+      const result = query.transform([responseItem], links);
+
+      expect(result).toStrictEqual({
+        isLastPage: false,
+        largeUpdateTileDefault: responseLargeItemProcessed,
+        updatesContent: [responseItemProcessed],
+      });
+    });
+
+    it('should recognise if it is the last page', () => {
+      const result = query.transform([responseItem], {});
+
+      expect(result).toStrictEqual({
+        isLastPage: true,
+        largeUpdateTileDefault: responseLargeItemProcessed,
+        updatesContent: [responseItemProcessed],
+      });
+    });
+  });
+});

--- a/server/repositories/cmsQueries/homepageContentQuery.js
+++ b/server/repositories/cmsQueries/homepageContentQuery.js
@@ -43,6 +43,7 @@ class HomepageContentQuery {
         'field_large_update_tile',
         'field_key_info_tiles',
         'field_key_info_tiles.field_moj_thumbnail_image',
+        'field_large_update_tile.field_moj_thumbnail_image',
       ])
 
       .addPageLimit(pageLimit)

--- a/server/repositories/cmsQueries/homepageUpdatesContentQuery.js
+++ b/server/repositories/cmsQueries/homepageUpdatesContentQuery.js
@@ -1,0 +1,76 @@
+const { DrupalJsonApiParams: Query } = require('drupal-jsonapi-params');
+const {
+  getPublishedAtSmallTile,
+  getLargeTile,
+  getPagination,
+} = require('../../utils/jsonApi');
+
+class HomepageUpdatesContentQuery {
+  static #TILE_FIELDS = [
+    'drupal_internal__nid',
+    'title',
+    'field_moj_thumbnail_image',
+    'field_moj_description',
+    'field_moj_series',
+    'path',
+    'type.meta.drupal_internal__target_id',
+    'published_at',
+  ];
+
+  constructor(establishmentName, page, pageLimit) {
+    this.establishmentName = establishmentName;
+    const queryWithoutOffset = new Query()
+      .addFields('node--page', HomepageUpdatesContentQuery.#TILE_FIELDS)
+      .addFields(
+        'node--moj_video_item',
+        HomepageUpdatesContentQuery.#TILE_FIELDS,
+      )
+      .addFields(
+        'node--moj_radio_item',
+        HomepageUpdatesContentQuery.#TILE_FIELDS,
+      )
+      .addFields('node--moj_pdf_item', HomepageUpdatesContentQuery.#TILE_FIELDS)
+
+      .addFields('file--file', [
+        'drupal_internal__fid',
+        'id',
+        'image_style_uri',
+      ])
+
+      .addInclude(['field_moj_thumbnail_image'])
+
+      .addGroup('categories_group', 'OR')
+
+      .addFilter(
+        'field_moj_top_level_categories.field_is_homepage_updates',
+        true,
+        '=',
+        'categories_group',
+      )
+      .addFilter(
+        'field_moj_series.field_is_homepage_updates',
+        true,
+        '=',
+        'categories_group',
+      )
+      .getQueryString();
+
+    this.query = `${queryWithoutOffset}&${getPagination(page, pageLimit)}`;
+  }
+
+  path() {
+    return `/jsonapi/prison/${this.establishmentName}/node?${this.query}`;
+  }
+
+  transform(items, links) {
+    return items.length
+      ? {
+          largeUpdateTileDefault: getLargeTile(items[0]),
+          updatesContent: items.map(getPublishedAtSmallTile),
+          isLastPage: !links.next,
+        }
+      : null;
+  }
+}
+
+module.exports = { HomepageUpdatesContentQuery };

--- a/server/routes/__tests__/updates.spec.js
+++ b/server/routes/__tests__/updates.spec.js
@@ -1,0 +1,251 @@
+const request = require('supertest');
+const cheerio = require('cheerio');
+
+jest.mock('@sentry/node');
+
+const { createUpdatesContentRouter } = require('../updates');
+const { setupBasicApp } = require('../../../test/test-helpers');
+
+describe('GET /updates', () => {
+  let app;
+
+  const cmsService = {
+    getUpdatesContent: jest.fn(),
+  };
+
+  const sessionMiddleware = (req, res, next) => {
+    req.session = {
+      establishmentId: 123,
+      establishmentName: 'berwyn',
+    };
+    next();
+  };
+
+  let relatedContent;
+  let data;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = setupBasicApp();
+    app.use(sessionMiddleware);
+    app.use('/', createUpdatesContentRouter({ cmsService }));
+
+    relatedContent = [
+      {
+        id: 15826,
+        contentType: 'video',
+        externalContent: false,
+        title: 'BBC. The Story of Maths. The Language of the Universe',
+        summary: 'BBC. The Story of Maths. The Language of the Universe',
+        contentUrl: '/content/15826',
+        displayUrl: undefined,
+        image: { url: 'image url', alt: 'Alt text' },
+      },
+      {
+        id: 15825,
+        contentType: 'video',
+        externalContent: false,
+        title: 'The Queen: 70 Glorious Years - British Royal Documentary',
+        summary: 'The Queen: 70 Glorious Years - British Royal Documentary',
+        contentUrl: '/content/15825',
+        displayUrl: undefined,
+        image: { url: 'image url', alt: 'Alt text' },
+      },
+    ];
+
+    data = {
+      isLastPage: false,
+      updatesContent: relatedContent,
+    };
+  });
+
+  describe('/', () => {
+    describe('on error', () => {
+      it('passes caught exceptions to next', async () => {
+        cmsService.getUpdatesContent.mockRejectedValue('💥');
+        await request(app).get('/').expect(500);
+      });
+    });
+
+    describe('on success', () => {
+      describe('updates page header', () => {
+        it('correctly renders a page header', () => {
+          cmsService.getUpdatesContent.mockReturnValue(data);
+
+          return request(app)
+            .get('/')
+            .expect(200)
+            .then(response => {
+              const $ = cheerio.load(response.text);
+
+              expect($('#title').text()).toContain('Updates');
+
+              expect($('#description').text()).toContain(
+                'The latest updates on the Hub.',
+              );
+            });
+        });
+      });
+
+      describe('updates content', () => {
+        it('correctly renders content', () => {
+          cmsService.getUpdatesContent.mockReturnValue(data);
+
+          return request(app)
+            .get('/')
+            .then(response => {
+              const $ = cheerio.load(response.text);
+
+              expect($('[data-featured-id]').length).toBe(2);
+
+              expect($('[data-featured-id="15826"]').text()).toContain(
+                relatedContent[0].title,
+              );
+
+              expect($('[data-featured-id="15825"]').text()).toContain(
+                relatedContent[1].title,
+              );
+
+              expect($('.tile-image').attr('src')).toContain(
+                relatedContent[0].image.url,
+              );
+
+              expect($('[data-featured-id="15826"]').attr('href')).toContain(
+                `/content/${relatedContent[0].id}`,
+              );
+
+              expect($('[data-featured-id="15825"]').attr('href')).toContain(
+                `/content/${relatedContent[1].id}`,
+              );
+            });
+        });
+
+        it('should display the Show more button when it is not the last page', () => {
+          cmsService.getUpdatesContent.mockReturnValue(data);
+
+          return request(app)
+            .get('/')
+            .then(response => {
+              const $ = cheerio.load(response.text);
+              expect($('.show-more-tiles').length).toBe(1);
+            });
+        });
+
+        it('should hide the Show more button when it is the last page', () => {
+          data.isLastPage = true;
+          cmsService.getUpdatesContent.mockReturnValue(data);
+
+          return request(app)
+            .get('/')
+            .then(response => {
+              const $ = cheerio.load(response.text);
+              expect($('.show-more-tiles').length).toBe(0);
+            });
+        });
+      });
+    });
+  });
+
+  describe('/json', () => {
+    describe('on error', () => {
+      it('passes caught exceptions to next', async () => {
+        cmsService.getUpdatesContent.mockRejectedValue('💥');
+        await request(app).get('/json').expect(500);
+      });
+    });
+
+    describe('on success', () => {
+      describe('json', () => {
+        it('it should return JSON data', () => {
+          cmsService.getUpdatesContent.mockReturnValue(data);
+
+          return request(app)
+            .get('/json')
+            .expect(200)
+            .then(response => {
+              expect(response.body).toBeDefined();
+            });
+        });
+
+        it("it should return JSON data containing the expected 'isLastPage' key/value pair value", () => {
+          cmsService.getUpdatesContent.mockReturnValue(data);
+
+          return request(app)
+            .get('/json')
+            .expect(200)
+            .then(response => {
+              const { isLastPage } = response.body;
+              expect(isLastPage).toBeDefined();
+              expect(isLastPage).toBe(false);
+            });
+        });
+
+        it('it should return JSON data containing the expected data', () => {
+          cmsService.getUpdatesContent.mockReturnValue(data);
+
+          return request(app)
+            .get('/json')
+            .expect(200)
+            .then(response => {
+              const { data: respData } = response.body;
+              expect(respData).toBeDefined();
+              expect(respData.length).toBe(2);
+              expect(respData).toEqual(data.updatesContent);
+            });
+        });
+
+        it('it should return JSON data containing the expected data types', () => {
+          cmsService.getUpdatesContent.mockReturnValue(data);
+
+          return request(app)
+            .get('/json')
+            .expect(200)
+            .then(response => {
+              const { data: respData } = response.body;
+              expect(respData).toBeDefined();
+              expect(respData[0]).toEqual(
+                expect.objectContaining({
+                  id: expect.any(Number),
+                  contentType: expect.any(String),
+                  externalContent: expect.any(Boolean),
+                  title: expect.any(String),
+                  contentUrl: expect.any(String),
+                  image: expect.any(Object),
+                }),
+              );
+            });
+        });
+
+        it("it should return JSON data containing an 'image' object with the expected data", () => {
+          cmsService.getUpdatesContent.mockReturnValue(data);
+
+          return request(app)
+            .get('/json')
+            .expect(200)
+            .then(response => {
+              const { image } = response.body.data[0];
+              expect(image).toBeDefined();
+              expect(image).toEqual(data.updatesContent[0].image);
+            });
+        });
+
+        it("it should return JSON data containing an 'image' object with the expected data types", () => {
+          cmsService.getUpdatesContent.mockReturnValue(data);
+
+          return request(app)
+            .get('/json')
+            .expect(200)
+            .then(response => {
+              const { image } = response.body.data[0];
+              expect(image).toEqual(
+                expect.objectContaining({
+                  alt: expect.any(String),
+                  url: expect.any(String),
+                }),
+              );
+            });
+        });
+      });
+    });
+  });
+});

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -42,13 +42,17 @@ const createHomepageRouter = ({ cmsService, offenderService }) => {
         throw new Error('Could not determine establishment!');
       }
 
-      const [homepageContent, recentlyAddedHomepageContent, exploreContent] =
-        await Promise.all([
-          cmsService.getHomepageContent(establishmentName),
-          cmsService.getRecentlyAddedHomepageContent(establishmentName),
-          cmsService.getExploreContent(establishmentName),
-        ]);
-
+      const [
+        { featuredContent, keyInfo, largeUpdateTile },
+        recentlyAddedHomepageContent,
+        exploreContent,
+        { largeUpdateTileDefault, updatesContent },
+      ] = await Promise.all([
+        cmsService.getHomepageContent(establishmentName),
+        cmsService.getRecentlyAddedHomepageContent(establishmentName),
+        cmsService.getExploreContent(establishmentName),
+        cmsService.getUpdatesContent(establishmentName),
+      ]);
       const currentEvents = res.locals.isSignedIn
         ? await offenderService.getCurrentEvents(req.user)
         : {};
@@ -62,7 +66,10 @@ const createHomepageRouter = ({ cmsService, offenderService }) => {
         hideSignInLink: true,
         title: 'Home',
         recentlyAddedHomepageContent,
-        ...homepageContent,
+        updatesContent: updatesContent.splice(largeUpdateTile ? 0 : 1, 4),
+        featuredContent,
+        keyInfo,
+        largeUpdateTile: largeUpdateTile || largeUpdateTileDefault,
         exploreContent,
         currentEvents,
       });

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -16,6 +16,7 @@ const { createSearchRouter } = require('./search');
 const { createNprRouter } = require('./npr');
 const { createHelpRouter } = require('./help');
 const { createRecentlyAddedContentRouter } = require('./recentlyAdded');
+const { createUpdatesContentRouter } = require('./updates');
 const createPrimaryNavigationMiddleware = require('../middleware/primaryNavigationMiddleware');
 const retrieveTopicList = require('../middleware/retrieveTopicList');
 
@@ -48,6 +49,7 @@ module.exports = (
       '/games',
       '^/search/?$',
       '/recently-added',
+      '/updates',
       '/new-homepage',
     ],
     [
@@ -117,6 +119,8 @@ module.exports = (
     '/recently-added',
     createRecentlyAddedContentRouter({ cmsService }),
   );
+
+  router.use('/updates', createUpdatesContentRouter({ cmsService }));
 
   router.use('*', (req, res) => {
     res.status(404);

--- a/server/routes/updates.js
+++ b/server/routes/updates.js
@@ -1,0 +1,67 @@
+const express = require('express');
+
+const createUpdatesContentRouter = ({ cmsService }) => {
+  const router = express.Router();
+
+  const getUpdatesContent = req => {
+    const { establishmentName } = req.session;
+
+    if (!establishmentName) {
+      throw new Error('Could not determine establishment!');
+    }
+
+    const { page } = req.query;
+
+    return cmsService.getUpdatesContent(establishmentName, page, 40);
+  };
+
+  router.get('/', async (req, res, next) => {
+    try {
+      const { updatesContent, isLastPage = true } = await getUpdatesContent(
+        req,
+      );
+
+      res.render('pages/collections', {
+        config: {
+          content: true,
+        },
+        title: 'Updates',
+        data: {
+          hubContentData: {
+            data: updatesContent,
+            isLastPage,
+          },
+          summary: 'The latest updates on the Hub.',
+          breadcrumbs: [
+            { href: '/', text: 'Home' },
+            { href: '', text: 'Updates' },
+          ],
+        },
+      });
+    } catch (e) {
+      e.message = `Error loading content: ${e.message}`;
+      next(e);
+    }
+  });
+
+  router.get('/json', async (req, res, next) => {
+    try {
+      const { updatesContent: hubContentData, isLastPage } =
+        await getUpdatesContent(req);
+
+      res.json({
+        data: hubContentData,
+        isLastPage,
+      });
+    } catch (e) {
+      e.message = `Error loading content: ${e.message}`;
+      next(e);
+    }
+  });
+
+  return router;
+};
+
+module.exports = {
+  createUpdatesContentRouter,
+};

--- a/server/services/cms.js
+++ b/server/services/cms.js
@@ -43,6 +43,9 @@ const {
   HomepageContentQuery,
 } = require('../repositories/cmsQueries/homepageContentQuery');
 const {
+  HomepageUpdatesContentQuery,
+} = require('../repositories/cmsQueries/homepageUpdatesContentQuery');
+const {
   ExploreContentQuery,
 } = require('../repositories/cmsQueries/exploreContentQuery');
 
@@ -221,6 +224,13 @@ class CmsService {
       new HomepageContentQuery(establishmentName),
     );
     return homepageContent[0];
+  }
+
+  async getUpdatesContent(establishmentName, page = 1, pageLimit = 5) {
+    const updatesContent = await this.#cmsApi.get(
+      new HomepageUpdatesContentQuery(establishmentName, page, pageLimit),
+    );
+    return updatesContent;
   }
 
   async getExploreContent(establishmentName) {

--- a/server/utils/__tests__/jsonApi.spec.js
+++ b/server/utils/__tests__/jsonApi.spec.js
@@ -3,6 +3,7 @@ const {
   getLargeImage,
   getLargeTile,
   getSmallTile,
+  getPublishedAtSmallTile,
   getCategoryId,
   buildFieldTopics,
   typeFrom,
@@ -456,6 +457,46 @@ describe('with content tile data', () => {
     },
     path: { alias: '/content/42' },
   };
+
+  describe('getPublishedAtSmallTile', () => {
+    describe('with a valid publishedAt date', () => {
+      it('should return small tile data and generate a valid date string', () => {
+        expect(
+          getPublishedAtSmallTile({
+            ...tileData,
+            publishedAt: '2020-07-10T14:02:58+00:00',
+          }),
+        ).toEqual({
+          id: 42,
+          contentType: 'video',
+          title: 'title',
+          summary: 'summary',
+          contentUrl: '/content/42',
+          displayUrl: 'link',
+          externalContent: false,
+          image: { url: 'tile_small', alt: 'alt' },
+          isNew: false,
+          publishedAt: 'Friday 10th July',
+        });
+      });
+    });
+    describe('with an undefined publishedAt date', () => {
+      it('should return small tile data and', () => {
+        expect(getPublishedAtSmallTile(tileData)).toEqual({
+          id: 42,
+          contentType: 'video',
+          title: 'title',
+          summary: 'summary',
+          contentUrl: '/content/42',
+          displayUrl: 'link',
+          externalContent: false,
+          image: { url: 'tile_small', alt: 'alt' },
+          isNew: false,
+          publishedAt: '',
+        });
+      });
+    });
+  });
   describe('getSmallTile', () => {
     it('should return the small tile data', () => {
       expect(getSmallTile(tileData)).toEqual({

--- a/server/utils/jsonApi.js
+++ b/server/utils/jsonApi.js
@@ -1,4 +1,4 @@
-const { differenceInDays } = require('date-fns');
+const { differenceInDays, format } = require('date-fns');
 
 const getPagination = (page, size = 40) =>
   `page[offset]=${Math.max(page - 1, 0) * size}&page[limit]=${size}`;
@@ -48,6 +48,13 @@ const getTile = (item, imageSize) => {
 
 const getSmallTile = item => getTile(item, 'tile_small');
 const getLargeTile = item => getTile(item, 'tile_large');
+
+const getPublishedAtSmallTile = item => ({
+  ...getTile(item, 'tile_small'),
+  publishedAt: item?.publishedAt
+    ? format(new Date(item?.publishedAt), 'EEEE do MMMM')
+    : '',
+});
 
 const getCategoryId = categories => {
   if (!categories || (Array.isArray(categories) && categories.length === 0))
@@ -144,6 +151,7 @@ module.exports = {
   getSmallTile,
   getLargeTile,
   getLargeImage,
+  getPublishedAtSmallTile,
   getCategoryId,
   buildFieldTopics,
   typeFrom,

--- a/server/views/components/content-tile-featured/macro.njk
+++ b/server/views/components/content-tile-featured/macro.njk
@@ -1,0 +1,3 @@
+{% macro contentTileFeatured(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/components/content-tile-featured/template.njk
+++ b/server/views/components/content-tile-featured/template.njk
@@ -1,0 +1,27 @@
+<a class="govuk-hub-content-tile-featured govuk-body govuk-link govuk-link--no-underline govuk-!-margin-0"
+  data-featured-tile-id="{{params.content.id}}" 
+  data-featured-id="{{params.content.id}}" 
+  data-featured-title="{{ params.content.title }}" 
+  href="{{params.content.contentUrl}}" 
+  {% if params.content.externalContent %}target="_blank"{% endif %}>
+  <div class="govuk-hub-content-tile-featured_content">
+    <img src="{{params.image.url}}" alt="{{params.image.alt}}">
+    <div>
+      <h3 class="govuk-heading-l">{{params.title}}</h3>
+      <p>{{params.summary | safe}}</p>
+    </div>
+  </div>
+  {% if params.contentType === "video" %}
+    <p class="content-link--video">Watch</p>
+  {% elif params.contentType === "radio" %}
+    <p class="content-link--audio">Listen</p>
+  {% elif params.contentType === "external_link" %}
+    <p class="content-link--external">{{ params.displayUrl }}</p>
+  {% elif params.contentType === "internal_link" %}
+    <p class="content-link--internal"></p>
+  {% elif params.contentType === "series" or params.contentType === "category" %}
+    <p class="content-link--collection">Collection</p>
+  {% else %}
+    <p class="content-link--article">Read</p>
+  {% endif %}
+</a>

--- a/server/views/components/key-info-items/template.njk
+++ b/server/views/components/key-info-items/template.njk
@@ -4,11 +4,7 @@
     data-featured-title="{{ item.title }}" 
     href="{{item.contentUrl}}" 
     {% if item.externalContent %}target="_blank"{% endif %}
-    class="key-info-item">
-
-    <div class="govuk-grid-row
-                key-info-item-container
-                govuk-!-margin-bottom-2">
+    class="key-info-item govuk-grid-row govuk-!-margin-bottom-2">
 
       <div class="govuk-grid-column-one-half 
                   govuk-!-padding-0
@@ -30,6 +26,5 @@
                     govuk-!-margin-bottom-0">{{item.title}}</h3>
       </div>
 
-    </div>
   </a>
 {% endfor %}

--- a/server/views/components/update-items/macro.njk
+++ b/server/views/components/update-items/macro.njk
@@ -1,0 +1,3 @@
+{% macro updateItems(items) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/components/update-items/template.njk
+++ b/server/views/components/update-items/template.njk
@@ -1,0 +1,22 @@
+{% macro updateItem(item) %}
+  <a class="govuk-hub-update-items-link govuk-link govuk-!-margin-bottom-3" data-featured-tile-id="{{ item.content.id }}" data-featured-id="{{item.content.id}}" data-featured-title="{{ item.content.title }}" href="{{item.content.contentUrl}}" {% if item.content.externalContent %}target="_blank"{% endif %}>
+    <div class="govuk-hub-update-items-link_content">
+      <img src="{{item.image.url}}" alt="{{item.image.alt}}">
+
+      <div class="govuk-hub-update-items-link_text govuk-!-margin-0">
+        <h3 class="govuk-heading-s">{{item.publishedAt}}</h3>
+        <p class="govuk-body">{{item.title | safe}}</p>
+      </div>
+    </div>
+  </a>
+{% endmacro %}
+<div class="govuk-hub-update-items govuk-body govuk-!-margin-0">
+  <div>
+    {% for item in items %}
+      {{ updateItem(item) }}
+    {% endfor %}
+  </div>
+  <a class="govuk-link" href="/updates">
+    View all
+  </a>
+</div>

--- a/server/views/pages/home-new.html
+++ b/server/views/pages/home-new.html
@@ -1,6 +1,8 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "../components/personal-schedule-today/macro.njk" import personalScheduleToday %}
 {% from "../components/content-tile-small/macro.njk" import contentTileSmall %}
+{% from "../components/content-tile-featured/macro.njk" import contentTileFeatured %}
+{% from "../components/update-items/macro.njk" import updateItems %}
 {% from "../components/hub-content-block/macro.njk" import hubContentBlock %}
 {% from "../components/key-info-items/macro.njk" import keyInfoItems %}
 
@@ -31,14 +33,14 @@
   </h2>
   <div class="govuk-grid-row govuk-!-margin-0 govuk-body">
     <div class="govuk-grid-column-three-quarters govuk-!-padding-0">
-      <div class="govuk-grid-row govuk-!-margin-0">
-        <div class="govuk-grid-column-one-half govuk-!-padding-0">
+      <div class="govuk-grid-row govuk-!-margin-0 govuk-hub-home-updates">
+        <div class="govuk-grid-column-one-half govuk-!-padding-0 govuk-!-padding-right-3">
           <!-- 450px column, large update link -->
-          Large update link
+          {{ contentTileFeatured(largeUpdateTile) }}
         </div>
-        <div class="govuk-grid-column-one-half govuk-!-padding-0">
+        <div class="govuk-grid-column-one-half govuk-!-padding-0 govuk-!-padding-right-3">
           <!-- 450px column, small update links -->
-          Small update links
+          {{ updateItems(updatesContent) }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/K2Hkxiw8/998-create-the-updates-section

> If this is an issue, do we have steps to reproduce?
n/a

### Intent

> What changes are introduced by this PR that correspond to the above card?
Added the updates sections for the new home page

> Would this PR benefit from screenshots?
<img width="1266" alt="Screenshot 2022-07-22 at 09 40 53" src="https://user-images.githubusercontent.com/50403492/180401489-bd8d7de9-29ed-4512-8ab7-68e2e7463956.png">


### Considerations

> Is there any additional information that would help when reviewing this PR?
Slight changes to a couple of classes used elsewhere. Check rollovers on other pages.

> Are there any steps required when merging/deploying this PR?
n/a

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
