### PR TITLE
feature/1172-Caching-Drupal-requests-in-the-frontend

### DIFF
--- a/server/services/index.js
+++ b/server/services/index.js
@@ -35,7 +35,10 @@ const incentivesApiClient = new IncentivesApiClient({
 });
 
 const cmsApi = new CmsApi(jsonApiClient);
-const cmsService = new CmsService(cmsApi);
+const cmsService = new CmsService({
+  cmsApi,
+  cachingStrategy: new InMemoryCachingStrategy(),
+});
 
 module.exports = {
   logger,

--- a/server/utils/caching/cms.js
+++ b/server/utils/caching/cms.js
@@ -1,0 +1,18 @@
+const { clone } = require('ramda');
+
+const getCacheArrayQuery = async (query, cache, key, expiry = 60) => {
+  let data = (await cache.get(key)) || null;
+  if (!data) {
+    data = (await query()) || [];
+    await cache.set(key, data, expiry);
+  }
+  // move to "structuredClone" when on node 18+
+  return clone(data);
+};
+
+const getCacheKey = (...args) => args.join(':');
+
+module.exports = {
+  getCacheKey,
+  getCacheArrayQuery,
+};


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/75vh6YsD/1172-caching-drupal-requests-in-the-frontend

> If this is an issue, do we have steps to reproduce?
n/a

### Intent

> What changes are introduced by this PR that correspond to the above card?
in memory cache implemented for certain drupal calls

> Would this PR benefit from screenshots?
n/a

### Considerations

> Is there any additional information that would help when reviewing this PR?
n/a
> Are there any steps required when merging/deploying this PR?
Monitor the RAM usage of the front end apps.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
