### PR TITLE
bug/1350-accessing-the-wrong-hubs

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -117,6 +117,9 @@ const createApp = services => {
       resave: false,
       saveUninitialized: true,
       maxAge: 4.32e7, // 12 Hours
+      cookie: {
+        domain: config.singleHostName,
+      },
     }),
   );
 


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/MZYrFDOg/1350-problem-with-prisoners-accessing-the-wrong-hub-at-swaleside

> If this is an issue, do we have steps to reproduce?
click on an absolute url

### Intent

> What changes are introduced by this PR that correspond to the above card?
Trying to set the cookies on the parent

> Would this PR benefit from screenshots?
n/a

### Considerations

> Is there any additional information that would help when reviewing this PR?
n/a

> Are there any steps required when merging/deploying this PR?
n/a

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
