### PR TITLE
feature/1403-homepage-reflow

### DIFF
--- a/assets/sass/components/_home-content.scss
+++ b/assets/sass/components/_home-content.scss
@@ -292,12 +292,25 @@
   }
 }
 
+.govuk-hub-home-updates-feature {
+  padding-right: govuk-spacing(1);
+}
+
+.govuk-hub-home-updates-content {
+  padding-left: govuk-spacing(1);
+}
+
 .govuk-hub-home-updates-feature,
 .govuk-hub-home-updates-content {
   max-width: 50%;
   flex-grow: 3;
   @include govuk-media-query($from: $width-override) {
     max-width: 450px;
+  }
+  @include govuk-media-query($until: tablet) {
+    max-width: none;
+    min-width: 100%;
+    padding: 0 0 govuk-spacing(2) 0;
   }
 }
 

--- a/assets/sass/components/_home-content.scss
+++ b/assets/sass/components/_home-content.scss
@@ -88,7 +88,7 @@
 .home-content > :last-child,
 .home-content__four-items > a,
 .tags-content__four-items > a,
-.key-info-item,
+.govuk-hub-key-info-item > a,
 .govuk-hub-content-tile-featured,
 .govuk-hub-update-items-link {
   position: relative;
@@ -114,8 +114,8 @@
 
 .home-content > a:hover,
 .home-content > a:focus,
-.key-info-item:hover,
-.key-info-item:focus,
+.govuk-hub-key-info-item > a:hover,
+.govuk-hub-key-info-item > a:focus,
 .govuk-hub-content-tile-featured:hover,
 .govuk-hub-content-tile-featured:focus,
 .govuk-hub-update-items-link:hover,
@@ -282,22 +282,34 @@
   width: 100%;
 }
 
-.key-info-item {
-  display: block;
-  height: 90px;
-  background-color: $real-dark-grey;
-  overflow: hidden;
-
-  .govuk-heading-s {
-    color: govuk-colour('white');
+.govuk-hub-home-updates {
+  display: flex;
+  @include govuk-media-query($until: $width-override) {
+    flex-wrap: wrap;
   }
-
-  img {
-    width: 100%;
-    height: 90px;
+  > div {
+    box-sizing: border-box;
   }
 }
 
-.govuk-hub-home-updates {
-  display: flex;
+.govuk-hub-home-updates-feature,
+.govuk-hub-home-updates-content {
+  max-width: 50%;
+  flex-grow: 3;
+  @include govuk-media-query($from: $width-override) {
+    max-width: 450px;
+  }
+}
+
+.govuk-hub-home-updates-content {
+  @include govuk-media-query($until: $width-override) {
+    padding-right: 0;
+  }
+}
+
+.govuk-hub-home-updates-keyInfo {
+  flex-grow: 2;
+  @include govuk-media-query($until: $width-override) {
+    margin-top: govuk-spacing(2);
+  }
 }

--- a/assets/sass/components/_key-info-items.scss
+++ b/assets/sass/components/_key-info-items.scss
@@ -2,6 +2,7 @@
   display: flex;
   margin-left: govuk-spacing(2);
   flex-direction: column;
+
   @include govuk-media-query($until: $width-override) {
     flex-direction: row;
     margin-left: 0;
@@ -9,16 +10,16 @@
     > .govuk-hub-key-info-item {
       padding: 0 govuk-spacing(1);
       width: 25%;
-      width: 25%;
       > a {
         flex-direction: column;
         height: auto;
         > .govuk-heading-s {
-          min-height: 44px;
+          min-height: 50px;
         }
         > img {
           height: 100px;
-          width: 100%;
+          min-width: 100%;
+          max-width: 100%;
         }
       }
     }
@@ -27,6 +28,13 @@
     }
     :first-child {
       padding-left: 0;
+    }
+  }
+  @include govuk-media-query($until: tablet) {
+    flex-wrap: wrap;
+    > .govuk-hub-key-info-item {
+      width: 50%;
+      padding: 0;
     }
   }
 }
@@ -45,7 +53,10 @@
   }
 
   > img {
-    width: 50%;
+    min-width: 50%;
+    max-width: 50%;
     height: 90px;
+    object-fit: cover;
+    object-position: 50% 50%;
   }
 }

--- a/assets/sass/components/_key-info-items.scss
+++ b/assets/sass/components/_key-info-items.scss
@@ -1,0 +1,51 @@
+.govuk-hub-key-info-items {
+  display: flex;
+  margin-left: govuk-spacing(2);
+  flex-direction: column;
+  @include govuk-media-query($until: $width-override) {
+    flex-direction: row;
+    margin-left: 0;
+
+    > .govuk-hub-key-info-item {
+      padding: 0 govuk-spacing(1);
+      width: 25%;
+      width: 25%;
+      > a {
+        flex-direction: column;
+        height: auto;
+        > .govuk-heading-s {
+          min-height: 44px;
+        }
+        > img {
+          height: 100px;
+          width: 100%;
+        }
+      }
+    }
+    :last-child {
+      padding-right: 0;
+    }
+    :first-child {
+      padding-left: 0;
+    }
+  }
+}
+
+.govuk-hub-key-info-item > a {
+  display: flex;
+  height: 90px;
+  background-color: $real-dark-grey;
+  overflow: hidden;
+  text-decoration: none;
+  box-sizing: border-box;
+
+  > .govuk-heading-s {
+    color: govuk-colour('white');
+    padding: govuk-spacing(1) govuk-spacing(3);
+  }
+
+  > img {
+    width: 50%;
+    height: 90px;
+  }
+}

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -24,6 +24,7 @@ $real-dark-grey: #232425;
 @import 'components/search';
 @import 'components/user-details';
 @import 'components/home-navigation';
+@import 'components/key-info-items';
 @import 'components/home-content';
 @import 'components/timetable';
 @import 'components/page-navigation';

--- a/server/routes/__tests__/homepage.spec.js
+++ b/server/routes/__tests__/homepage.spec.js
@@ -706,8 +706,8 @@ describe('GET /', () => {
           .expect(200)
           .then(response => {
             const $ = cheerio.load(response.text);
-            expect($('#keyInfo a div').children()[0].type).toBe('tag');
-            expect($('#keyInfo a div').children()[0].name).toBe('img');
+            expect($('#keyInfo a').children()[0].type).toBe('tag');
+            expect($('#keyInfo a').children()[0].name).toBe('img');
           }));
 
       it('Should render a html h3 tag in the homepage key info content tile', () =>
@@ -716,8 +716,8 @@ describe('GET /', () => {
           .expect(200)
           .then(response => {
             const $ = cheerio.load(response.text);
-            expect($('#keyInfo a div').children()[1].type).toBe('tag');
-            expect($('#keyInfo a div').children()[1].name).toBe('h3');
+            expect($('#keyInfo a').children()[1].type).toBe('tag');
+            expect($('#keyInfo a').children()[1].name).toBe('h3');
           }));
 
       it('Should render a html h3 tag with the expected text in the homepage key info content tile', () =>
@@ -726,7 +726,7 @@ describe('GET /', () => {
           .expect(200)
           .then(response => {
             const $ = cheerio.load(response.text);
-            expect($('#keyInfo a div h3:last').text()).toBe(
+            expect($('#keyInfo a h3:last').text()).toBe(
               'A title that is long enough to be cropped with an ellipse added to the end',
             );
           }));

--- a/server/views/components/key-info-items/template.njk
+++ b/server/views/components/key-info-items/template.njk
@@ -1,14 +1,13 @@
-{% for item in params.data %}
-  <a data-featured-tile-id="{{item.id}}" 
-    data-featured-id="{{item.id}}" 
-    data-featured-title="{{ item.title }}" 
-    href="{{item.contentUrl}}" 
-    {% if item.externalContent %}target="_blank"{% endif %}
-    class="key-info-item govuk-grid-row govuk-!-margin-bottom-2">
+<div class="govuk-hub-key-info-items">
+  {% for item in params.data %}
+    <div class="govuk-hub-key-info-item" id="keyInfo">
+      <a data-featured-tile-id="{{item.id}}" 
+        data-featured-id="{{item.id}}" 
+        data-featured-title="{{ item.title }}" 
+        href="{{item.contentUrl}}" 
+        {% if item.externalContent %}target="_blank"{% endif %}
+        class="govuk-link govuk-link--no-visited-state govuk-link--no-underline govuk-!-margin-bottom-2">
 
-      <div class="govuk-grid-column-one-half 
-                  govuk-!-padding-0
-                  govuk-!-margin-0">
         {% if item.image.url %}
           <img src="{{item.image.url}}" 
               alt="{{item.image.alt}}">
@@ -16,15 +15,9 @@
           <img src="/public/images/default_key_info_item_hub_logo.png"
               alt="logo">
         {% endif %}
-      </div>
+          <h3 class="govuk-heading-s govuk-!-margin-0">{{item.title}}</h3>
 
-      <div class="govuk-grid-column-one-half
-                  govuk-!-padding-top-1
-                  govuk-!-padding-bottom-1">
-          <h3 class="govuk-!-font-size-19
-                    govuk-!-margin-top-0
-                    govuk-!-margin-bottom-0">{{item.title}}</h3>
-      </div>
-
-  </a>
-{% endfor %}
+      </a>
+    </div>
+  {% endfor %}
+</div>

--- a/server/views/pages/home-new.html
+++ b/server/views/pages/home-new.html
@@ -33,14 +33,12 @@
       <span class="black-background govuk-!-padding-right-2">Updates</span>
     </h2>
     <div class="govuk-grid-row govuk-!-margin-0 govuk-body govuk-hub-home-updates">
-      <div class="govuk-hub-home-updates-feature govuk-!-padding-right-1">
-        <!-- 450px column, large update link -->
+      <div class="govuk-hub-home-updates-feature">
         {% if largeUpdateTile %}
           {{ contentTileFeatured(largeUpdateTile) }}
         {% endif %}
       </div>
-      <div class="govuk-hub-home-updates-content govuk-!-padding-left-1">
-        <!-- 450px column, small update links -->
+      <div class="govuk-hub-home-updates-content">
         {% if updatesContent | length %}
           {{ updateItems(updatesContent, updatesContentHideViewAll) }}
         {% endif %}

--- a/server/views/pages/home-new.html
+++ b/server/views/pages/home-new.html
@@ -32,24 +32,20 @@
     <h2 class="govuk-heading-l govuk-hub-white-heading govuk-!-margin-top-5 govuk-!-margin-bottom-6 hub-horizontal-rule-title">
       <span class="black-background govuk-!-padding-right-2">Updates</span>
     </h2>
-    <div class="govuk-grid-row govuk-!-margin-0 govuk-body">
-      <div class="govuk-grid-column-three-quarters govuk-!-padding-0">
-        <div class="govuk-grid-row govuk-!-margin-0 govuk-hub-home-updates">
-          <div class="govuk-grid-column-one-half govuk-!-padding-0 govuk-!-padding-right-3">
-            <!-- 450px column, large update link -->
-            {% if largeUpdateTile %}
-              {{ contentTileFeatured(largeUpdateTile) }}
-            {% endif %}
-          </div>
-          <div class="govuk-grid-column-one-half govuk-!-padding-0 govuk-!-padding-right-3">
-            <!-- 450px column, small update links -->
-            {% if updatesContent | length %}
-              {{ updateItems(updatesContent, updatesContentHideViewAll) }}
-            {% endif %}
-          </div>
-        </div>
+    <div class="govuk-grid-row govuk-!-margin-0 govuk-body govuk-hub-home-updates">
+      <div class="govuk-hub-home-updates-feature govuk-!-padding-right-1">
+        <!-- 450px column, large update link -->
+        {% if largeUpdateTile %}
+          {{ contentTileFeatured(largeUpdateTile) }}
+        {% endif %}
       </div>
-      <div class="govuk-grid-column-one-quarter" id="keyInfo">
+      <div class="govuk-hub-home-updates-content govuk-!-padding-left-1">
+        <!-- 450px column, small update links -->
+        {% if updatesContent | length %}
+          {{ updateItems(updatesContent, updatesContentHideViewAll) }}
+        {% endif %}
+      </div>
+      <div class="govuk-hub-home-updates-keyInfo" id="keyInfo">
         {% if keyInfo.data | length %}
           {{ keyInfoItems(keyInfo) }}
         {% endif %}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/r9grt0oc/1403-new-homepage-reflowing

> If this is an issue, do we have steps to reproduce?
When the site is resized the home elements become distorted and difficult to use.

### Intent

> What changes are introduced by this PR that correspond to the above card?
Attempted to reflow the items as shown in the relevant figma

> Would this PR benefit from screenshots?
<img width="1251" alt="Screenshot 2022-08-16 at 09 21 35" src="https://user-images.githubusercontent.com/50403492/184811487-d012a29d-a9a6-488b-9da8-3c11bf5a8084.png">
<img width="1084" alt="Screenshot 2022-08-16 at 09 21 07" src="https://user-images.githubusercontent.com/50403492/184811517-d44bf3d4-8aee-445a-ab9d-99e0a24d2236.png">


### Considerations

> Is there any additional information that would help when reviewing this PR?
Currently the page reflows under 1200px.

> Are there any steps required when merging/deploying this PR?
n/a

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
