### PR TITLE
bug/1417-GDS-date-format

### DIFF
--- a/server/utils/__tests__/jsonApi.spec.js
+++ b/server/utils/__tests__/jsonApi.spec.js
@@ -476,7 +476,7 @@ describe('with content tile data', () => {
           externalContent: false,
           image: { url: 'tile_small', alt: 'alt' },
           isNew: false,
-          publishedAt: 'Friday 10th July',
+          publishedAt: 'Friday 10 July',
         });
       });
       it('should ellipse longer values', () => {
@@ -498,7 +498,7 @@ describe('with content tile data', () => {
           externalContent: false,
           image: { url: 'tile_small', alt: 'alt' },
           isNew: false,
-          publishedAt: 'Friday 10th July',
+          publishedAt: 'Friday 10 July',
         });
       });
     });

--- a/server/utils/jsonApi.js
+++ b/server/utils/jsonApi.js
@@ -54,7 +54,7 @@ const getPublishedAtSmallTile = item =>
     {
       ...getTile(item, 'tile_small'),
       publishedAt: item?.publishedAt
-        ? format(new Date(item?.publishedAt), 'EEEE do MMMM')
+        ? format(new Date(item?.publishedAt), 'EEEE d MMMM')
         : '',
     },
     70,


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/vKDcRRw7/1417-make-dates-gds-format-on-new-homepage

> If this is an issue, do we have steps to reproduce?
got to new homepage and check date

### Intent

> What changes are introduced by this PR that correspond to the above card?
date format changed to GDS one, `Day date Month`, e.g. `Tuesday 4 June`

> Would this PR benefit from screenshots?
<img width="448" alt="Screenshot 2022-08-16 at 13 54 03" src="https://user-images.githubusercontent.com/50403492/184862877-5f89731a-0ec8-4e29-8f2e-55508a265aba.png">


### Considerations

> Is there any additional information that would help when reviewing this PR?
n/a

> Are there any steps required when merging/deploying this PR?
n/a

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
