### PR TITLE
bug/1416-flip-featured-and-recently-updated-on-new-homepage

### DIFF
--- a/server/views/pages/home-new.html
+++ b/server/views/pages/home-new.html
@@ -53,16 +53,16 @@
   {% endif %}
 
   {{ hubContentBlock({
+    title: 'Featured',
+    id: 'featuredContent',
+    data: featuredContent
+  }) }}
+
+  {{ hubContentBlock({
     title: 'Recently added',
     viewAllUrl: '/recently-added',
     id: 'recentlyAdded',
     data: recentlyAddedHomepageContent
-  }) }}
-
-  {{ hubContentBlock({
-    title: 'Featured',
-    id: 'featuredContent',
-    data: featuredContent
   }) }}
 
   {{ hubContentBlock({


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/ysYk6kpG/1416-flip-order-of-recently-added-and-featured-on-new-home-page

> If this is an issue, do we have steps to reproduce?
got to the new homepage. featured should come before the recently updated section.

### Intent

> What changes are introduced by this PR that correspond to the above card?
Blocks switched in home page.

> Would this PR benefit from screenshots?
![Uploading Screenshot 2022-08-16 at 14.27.57.png…]()


### Considerations

> Is there any additional information that would help when reviewing this PR?
n/a

> Are there any steps required when merging/deploying this PR?
n/a

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
