### PR TITLE
bug/1420-fix-new-homepage-featured-update-height

### DIFF
--- a/assets/sass/components/_content-tile-featured.scss
+++ b/assets/sass/components/_content-tile-featured.scss
@@ -13,7 +13,11 @@
   }
   & .govuk-hub-content-tile-featured_content {
     & img {
-      width: 100%;
+      height: 210px;
+      max-width: 100%;
+      min-width: 100%;
+      object-fit: cover;
+      object-position: 50% 50%;
     }
     & div {
       padding: govuk-spacing(2) govuk-spacing(3) govuk-spacing(1)


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/EbNolqOx/1420-new-home-page-set-max-height-on-main-features-updates-tile

> If this is an issue, do we have steps to reproduce?
Got to new-homepage with a long thin image; the updates section it distorted.

### Intent

> What changes are introduced by this PR that correspond to the above card?
The main image is now fixed in height and will crop and scale when reflowed.

> Would this PR benefit from screenshots?
<img width="1261" alt="Screenshot 2022-08-16 at 14 50 17" src="https://user-images.githubusercontent.com/50403492/184872885-42d1444c-4768-4dc2-8af0-f2e5afd6184c.png">


### Considerations

> Is there any additional information that would help when reviewing this PR?
n/a

> Are there any steps required when merging/deploying this PR?
n/a

![Uploading Screenshot 2022-08-16 at 14.50.40.png…]()
### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
