### PR TITLE
bug/hub-content-block-displaying-even-when-empty

### DIFF
--- a/server/views/components/hub-content-block/template.njk
+++ b/server/views/components/hub-content-block/template.njk
@@ -1,6 +1,5 @@
 {% from "../hub-content/macro.njk" import hubContent %}
-
-{% if params.data|length %}
+{% if params.data.data|length %}
 <section id="{{ params.id }}" class="govuk-!-margin-bottom-5">
   <div class="hub-content-block__title-bar govuk-!-margin-bottom-3">
     <h2 class="govuk-heading-l govuk-hub-white-heading govuk-!-margin-bottom-0">{{ params.title }}</h2>


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
no

> If this is an issue, do we have steps to reproduce?
Empty content blocks were still displaying as the data length was being incorrectly checked.

### Intent

> What changes are introduced by this PR that correspond to the above card?
check corrected

> Would this PR benefit from screenshots?
n/a

### Considerations

> Is there any additional information that would help when reviewing this PR?
n/a
> Are there any steps required when merging/deploying this PR?
n/a

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
