### PR TITLE
bug/1421-max-page-width-override-lacks-gutters-between-desktop-and-12…

### DIFF
--- a/assets/sass/_general.scss
+++ b/assets/sass/_general.scss
@@ -1,6 +1,6 @@
 .govuk-width-container,
 .moj-primary-navigation__container {
-  max-width: $width-override; // override gov container
+  @include govuk-width-container($width-override);
 }
 
 .govuk-main-wrapper {

--- a/assets/sass/components/_home-navigation.scss
+++ b/assets/sass/components/_home-navigation.scss
@@ -77,7 +77,6 @@
   border: govuk-spacing(1) solid govuk-colour('blue');
   padding: govuk-spacing(4);
   margin-bottom: govuk-spacing(5);
-  margin-left: govuk-spacing(4);
 
   & h3 {
     margin-bottom: govuk-spacing(2);

--- a/server/views/pages/home-new.html
+++ b/server/views/pages/home-new.html
@@ -15,7 +15,7 @@
       text: "Browse all topics",
       href: "/topics",
       isStartButton: true,
-      classes: "govuk-!-margin-2"
+      classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-2 govuk-!-margin-right-2"
     }) }}
 {% endblock %}
 


### PR DESCRIPTION
…00px

### Context

> Does this issue have a Trello card?
https://trello.com/c/LxbQgfYy/1421-new-homepage-add-left-and-right-margins-to-main-site-when-resized-between-1000px-and-1200px

> If this is an issue, do we have steps to reproduce?
Resize the page between 1000 and 1200px; the left and right gutters disappear

### Intent

> What changes are introduced by this PR that correspond to the above card?
used the govuk mixin to define the new page max width and auto guttering that comes with that. Tweaks to browse button and timetable widget that were attempting to correct the lack of gutters internally.

> Would this PR benefit from screenshots?
<img width="1126" alt="Screenshot 2022-08-17 at 10 26 43" src="https://user-images.githubusercontent.com/50403492/185059961-eaa15677-7d2a-42a6-8e49-07acb137bb69.png">


### Considerations

> Is there any additional information that would help when reviewing this PR?
This change affects ALL pages. Extra effort should be made in testing the rest of the sites functionality.

> Are there any steps required when merging/deploying this PR?
n/a
<img width="1126" alt="Screenshot 2022-08-17 at 10 26 59" src="https://user-images.githubusercontent.com/50403492/185060000-d2e84ccc-a634-4828-9224-4948dc7f46d1.png">


### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
