### PR TITLE
updates styles to enable word wrap

### DIFF
--- a/assets/sass/components/_home-content.scss
+++ b/assets/sass/components/_home-content.scss
@@ -151,7 +151,7 @@
     position: relative;
     margin-bottom: govuk-spacing(1);
     margin-right: 0.4%;
-
+    max-width: 24.7%;
     @media (min-width: $desktop-breakpoint) {
       flex: 0 0 24.7%;
     }
@@ -160,6 +160,7 @@
       color: govuk-colour('white');
       margin: govuk-spacing(1) govuk-spacing(3);
       padding-bottom: 50px;
+      overflow-wrap: break-word;
       @include govuk-font(24, 'bold');
       @media (min-width: $desktop-breakpoint) {
         @include govuk-font(24, 'bold');


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/Y3q3TWWw/1422-fe-bug-tile-sizes-being-distorted-by-long-content-descriptions

> If this is an issue, do we have steps to reproduce?
Visiting https://cookhamwood.content-hub.prisoner.service.justice.gov.uk/recently-added and scrolling down the page, you will see a tile that has been stretched beyond the standard tile width due to a long string that does not wrap.

### Intent

> What changes are introduced by this PR that correspond to the above card?
- Updated CSS to enable word wrapping 
- Updated CSS to set a max-width on the parent tile element. This is essential for the CSS overflow-wrap property to work.

> Would this PR benefit from screenshots?
Prior to the fix:
<img width="1280" alt="Screenshot 2022-08-18 at 07 56 16" src="https://user-images.githubusercontent.com/104000682/185337879-77422226-8a90-4597-9383-8f1a3ab7c100.png">

With the fix in place:
<img width="1248" alt="Screenshot 2022-08-18 at 07 55 48" src="https://user-images.githubusercontent.com/104000682/185337968-a123700c-f375-48ba-9a47-86faefa83a57.png">

<img width="1284" alt="Screenshot 2022-08-18 at 07 56 38" src="https://user-images.githubusercontent.com/104000682/185337979-ddad36e2-272f-4afd-b9a5-28d49544ba32.png">

### Considerations

> Is there any additional information that would help when reviewing this PR?
No.

> Are there any steps required when merging/deploying this PR?
No.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
