### PR TITLE
Bug/1423 media pages not resizing correctly

### DIFF
--- a/assets/sass/components/_media-player.scss
+++ b/assets/sass/components/_media-player.scss
@@ -17,6 +17,13 @@
   margin-right: govuk-spacing(4);
 }
 
+.govuk-hub-title-container {
+  @include govuk-media-query($until: $width-override) {
+    width: 75%;
+    word-wrap: break-word;
+  }
+}
+
 .govuk-hub-media-player__catgeory,
 .govuk-hub-media-player__title {
   color: govuk-colour('white');

--- a/server/views/components/mediaTemplate.njk
+++ b/server/views/components/mediaTemplate.njk
@@ -24,7 +24,7 @@
         <p class="govuk-hub-media-player__catgeory govuk-heading-m">
           <a href="/tags/{{data.seriesId}}" id="series" title="{{ data.seriesName }}" class="govuk-link govuk-hub-media-player__catgeory-link">{{ data.seriesName }}</a>
         </p>
-        <h1 id="title" class="govuk-hub-media-player__title govuk-heading-xl govuk-body govuk-!-font-size-36 govuk-body govuk-!-font-weight-bold">{{ data.title }}</h1>
+        <h1 id="title" class="govuk-heading-xl govuk-body govuk-!-font-size-36 govuk-hub-media-player__title govuk-!-font-weight-bold">{{ data.title }}</h1> <!-- need style to limit title width here -->
       </div>
     </header>
     {% block media %}{% endblock %}

--- a/server/views/components/mediaTemplate.njk
+++ b/server/views/components/mediaTemplate.njk
@@ -24,7 +24,7 @@
         <p class="govuk-hub-media-player__catgeory govuk-heading-m">
           <a href="/tags/{{data.seriesId}}" id="series" title="{{ data.seriesName }}" class="govuk-link govuk-hub-media-player__catgeory-link">{{ data.seriesName }}</a>
         </p>
-        <h1 id="title" class="govuk-heading-xl govuk-body govuk-!-font-size-36 govuk-hub-media-player__title govuk-!-font-weight-bold">{{ data.title }}</h1> <!-- need style to limit title width here -->
+        <h1 id="title" class="govuk-heading-xl govuk-body govuk-!-font-size-36 govuk-hub-media-player__title govuk-!-font-weight-bold">{{ data.title }}</h1>
       </div>
     </header>
     {% block media %}{% endblock %}

--- a/server/views/pages/audio.html
+++ b/server/views/pages/audio.html
@@ -10,6 +10,7 @@
     preload="auto"
     poster="/public/images/radio-player-background.jpg"
     data-setup='{
+      "fluid": true,
       "controlBar": {
         "children": [
             "playToggle",


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/qpb9oAR4/1423-fe-bug-media-pages-not-resizing-correctly

> If this is an issue, do we have steps to reproduce?
na

### Intent

> What changes are introduced by this PR that correspond to the above card?
- Added "fluid": true property to audio component to enable scaling
- Added word-wrap and element width CSS to title page element

> Would this PR benefit from screenshots?

![Screenshot 2022-08-22 at 13 13 18](https://user-images.githubusercontent.com/104000682/185918571-462aecad-6b2f-408e-8f0c-7a27750db267.png)

![Screenshot 2022-08-22 at 10 32 43](https://user-images.githubusercontent.com/104000682/185889427-488e8a20-d346-49c3-8b5e-8fc3050c30bd.png)

### Considerations

> Is there any additional information that would help when reviewing this PR?
no

> Are there any steps required when merging/deploying this PR?
no

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
