### PR TITLE
Add condition around display tag html

### DIFF
--- a/server/views/components/mediaTemplate.njk
+++ b/server/views/components/mediaTemplate.njk
@@ -21,9 +21,11 @@
         <img id="thumbnail" src="{{ data.image.url }}" alt="{{ data.image.alt }}" class="govuk-hub-media-player__show-tag"/>
       </div>
       <div class="govuk-hub-title-container">
-        <p class="govuk-hub-media-player__catgeory govuk-heading-m">
-          <a href="/tags/{{data.seriesId}}" id="series" title="{{ data.seriesName }}" class="govuk-link govuk-hub-media-player__catgeory-link">{{ data.seriesName }}</a>
-        </p>
+        {% if data.seriesId %}
+          <p class="govuk-hub-media-player__catgeory govuk-heading-m">
+            <a href="/tags/{{data.seriesId}}" id="series" title="{{ data.seriesName }}" class="govuk-link govuk-hub-media-player__catgeory-link">{{ data.seriesName }}</a>
+          </p>
+        {% endif %}
         <h1 id="title" class="govuk-heading-xl govuk-body govuk-!-font-size-36 govuk-hub-media-player__title govuk-!-font-weight-bold">{{ data.title }}</h1>
       </div>
     </header>


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/i0UXWdOk/1443-unneeded-html-being-added-to-the-page-forcing-the-title-to-be-pushed-down-when-tag-data-is-not-present

> If this is an issue, do we have steps to reproduce?
na

### Intent

> What changes are introduced by this PR that correspond to the above card?
- Added a condition to display the HTML related to displaying tag data only when the tag data (data.seriesId) is available. This prevents additional HTML being added to the view and pushing down the title. Whilst maintaining the ability to display the Tag when it is available.

> Would this PR benefit from screenshots?

**Prior to the change:**

**No tag available**
![Screenshot 2022-08-19 at 07 58 44](https://user-images.githubusercontent.com/104000682/186350011-8a799b79-4da3-44ea-9cfc-d51379dee06e.png)

**After the change**

**No tag available**
![Screenshot 2022-08-24 at 07 53 13](https://user-images.githubusercontent.com/104000682/186350813-4cf405e8-7a14-461e-b4da-0f60be392c0c.png)

**Tag available prior to and after the change**
![Screenshot 2022-08-19 at 07 59 04](https://user-images.githubusercontent.com/104000682/186350889-892c06fb-afd3-435f-8c7f-83dbcb099624.png)

### Considerations

> Is there any additional information that would help when reviewing this PR?
No

> Are there any steps required when merging/deploying this PR?
No

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
