### PR TITLE
bug/1429-add condition to display place holder image

### DIFF
--- a/server/views/components/update-items/template.njk
+++ b/server/views/components/update-items/template.njk
@@ -1,8 +1,11 @@
 {% macro updateItem(item) %}
   <a class="govuk-hub-update-items-link govuk-link govuk-!-margin-bottom-3" data-featured-tile-id="{{ item.id }}" data-featured-id="{{item.id}}" data-featured-title="{{ item.title }}" href="{{item.contentUrl}}" {% if item.externalContent %}target="_blank"{% endif %}>
     <div class="govuk-hub-update-items-link_content">
-      <img src="{{item.image.url}}" alt="{{item.image.alt}}">
-
+       {% if item.image.url %}
+        <img src="{{item.image.url}}" alt="{{item.image.alt}}" class="tile-image">
+      {% else %}
+        <img src="/public/images/default_small_tile_hub_logo.png" alt="logo" class="tile-image">
+      {% endif %}
       <div class="govuk-hub-update-items-link_text govuk-!-margin-0">
         <h3 class="govuk-heading-s">{{item.publishedAt}}</h3>
         <p class="govuk-body">{{item.title | safe}}</p>


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/WE8lpHRS/1429-homepage-updates-links-are-not-using-the-default-image-if-there-is-no-image

> If this is an issue, do we have steps to reproduce?
visit https://stokeheath.content-hub.prisoner.service.justice.gov.uk > homepage > updates section. Where an image hasn't been set for an update the hub logo is not currently displayed. This update fixes this. 

### Intent

> What changes are introduced by this PR that correspond to the above card?
- Added a condition to display the hub logo place holder image in place of an empty space.

> Would this PR benefit from screenshots?

**prior to the change**
![Screenshot 2022-08-25 at 08 26 18](https://user-images.githubusercontent.com/104000682/186602123-5d3b2783-780b-455b-a4b9-11f88836e416.png)

**after the change**
![Screenshot 2022-08-25 at 09 39 14](https://user-images.githubusercontent.com/104000682/186618006-d643cb56-e2e2-4566-9de9-f33711aa56ce.png)


### Considerations

> Is there any additional information that would help when reviewing this PR?
no

> Are there any steps required when merging/deploying this PR?
no

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
