### PR TITLE
Add urgent banner component and styles

### DIFF
--- a/assets/sass/components/_urgent-banner.scss
+++ b/assets/sass/components/_urgent-banner.scss
@@ -1,0 +1,36 @@
+.govuk-notification-banner--urgent {
+  @extend .govuk-notification-banner;
+
+  border-color: #d4351c;
+  background-color: #d4351c;
+  color: #fff;
+  margin-bottom: 0;
+
+  .govuk-notification-banner__heading {
+    min-width: 100%;
+  }
+
+  .govuk-notification-banner__link:link,
+  .govuk-notification-banner__link:visited {
+    color: #d4351c;
+  }
+
+  .govuk-notification-banner__link:hover {
+    color: #922615;
+  }
+
+  .govuk-notification-banner__link:active,
+  .govuk-notification-banner__link:focus {
+    color: #000000;
+  }
+
+  @media (max-width: $tablet-breakpoint) {
+    h2 {
+      padding: 0.2em 0;
+    }
+
+    svg {
+      transform: scale(0.9);
+    }
+  }
+}

--- a/assets/sass/components/_urgent-banner.scss
+++ b/assets/sass/components/_urgent-banner.scss
@@ -24,7 +24,7 @@
     color: #000000;
   }
 
-  @media (max-width: $tablet-breakpoint) {
+  @include govuk-media-query($until: tablet) {
     h2 {
       padding: 0.2em 0;
     }

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -43,6 +43,7 @@ $real-dark-grey: #232425;
 @import 'components/card';
 @import 'components/external-link';
 @import 'components/related-topics';
+@import 'components/urgent-banner';
 
 @import 'pages/flat-content';
 @import 'pages/step-by-step';

--- a/e2e/cypress/features/profile.feature.js
+++ b/e2e/cypress/features/profile.feature.js
@@ -5,6 +5,7 @@ describe('Profile', () => {
   beforeEach(() => {
     cy.task('reset');
     cy.task('stubPrimaryNavigation');
+    cy.task('stubUrgentBanners');
     cy.task('stubBrowseAllTopics');
     cy.visit(`http://cookhamwood.content-hub.localhost:3000/profile`);
   });

--- a/e2e/cypress/features/timetable.feature.js
+++ b/e2e/cypress/features/timetable.feature.js
@@ -5,6 +5,7 @@ describe('Timetable', () => {
   beforeEach(() => {
     cy.task('reset');
     cy.task('stubPrimaryNavigation');
+    cy.task('stubUrgentBanners');
     cy.task('stubBrowseAllTopics');
     cy.visit(`http://cookhamwood.content-hub.localhost:3000/timetable`);
   });

--- a/e2e/cypress/mockApis/drupal.js
+++ b/e2e/cypress/mockApis/drupal.js
@@ -2,6 +2,7 @@ const jwt = require('jsonwebtoken');
 const { stubFor } = require('./wiremock');
 const primaryNavigationData = require('./drupalData/primaryNavigation.json');
 const browseAllTopicsData = require('./drupalData/browseAllTopics.json');
+const urgentBannersData = require('./drupalData/urgentBanners.json');
 
 const stubPrimaryNavigation = () =>
   stubFor({
@@ -33,7 +34,23 @@ const stubBrowseAllTopics = () =>
     },
   });
 
+const stubUrgentBanners = () =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/drupal/jsonapi/prison/.*?/node/urgent_banner.*?',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: urgentBannersData,
+    },
+  });
+
 module.exports = {
   stubPrimaryNavigation,
   stubBrowseAllTopics,
+  stubUrgentBanners,
 };

--- a/e2e/cypress/mockApis/drupalData/urgentBanners.json
+++ b/e2e/cypress/mockApis/drupalData/urgentBanners.json
@@ -1,0 +1,318 @@
+{
+  "jsonapi": {
+    "version": "1.0",
+    "meta": {
+      "links": {
+        "self": {
+          "href": "http://jsonapi.org/format/1.0/"
+        }
+      }
+    }
+  },
+  "data": [
+    {
+      "type": "node--urgent_banner",
+      "id": "2c562bbb-b00e-47f3-a170-5d0dbb87882b",
+      "links": {
+        "self": {
+          "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/urgent_banner/2c562bbb-b00e-47f3-a170-5d0dbb87882b?resourceVersion=id%3A64817"
+        }
+      },
+      "attributes": {
+        "drupal_internal__nid": 18631,
+        "title": "Urgent update - This is a test update whilst we work on this functionality",
+        "created": "2022-08-23T13:21:13+00:00",
+        "changed": "2022-08-23T13:23:10+00:00"
+      },
+      "relationships": {
+        "field_more_info_page": {
+          "data": {
+            "type": "node--page",
+            "id": "82e03a3e-76e2-4d96-ac68-5c871f719177",
+            "meta": {
+              "drupal_internal__target_id": 7181
+            }
+          },
+          "links": {
+            "related": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/urgent_banner/2c562bbb-b00e-47f3-a170-5d0dbb87882b/field_more_info_page?resourceVersion=id%3A64817"
+            },
+            "self": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/urgent_banner/2c562bbb-b00e-47f3-a170-5d0dbb87882b/relationships/field_more_info_page?resourceVersion=id%3A64817"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "node--urgent_banner",
+      "id": "24f2974e-c72a-4921-8c49-413e48a1fc41",
+      "links": {
+        "self": {
+          "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/urgent_banner/24f2974e-c72a-4921-8c49-413e48a1fc41?resourceVersion=id%3A64818"
+        }
+      },
+      "attributes": {
+        "drupal_internal__nid": 18632,
+        "title": "Urgent update - This is another test update whilst we work on this functionality (with no more info link)",
+        "created": "2022-08-23T13:23:24+00:00",
+        "changed": "2022-08-23T13:23:47+00:00"
+      },
+      "relationships": {
+        "field_more_info_page": {
+          "data": null,
+          "links": {
+            "related": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/urgent_banner/24f2974e-c72a-4921-8c49-413e48a1fc41/field_more_info_page?resourceVersion=id%3A64818"
+            },
+            "self": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/urgent_banner/24f2974e-c72a-4921-8c49-413e48a1fc41/relationships/field_more_info_page?resourceVersion=id%3A64818"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "type": "node--page",
+      "id": "82e03a3e-76e2-4d96-ac68-5c871f719177",
+      "links": {
+        "self": {
+          "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177?resourceVersion=id%3A63238"
+        }
+      },
+      "attributes": {
+        "drupal_internal__nid": 7181,
+        "title": "FYI: Vitamin D",
+        "created": "2020-11-13T12:40:16+00:00",
+        "breadcrumbs": [
+          {
+            "uri": "/",
+            "title": "Home",
+            "options": []
+          },
+          {
+            "uri": "/tags/644",
+            "title": "News and events",
+            "options": []
+          },
+          {
+            "uri": "/tags/1394",
+            "title": "FYI: Information in Wayland",
+            "options": []
+          }
+        ],
+        "field_exclude_feedback": false,
+        "field_moj_description": {
+          "value": "<p>&nbsp;</p>\r\n\r\n<p><a href=\"/content/7183\">HMPPS Question and Answers&nbsp;about vitamin D</a></p>\r\n\r\n<p><a href=\"/content/7180\">Information from the NHS website&nbsp;about vitamin D</a></p>\r\n\r\n<p><img alt=\"Vitamin D Poster\" data-align=\"left\" data-entity-type=\"file\" data-entity-uuid=\"0e832cd6-0519-4539-8efa-2d7ff98d56d0\" height=\"1396\" src=\"https://cloud-platform-5e5f7ac99afe21a0181cbf50a850627b.s3.eu-west-1.amazonaws.com/inline-images/Screenshot%202020-11-13%20at%2012.45.50.png?X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&amp;X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=AKIA27HJSWAHOEAPZ56S%2F20220804%2Feu-west-1%2Fs3%2Faws4_request&amp;X-Amz-Date=20220804T151422Z&amp;X-Amz-SignedHeaders=host&amp;X-Amz-Expires=38738&amp;X-Amz-Signature=1ceff029c5f497eef618d82c0558f0f8785d1a9f61b6d064c86468f9f1f10001\" width=\"990\" /></p>\r\n",
+          "format": "basic_html",
+          "processed": "<p> </p>\n\n<p><a href=\"/content/7183\">HMPPS Question and Answers about vitamin D</a></p>\n\n<p><a href=\"/content/7180\">Information from the NHS website about vitamin D</a></p>\n\n<p><img alt=\"Vitamin D Poster\" data-entity-type=\"file\" data-entity-uuid=\"0e832cd6-0519-4539-8efa-2d7ff98d56d0\" height=\"1396\" src=\"https://cloud-platform-c3b3fc90408e8f9501268e354d44f461.s3.eu-west-2.amazonaws.com/inline-images/Screenshot%202020-11-13%20at%2012.45.50.png?X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&amp;X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=AKIA27HJSWAHLQIQVZEJ%2F20220901%2Feu-west-2%2Fs3%2Faws4_request&amp;X-Amz-Date=20220901T061437Z&amp;X-Amz-SignedHeaders=host&amp;X-Amz-Expires=71123&amp;X-Amz-Signature=acd3d2749b467077bf086f454c58e270cea7cdb45e61f606b4f2bc1518ca548c\" width=\"990\" class=\"align-left\" loading=\"lazy\" /></p>",
+          "summary": "Information about the benefits of vitamin D and you can access it."
+        },
+        "field_moj_stand_first": "Your body needs vitamin D. From 1 March you can order vitamin D on canteen forms – free of charge. ",
+        "drupal_internal__vid": 63238,
+        "langcode": "en",
+        "revision_timestamp": "2022-08-04T15:14:34+00:00",
+        "revision_log": null,
+        "status": true,
+        "changed": "2022-08-04T15:14:34+00:00",
+        "promote": false,
+        "sticky": false,
+        "default_langcode": true,
+        "revision_translation_affected": true,
+        "path": {
+          "alias": "/content/7181",
+          "pid": 2872,
+          "langcode": "en"
+        },
+        "series_sort_value": -1614168000,
+        "publish_on": null,
+        "unpublish_on": null,
+        "published_at": "2020-11-13T12:50:07+00:00",
+        "field_moj_episode": null,
+        "field_moj_season": null,
+        "field_not_in_series": true,
+        "field_release_date": null
+      },
+      "relationships": {
+        "field_moj_series": {
+          "data": null,
+          "links": {
+            "related": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/field_moj_series?resourceVersion=id%3A63238"
+            },
+            "self": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/relationships/field_moj_series?resourceVersion=id%3A63238"
+            }
+          }
+        },
+        "field_moj_top_level_categories": {
+          "data": {
+            "type": "taxonomy_term--moj_categories",
+            "id": "91b023c9-fb03-422c-9f70-3c7a5da0e2ff",
+            "meta": {
+              "drupal_internal__target_id": 1394
+            }
+          },
+          "links": {
+            "related": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/field_moj_top_level_categories?resourceVersion=id%3A63238"
+            },
+            "self": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/relationships/field_moj_top_level_categories?resourceVersion=id%3A63238"
+            }
+          }
+        },
+        "field_topics": {
+          "data": [],
+          "links": {
+            "related": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/field_topics?resourceVersion=id%3A63238"
+            },
+            "self": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/relationships/field_topics?resourceVersion=id%3A63238"
+            }
+          }
+        },
+        "node_type": {
+          "data": {
+            "type": "node_type--node_type",
+            "id": "2a0fd1a2-181b-4638-b6f0-9356b1a84dca",
+            "meta": {
+              "drupal_internal__target_id": "page"
+            }
+          },
+          "links": {
+            "related": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/node_type?resourceVersion=id%3A63238"
+            },
+            "self": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/relationships/node_type?resourceVersion=id%3A63238"
+            }
+          }
+        },
+        "revision_uid": {
+          "data": {
+            "type": "user--user",
+            "id": "5dba7612-5f74-41e3-9022-781214f2fa4c",
+            "meta": {
+              "drupal_internal__target_id": 975
+            }
+          },
+          "links": {
+            "related": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/revision_uid?resourceVersion=id%3A63238"
+            },
+            "self": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/relationships/revision_uid?resourceVersion=id%3A63238"
+            }
+          }
+        },
+        "uid": {
+          "data": {
+            "type": "user--user",
+            "id": "65af138a-aa71-4197-99aa-df114ea3c108",
+            "meta": {
+              "drupal_internal__target_id": 278
+            }
+          },
+          "links": {
+            "related": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/uid?resourceVersion=id%3A63238"
+            },
+            "self": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/relationships/uid?resourceVersion=id%3A63238"
+            }
+          }
+        },
+        "field_exclude_from_prison": {
+          "data": [],
+          "links": {
+            "related": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/field_exclude_from_prison?resourceVersion=id%3A63238"
+            },
+            "self": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/relationships/field_exclude_from_prison?resourceVersion=id%3A63238"
+            }
+          }
+        },
+        "field_moj_secondary_tags": {
+          "data": [],
+          "links": {
+            "related": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/field_moj_secondary_tags?resourceVersion=id%3A63238"
+            },
+            "self": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/relationships/field_moj_secondary_tags?resourceVersion=id%3A63238"
+            }
+          }
+        },
+        "field_moj_thumbnail_image": {
+          "data": {
+            "type": "file--file",
+            "id": "7b644727-f615-4d08-8511-0821b38a3440",
+            "meta": {
+              "alt": "Vitamin D in prison",
+              "title": "",
+              "width": 990,
+              "height": 1396,
+              "drupal_internal__target_id": 18730
+            }
+          },
+          "links": {
+            "related": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/field_moj_thumbnail_image?resourceVersion=id%3A63238"
+            },
+            "self": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/relationships/field_moj_thumbnail_image?resourceVersion=id%3A63238"
+            }
+          }
+        },
+        "field_prisons": {
+          "data": [
+            {
+              "type": "taxonomy_term--prisons",
+              "id": "b73767ea-2cbb-4ad5-ba22-09379cc07241",
+              "meta": {
+                "drupal_internal__target_id": 793
+              }
+            }
+          ],
+          "links": {
+            "related": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/field_prisons?resourceVersion=id%3A63238"
+            },
+            "self": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/relationships/field_prisons?resourceVersion=id%3A63238"
+            }
+          }
+        },
+        "field_prison_owner": {
+          "data": [
+            {
+              "type": "taxonomy_term--prisons",
+              "id": "b73767ea-2cbb-4ad5-ba22-09379cc07241",
+              "meta": {
+                "drupal_internal__target_id": 793
+              }
+            }
+          ],
+          "links": {
+            "related": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/field_prison_owner?resourceVersion=id%3A63238"
+            },
+            "self": {
+              "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/page/82e03a3e-76e2-4d96-ac68-5c871f719177/relationships/field_prison_owner?resourceVersion=id%3A63238"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "links": {
+    "self": {
+      "href": "https://jsonapi-cms-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk/jsonapi/prison/wayland/node/urgent_banner?fields%5Bnode--urgent_banner%5D=drupal_internal__nid%2Ctitle%2Ccreated%2Cchanged%2Cfield_more_info_page&include=field_more_info_page"
+    }
+  }
+}

--- a/e2e/cypress/support/step_definitions/common.js
+++ b/e2e/cypress/support/step_definitions/common.js
@@ -2,6 +2,7 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
 import { activity, appointment } from '../../mockApis/data';
 import { horizontalTableToObject } from './utils';
 import { format, addDays } from 'date-fns';
+import { cy } from 'date-fns/locale';
 
 Given(
   'that with an {string} content hub url, I request {string} page',
@@ -27,6 +28,7 @@ Given(
   'that with an {string} content hub url, I go to the {string} page',
   (establishment, page) => {
     cy.task('stubPrimaryNavigation');
+    cy.task('stubUrgentBanners');
     cy.task('stubBrowseAllTopics');
     const establishmentString = establishment
       ? `${establishment.toLowerCase().replace(' ', '')}.`
@@ -42,6 +44,7 @@ Given('that I am viewing some content', () => {
 
 Given('that I go to the {string} page', val => {
   cy.task('stubPrimaryNavigation');
+  cy.task('stubUrgentBanners');
   cy.task('stubBrowseAllTopics');
   cy.visit(`/${val}`);
 });

--- a/server/__tests__/app.spec.js
+++ b/server/__tests__/app.spec.js
@@ -318,6 +318,7 @@ function app(opts = {}) {
   const services = {
     cmsService: {
       getPrimaryNavigation: jest.fn().mockResolvedValue([]),
+      getUrgentBanners: jest.fn().mockResolvedValue([]),
       getTopics: jest.fn().mockResolvedValue([]),
     },
     offenderService: {

--- a/server/middleware/urgentBannerMiddleware.js
+++ b/server/middleware/urgentBannerMiddleware.js
@@ -1,0 +1,13 @@
+module.exports =
+  cmsService =>
+  async ({ session: { establishmentName } }, res, next) => {
+    try {
+      const urgentBanners = await cmsService.getUrgentBanners(
+        establishmentName,
+      );
+      res.locals.urgentBanners = urgentBanners;
+      return next();
+    } catch (e) {
+      return next(e);
+    }
+  };

--- a/server/repositories/cmsQueries/__tests__/urgentBannerQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/urgentBannerQuery.spec.js
@@ -5,7 +5,7 @@ describe('Urgent banner query', () => {
   describe('path', () => {
     it('should create correct path', async () => {
       expect(query.path()).toStrictEqual(
-        '/jsonapi/prison/wayland/node/urgent_banner?include=field_more_info_page&fields%5Bnode--urgent_banner%5D=drupal_internal__nid%2Ctitle%2Ccreated%2Cchanged%2Cfield_more_info_page',
+        '/jsonapi/prison/wayland/node/urgent_banner?include=field_more_info_page&fields%5Bnode--urgent_banner%5D=drupal_internal__nid%2Ctitle%2Ccreated%2Cchanged%2Cfield_more_info_page%2Cunpublish_on',
       );
     });
   });
@@ -14,6 +14,7 @@ describe('Urgent banner query', () => {
     it('should create correct structure', async () => {
       const banner = {
         title: 'banner',
+        unpublish_on: '2022-08-04T15:14:34+00:00',
         fieldMoreInfoPage: {
           path: {
             alias: '/more/info',
@@ -22,7 +23,8 @@ describe('Urgent banner query', () => {
       };
       expect(query.transformEach(banner)).toStrictEqual({
         title: 'banner',
-        more_info_link: '/more/info',
+        moreInfoLink: '/more/info',
+        unpublishOn: 1659626074000,
       });
     });
   });

--- a/server/repositories/cmsQueries/__tests__/urgentBannerQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/urgentBannerQuery.spec.js
@@ -1,0 +1,29 @@
+const { UrgentBannerQuery } = require('../urgentBannerQuery');
+
+describe('Urgent banner query', () => {
+  const query = new UrgentBannerQuery('wayland');
+  describe('path', () => {
+    it('should create correct path', async () => {
+      expect(query.path()).toStrictEqual(
+        '/jsonapi/prison/wayland/node/urgent_banner?include=field_more_info_page&fields%5Bnode--urgent_banner%5D=drupal_internal__nid%2Ctitle%2Ccreated%2Cchanged%2Cfield_more_info_page',
+      );
+    });
+  });
+
+  describe('transformEach', () => {
+    it('should create correct structure', async () => {
+      const banner = {
+        title: 'banner',
+        fieldMoreInfoPage: {
+          path: {
+            alias: '/more/info',
+          },
+        },
+      };
+      expect(query.transformEach(banner)).toStrictEqual({
+        title: 'banner',
+        more_info_link: '/more/info',
+      });
+    });
+  });
+});

--- a/server/repositories/cmsQueries/urgentBannerQuery.js
+++ b/server/repositories/cmsQueries/urgentBannerQuery.js
@@ -1,0 +1,33 @@
+const { DrupalJsonApiParams: Query } = require('drupal-jsonapi-params');
+
+class UrgentBannerQuery {
+  constructor(establishmentName) {
+    this.establishmentName = establishmentName;
+    this.query = new Query()
+
+      .addFields('node--urgent_banner', [
+        'drupal_internal__nid',
+        'title',
+        'created',
+        'changed',
+        'field_more_info_page',
+      ])
+
+      .addInclude(['field_more_info_page'])
+
+      .getQueryString();
+  }
+
+  path() {
+    return `/jsonapi/prison/${this.establishmentName}/node/urgent_banner?${this.query}`;
+  }
+
+  transformEach(banner) {
+    return {
+      title: banner.title,
+      more_info_link: banner.fieldMoreInfoPage?.path?.alias,
+    };
+  }
+}
+
+module.exports = { UrgentBannerQuery };

--- a/server/repositories/cmsQueries/urgentBannerQuery.js
+++ b/server/repositories/cmsQueries/urgentBannerQuery.js
@@ -1,4 +1,5 @@
 const { DrupalJsonApiParams: Query } = require('drupal-jsonapi-params');
+const { getCmsCacheKey } = require('../../utils/caching/cms');
 
 class UrgentBannerQuery {
   constructor(establishmentName) {
@@ -11,11 +12,20 @@ class UrgentBannerQuery {
         'created',
         'changed',
         'field_more_info_page',
+        'unpublish_on',
       ])
 
       .addInclude(['field_more_info_page'])
 
       .getQueryString();
+  }
+
+  getKey() {
+    return getCmsCacheKey('urgentBanner', this.establishmentName);
+  }
+
+  getExpiry() {
+    return 300;
   }
 
   path() {
@@ -25,7 +35,8 @@ class UrgentBannerQuery {
   transformEach(banner) {
     return {
       title: banner.title,
-      more_info_link: banner.fieldMoreInfoPage?.path?.alias,
+      moreInfoLink: banner.fieldMoreInfoPage?.path?.alias,
+      unpublishOn: new Date(banner.unpublish_on).getTime() || null,
     };
   }
 }

--- a/server/routes/__tests__/profile.spec.js
+++ b/server/routes/__tests__/profile.spec.js
@@ -20,6 +20,7 @@ describe('GET /profile', () => {
   beforeEach(() => {
     const cmsService = {
       getPrimaryNavigation: jest.fn().mockResolvedValue([]),
+      getUrgentBanners: jest.fn().mockResolvedValue([]),
       getTopics: jest.fn().mockReturnValue([]),
     };
     app = setupApp({ offenderService, cmsService });

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -19,6 +19,7 @@ const { createRecentlyAddedContentRouter } = require('./recentlyAdded');
 const { createUpdatesContentRouter } = require('./updates');
 const createPrimaryNavigationMiddleware = require('../middleware/primaryNavigationMiddleware');
 const retrieveTopicList = require('../middleware/retrieveTopicList');
+const urgentBannerMiddleware = require('../middleware/urgentBannerMiddleware');
 
 module.exports = (
   {
@@ -54,6 +55,7 @@ module.exports = (
     [
       createPrimaryNavigationMiddleware(cmsService),
       retrieveTopicList(cmsService),
+      urgentBannerMiddleware(cmsService),
     ],
   );
 

--- a/server/services/__tests__/cmsService.spec.js
+++ b/server/services/__tests__/cmsService.spec.js
@@ -1006,34 +1006,37 @@ describe('cms Service', () => {
   });
 
   describe('getUrgentBanners', () => {
-    const createUrgentBanner = name => ({
-      title: `${name}`,
-      more_info_link: '/more/info',
-    });
+    const resArray = [
+      {
+        title: 'banner',
+        moreInfoLink: '/more/info',
+        unpublishedOn: '111',
+      },
+    ];
     let result;
+
     beforeEach(async () => {
-      cmsApi.get.mockResolvedValue([createUrgentBanner('banner')]);
+      cmsApi.getCache.mockResolvedValueOnce(resArray);
       result = await cmsService.getUrgentBanners(ESTABLISHMENT_NAME);
     });
-    it('first checks the cache', () => {
-      expect(testCacheStrategy.get).toHaveBeenCalledTimes(1);
+    it('should call cmsApi.getCache once', () => {
+      expect(cmsApi.getCache).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call cmsApi.get with the ExploreContentQuery', async () => {
+      expect(cmsApi.getCache).toHaveBeenCalledWith(
+        new UrgentBannerQuery(ESTABLISHMENT_NAME),
+      );
     });
 
     it('returns urgent banner', () => {
       expect(result).toStrictEqual([
         {
           title: `banner`,
-          more_info_link: '/more/info',
+          moreInfoLink: '/more/info',
+          unpublishedOn: '111',
         },
       ]);
-    });
-    it('it sets the cache', () => {
-      expect(testCacheStrategy.set).toHaveBeenCalledTimes(1);
-    });
-    it('Source to have been called correctly', async () => {
-      expect(cmsApi.get).toHaveBeenCalledWith(
-        new UrgentBannerQuery(ESTABLISHMENT_NAME),
-      );
     });
   });
 });

--- a/server/services/__tests__/cmsService.spec.js
+++ b/server/services/__tests__/cmsService.spec.js
@@ -56,6 +56,9 @@ const { CmsService } = require('../cms');
 const {
   PrimaryNavigationQuery,
 } = require('../../repositories/cmsQueries/PrimaryNavigationQuery');
+const {
+  UrgentBannerQuery,
+} = require('../../repositories/cmsQueries/urgentBannerQuery');
 
 jest.mock('../../repositories/cmsApi');
 
@@ -999,6 +1002,38 @@ describe('cms Service', () => {
 
     it('should return a result when cmsApi.get is called', async () => {
       expect(result).toBe(resObject);
+    });
+  });
+
+  describe('getUrgentBanners', () => {
+    const createUrgentBanner = name => ({
+      title: `${name}`,
+      more_info_link: '/more/info',
+    });
+    let result;
+    beforeEach(async () => {
+      cmsApi.get.mockResolvedValue([createUrgentBanner('banner')]);
+      result = await cmsService.getUrgentBanners(ESTABLISHMENT_NAME);
+    });
+    it('first checks the cache', () => {
+      expect(testCacheStrategy.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns urgent banner', () => {
+      expect(result).toStrictEqual([
+        {
+          title: `banner`,
+          more_info_link: '/more/info',
+        },
+      ]);
+    });
+    it('it sets the cache', () => {
+      expect(testCacheStrategy.set).toHaveBeenCalledTimes(1);
+    });
+    it('Source to have been called correctly', async () => {
+      expect(cmsApi.get).toHaveBeenCalledWith(
+        new UrgentBannerQuery(ESTABLISHMENT_NAME),
+      );
     });
   });
 });

--- a/server/services/cms.js
+++ b/server/services/cms.js
@@ -55,6 +55,8 @@ const { InMemoryCachingStrategy } = require('../utils/caching/memory');
 
 const { getOffsetUnixTime } = require('../utils/date');
 
+const { isUnpublished } = require('../utils/jsonApi');
+
 class CmsService {
   #cmsApi;
 
@@ -284,12 +286,10 @@ class CmsService {
   }
 
   async getUrgentBanners(establishmentName) {
-    return getCacheArrayQuery(
-      this.getQueryWrapper(UrgentBannerQuery, establishmentName),
-      this.#cache,
-      getCacheKey(CMS_URGENT_BANNER, establishmentName),
-      300,
-    );
+    const urgentBanner = await this.#cmsApi
+      .getCache(new UrgentBannerQuery(establishmentName))
+      .then(res => res.filter(isUnpublished));
+    return urgentBanner;
   }
 }
 

--- a/server/services/cms.js
+++ b/server/services/cms.js
@@ -47,6 +47,9 @@ const {
 const {
   ExploreContentQuery,
 } = require('../repositories/cmsQueries/exploreContentQuery');
+const {
+  UrgentBannerQuery,
+} = require('../repositories/cmsQueries/urgentBannerQuery');
 
 const { InMemoryCachingStrategy } = require('../utils/caching/memory');
 
@@ -278,6 +281,15 @@ class CmsService {
     );
 
     return RecentlyAddedHomepageContent;
+  }
+
+  async getUrgentBanners(establishmentName) {
+    return getCacheArrayQuery(
+      this.getQueryWrapper(UrgentBannerQuery, establishmentName),
+      this.#cache,
+      getCacheKey(CMS_URGENT_BANNER, establishmentName),
+      300,
+    );
   }
 }
 

--- a/server/utils/__tests__/jsonApi.spec.js
+++ b/server/utils/__tests__/jsonApi.spec.js
@@ -10,6 +10,7 @@ const {
   isBottomCategory,
   isNew,
   cropTextWithEllipsis,
+  isUnpublished,
 } = require('../jsonApi');
 
 const LARGE_TILE = 'enormous.jpg';
@@ -339,6 +340,28 @@ describe('getCategoryId', () => {
   });
   it('should cater for legacy receiving an array and return the category id from the first element', () => {
     expect(getCategoryId([categoryData])).toEqual({ id: ID1, uuid: UUID1 });
+  });
+});
+
+describe('isUnpublished', () => {
+  const now = new Date('2022-08-04T15:14:34+00:00').getTime();
+  let data;
+  beforeEach(() => {
+    data = { unpublishOn: now };
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+  it('should return false when the unpublish on date is in the past', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2022-08-05'));
+    expect(isUnpublished(data)).toBeFalsy();
+  });
+  it('should return true when the unpublish on date is in the future', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2022-08-03'));
+    expect(isUnpublished(data)).toBeTruthy();
+  });
+  it('should return true when the unpublish on date is not set', () => {
+    expect(isUnpublished({ unpublishOn: null })).toBeTruthy();
   });
 });
 

--- a/server/utils/jsonApi.js
+++ b/server/utils/jsonApi.js
@@ -76,6 +76,9 @@ const getCategoryId = categories => {
   };
 };
 
+const isUnpublished = ({ unpublishOn = null }) =>
+  !unpublishOn || unpublishOn >= new Date().getTime();
+
 const buildFieldTopics = (arr = []) =>
   arr.map(({ drupalInternal_Tid: id, name, id: uuid }) => ({
     id,
@@ -157,6 +160,7 @@ module.exports = {
   getLargeImage,
   getPublishedAtSmallTile,
   getCategoryId,
+  isUnpublished,
   buildFieldTopics,
   typeFrom,
   isBottomCategory,

--- a/server/views/components/basicTemplate.njk
+++ b/server/views/components/basicTemplate.njk
@@ -6,6 +6,7 @@
 {% from "../components/page-navigation/macro.njk" import pageNavigation %}
 {% from "./top-bar/macro.njk" import topBar %}
 {% from "./user-details/macro.njk" import userDetails %}
+{% from "./urgent-banner/macro.njk" import urgentBanner %}
 
 <!DOCTYPE html>
 <html lang="{{ htmlLang | default('en') }}" class="govuk-template {{ htmlClasses }}">
@@ -67,8 +68,12 @@
         }) }}
       {% endif %}
     {% endblock %}
+
     {% block notificationUserDetailsBar %}
       <div class="govuk-width-container">
+
+        {{ urgentBanner(urgentBanners) }}
+
         <div class="govuk-hub-navigationUserDetailsBar">
           {% block pageNavigation %}
             {{ pageNavigation({ title: title, hideHomePage: data.breadcrumbs  }) }}

--- a/server/views/components/urgent-banner/macro.njk
+++ b/server/views/components/urgent-banner/macro.njk
@@ -1,0 +1,3 @@
+{% macro urgentBanner(urgentBannerContent) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/components/urgent-banner/template.njk
+++ b/server/views/components/urgent-banner/template.njk
@@ -19,8 +19,8 @@
         <p class="govuk-notification-banner__heading">
         {{ urgentBanner.title }}
 
-        {% if urgentBanner.more_info_link %} 
-          <a class="govuk-notification-banner__link" href="{{ urgentBanner.more_info_link }}">More info</a>
+        {% if urgentBanner.moreInfoLink %} 
+          <a class="govuk-notification-banner__link" href="{{ urgentBanner.moreInfoLink }}">More info</a>
         {% endif %}
         </p>
       </div>

--- a/server/views/components/urgent-banner/template.njk
+++ b/server/views/components/urgent-banner/template.njk
@@ -1,0 +1,30 @@
+{% if urgentBannerContent %} 
+
+  {% for urgentBanner in urgentBannerContent %}
+    <div class="govuk-notification-banner--urgent
+                govuk-!-margin-top-4"
+        aria-labelledby="govuk-notification-banner-title">
+
+      <div class="govuk-notification-banner__header">
+        <svg class="moj-banner__icon" fill="white" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+          <path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8
+        C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z" />
+        </svg>
+        <h2 class="govuk-notification-banner__title" 
+            id="govuk-notification-banner-title">
+          URGENT
+        </h2>
+      </div>
+      <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">
+        {{ urgentBanner.title }}
+
+        {% if urgentBanner.more_info_link %} 
+          <a class="govuk-notification-banner__link" href="{{ urgentBanner.more_info_link }}">More info</a>
+        {% endif %}
+        </p>
+      </div>
+    </div>
+  {% endfor %}
+
+{% endif %}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/Isn6DtTl/997-allow-prisoners-to-see-urgent-notices-in-the-banner?filter=label:Front+End

> If this is an issue, do we have steps to reproduce?
n/a

### Intent

> What changes are introduced by this PR that correspond to the above card?
- Added a new Urgent banner component and supporting styles

> Would this PR benefit from screenshots?
![Screenshot 2022-08-30 at 15 32 06](https://user-images.githubusercontent.com/104000682/187464902-84ece5da-8052-4750-89cb-80d7ba3fb167.png)
![Screenshot 2022-08-30 at 15 32 22](https://user-images.githubusercontent.com/104000682/187464913-9b32e26c-27a0-4cac-bb66-4ad1284ee5c6.png)

<img width="487" alt="Screenshot 2022-08-31 at 07 22 49" src="https://user-images.githubusercontent.com/104000682/187608128-099bb98e-3a80-40eb-9df4-b21d3aea837f.png">


### Considerations

> Is there any additional information that would help when reviewing this PR?
n/a

> Are there any steps required when merging/deploying this PR?
n/a

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
