### PR TITLE
Bug/1480 remove duplicate updates content

### DIFF
--- a/server/routes/__tests__/homepage.spec.js
+++ b/server/routes/__tests__/homepage.spec.js
@@ -20,6 +20,7 @@ describe('GET /', () => {
   let featuredContent;
   let keyInfo;
   let largeUpdateTile;
+  let hubUpdatesContent;
 
   beforeEach(() => {
     featuredItem = {
@@ -85,6 +86,21 @@ describe('GET /', () => {
         contentUrl: '/content/444444',
         displayUrl: undefined,
         image: { url: 'image url', alt: 'Alt text' },
+        publishedAt: 'Monday 30th October',
+      },
+    ];
+    hubUpdatesContent = [
+      ...hubContent,
+      {
+        id: 555555,
+        contentType: 'video',
+        externalContent: false,
+        title:
+          'A title that is long enough to be cropped with an ellipse added to the end',
+        summary: 'A summary',
+        contentUrl: '/content/555555',
+        displayUrl: undefined,
+        image: { url: 'image url', alt: 'Alt text' },
         publishedAt: 'Monday 17th October',
       },
     ];
@@ -120,7 +136,7 @@ describe('GET /', () => {
       }),
       getUpdatesContent: jest.fn().mockResolvedValue({
         largeUpdateTileDefault: hubContent[0],
-        updatesContent: [...hubContent],
+        updatesContent: [...hubUpdatesContent],
       }),
     };
   });

--- a/server/routes/__tests__/homepage.spec.js
+++ b/server/routes/__tests__/homepage.spec.js
@@ -21,6 +21,7 @@ describe('GET /', () => {
   let keyInfo;
   let largeUpdateTile;
   let hubUpdatesContent;
+  let uniqueHubcontent;
 
   beforeEach(() => {
     featuredItem = {
@@ -89,6 +90,18 @@ describe('GET /', () => {
         publishedAt: 'Monday 30th October',
       },
     ];
+    uniqueHubcontent = {
+      id: 666666,
+      contentType: 'video',
+      externalContent: false,
+      title: 'BBC. The Story of Maths. The Language of the Universe',
+      summary: 'BBC. The Story of Maths. The Language of the Universe',
+      contentUrl: '/content/666666',
+      displayUrl: undefined,
+      image: { url: 'image url', alt: 'Alt text' },
+      publishedAt: 'Monday 1st November',
+    };
+
     hubUpdatesContent = [
       ...hubContent,
       {
@@ -110,7 +123,7 @@ describe('GET /', () => {
     keyInfo = {
       data: hubContent,
     };
-    [largeUpdateTile] = hubContent;
+    largeUpdateTile = uniqueHubcontent;
 
     cmsService = {
       getHomepage: jest.fn().mockReturnValue({
@@ -628,7 +641,7 @@ describe('GET /', () => {
           .then(response => {
             const $ = cheerio.load(response.text);
             expect($('.govuk-hub-update-items-link_text h3:last').text()).toBe(
-              'Monday 17th October',
+              'Monday 30th October',
             );
           }));
 
@@ -647,7 +660,7 @@ describe('GET /', () => {
         describe('returning less than 5 links and the default large update is not required', () => {
           it('Should hide the "View all" link', () => {
             cmsService.getUpdatesContent = jest.fn().mockResolvedValue({
-              largeUpdateTileDefault: hubContent[0],
+              largeUpdateTileDefault: uniqueHubcontent,
               updatesContent: [...hubContent],
               isLastPage: true,
             });
@@ -662,7 +675,7 @@ describe('GET /', () => {
               });
           });
         });
-        describe('returning 5 links and the default large update is not required', () => {
+        describe('returning 5 unique links and the default large update is not required', () => {
           it('Should render a "View all" link in the updates section', () => {
             cmsService.getUpdatesContent = jest.fn().mockResolvedValue({
               largeUpdateTileDefault: hubContent[0],

--- a/server/routes/__tests__/homepage.spec.js
+++ b/server/routes/__tests__/homepage.spec.js
@@ -723,11 +723,6 @@ describe('GET /', () => {
 
       it('should return the remaining 4 items in the updatesContent array when a duplicate item has been removed', () =>
         expect(updatesContentWithDuplicateRemoved.length).toBe(4));
-
-      it('should return the first 4 items from the updatesContent array when no duplicates are found', () =>
-        expect(
-          removeDuplicateUpdates(hubUpdatesContent, { id: 999999 }),
-        ).toEqual(hubUpdatesContent.splice(0, 4)));
     });
 
     describe('key info tiles', () => {

--- a/server/routes/__tests__/homepage.spec.js
+++ b/server/routes/__tests__/homepage.spec.js
@@ -2,7 +2,7 @@ const request = require('supertest');
 const cheerio = require('cheerio');
 const { User } = require('../../auth/user');
 
-const { createHomepageRouter } = require('../homepage');
+const { createHomepageRouter, removeDuplicateUpdates } = require('../homepage');
 const {
   setupBasicApp,
   consoleLogError,
@@ -704,6 +704,31 @@ describe('GET /', () => {
           });
         });
       });
+    });
+
+    describe('removeDuplicateUpdates', () => {
+      let updatesContentWithDuplicateRemoved;
+
+      beforeEach(() => {
+        updatesContentWithDuplicateRemoved = removeDuplicateUpdates(
+          hubUpdatesContent,
+          hubUpdatesContent[0],
+        );
+      });
+
+      it('should remove the update object with an id that matches the largeUpdateTileContent id', () =>
+        expect(updatesContentWithDuplicateRemoved).toEqual(
+          expect.not.objectContaining(hubUpdatesContent[0]),
+        ));
+
+      it('should return the remaining 4 items in the updatesContent array when a duplicate item has been removed', () => {
+        expect(updatesContentWithDuplicateRemoved.length).toBe(4);
+      });
+
+      it('should return the first 4 items from the updatesContent array when no duplicates are found', () =>
+        expect(
+          removeDuplicateUpdates(hubUpdatesContent, { id: 999999 }),
+        ).toEqual(hubUpdatesContent.splice(0, 4)));
     });
 
     describe('key info tiles', () => {

--- a/server/routes/__tests__/homepage.spec.js
+++ b/server/routes/__tests__/homepage.spec.js
@@ -721,9 +721,8 @@ describe('GET /', () => {
           expect.not.objectContaining(hubUpdatesContent[0]),
         ));
 
-      it('should return the remaining 4 items in the updatesContent array when a duplicate item has been removed', () => {
-        expect(updatesContentWithDuplicateRemoved.length).toBe(4);
-      });
+      it('should return the remaining 4 items in the updatesContent array when a duplicate item has been removed', () =>
+        expect(updatesContentWithDuplicateRemoved.length).toBe(4));
 
       it('should return the first 4 items from the updatesContent array when no duplicates are found', () =>
         expect(

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -57,12 +57,19 @@ const createHomepageRouter = ({ cmsService, offenderService }) => {
         ? await offenderService.getCurrentEvents(req.user)
         : {};
       const useLargeUpdateTile = Boolean(largeUpdateTile?.contentUrl);
-      const updatesContentHideViewAll =
-        isLastPage && (updatesContent.length < 5 || !useLargeUpdateTile);
 
       const largeUpdateTileContent = useLargeUpdateTile
         ? largeUpdateTile
         : largeUpdateTileDefault;
+
+      const updatesContentWithDuplicatesRemoved = removeDuplicateUpdates(
+        updatesContent,
+        largeUpdateTileContent,
+      );
+
+      const updatesContentHideViewAll =
+        isLastPage &&
+        (updatesContentWithDuplicatesRemoved.length < 5 || !useLargeUpdateTile);
 
       res.render('pages/home-new', {
         config: {
@@ -74,10 +81,7 @@ const createHomepageRouter = ({ cmsService, offenderService }) => {
         hideSignInLink: true,
         title: 'Home',
         recentlyAddedHomepageContent,
-        updatesContent: removeDuplicateUpdates(
-          updatesContent,
-          largeUpdateTileContent,
-        ),
+        updatesContent: updatesContentWithDuplicatesRemoved.splice(0, 4),
         updatesContentHideViewAll,
         featuredContent,
         keyInfo,
@@ -94,7 +98,7 @@ const createHomepageRouter = ({ cmsService, offenderService }) => {
 };
 
 const removeDuplicateUpdates = (updatesContent, { id }) =>
-  updatesContent.filter(update => update.id !== id).splice(0, 4);
+  updatesContent.filter(update => update.id !== id);
 
 module.exports = {
   createHomepageRouter,

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -59,6 +59,11 @@ const createHomepageRouter = ({ cmsService, offenderService }) => {
       const useLargeUpdateTile = Boolean(largeUpdateTile?.contentUrl);
       const updatesContentHideViewAll =
         isLastPage && (updatesContent.length < 5 || !useLargeUpdateTile);
+
+      const largeUpdateTileContent = useLargeUpdateTile
+        ? largeUpdateTile
+        : largeUpdateTileDefault;
+
       res.render('pages/home-new', {
         config: {
           content: true,
@@ -69,13 +74,14 @@ const createHomepageRouter = ({ cmsService, offenderService }) => {
         hideSignInLink: true,
         title: 'Home',
         recentlyAddedHomepageContent,
-        updatesContent: updatesContent.splice(useLargeUpdateTile ? 0 : 1, 4),
+        updatesContent: removeDuplicateUpdates(
+          updatesContent,
+          largeUpdateTileContent,
+        ),
         updatesContentHideViewAll,
         featuredContent,
         keyInfo,
-        largeUpdateTile: useLargeUpdateTile
-          ? largeUpdateTile
-          : largeUpdateTileDefault,
+        largeUpdateTile: largeUpdateTileContent,
         exploreContent,
         currentEvents,
       });
@@ -86,6 +92,9 @@ const createHomepageRouter = ({ cmsService, offenderService }) => {
 
   return router;
 };
+
+const removeDuplicateUpdates = (updatesContent, { id }) =>
+  updatesContent.filter(update => update.id !== id).splice(0, 4);
 
 module.exports = {
   createHomepageRouter,

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -43,7 +43,7 @@ const createHomepageRouter = ({ cmsService, offenderService }) => {
       }
 
       const [
-        { featuredContent, keyInfo, largeUpdateTile },
+        { featuredContent, keyInfo, largeUpdateTile: largeUpdateTileSpecified },
         recentlyAddedHomepageContent,
         exploreContent,
         { largeUpdateTileDefault, updatesContent, isLastPage },
@@ -56,15 +56,15 @@ const createHomepageRouter = ({ cmsService, offenderService }) => {
       const currentEvents = res.locals.isSignedIn
         ? await offenderService.getCurrentEvents(req.user)
         : {};
-      const useLargeUpdateTile = Boolean(largeUpdateTile?.contentUrl);
+      const useLargeUpdateTile = Boolean(largeUpdateTileSpecified?.contentUrl);
 
-      const largeUpdateTileContent = useLargeUpdateTile
-        ? largeUpdateTile
+      const largeUpdateTile = useLargeUpdateTile
+        ? largeUpdateTileSpecified
         : largeUpdateTileDefault;
 
       const updatesContentWithDuplicatesRemoved = removeDuplicateUpdates(
         updatesContent,
-        largeUpdateTileContent,
+        largeUpdateTile,
       );
 
       const updatesContentHideViewAll =
@@ -85,7 +85,7 @@ const createHomepageRouter = ({ cmsService, offenderService }) => {
         updatesContentHideViewAll,
         featuredContent,
         keyInfo,
-        largeUpdateTile: largeUpdateTileContent,
+        largeUpdateTile,
         exploreContent,
         currentEvents,
       });

--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -98,4 +98,5 @@ const removeDuplicateUpdates = (updatesContent, { id }) =>
 
 module.exports = {
   createHomepageRouter,
+  removeDuplicateUpdates,
 };

--- a/server/services/index.js
+++ b/server/services/index.js
@@ -33,8 +33,10 @@ const incentivesApiClient = new IncentivesApiClient({
   incentivesApi: config.incentivesApi,
   cachingStrategy: new InMemoryCachingStrategy(),
 });
-
-const cmsApi = new CmsApi(jsonApiClient);
+const cmsApi = new CmsApi({
+  jsonApiClient,
+  cachingStrategy: new InMemoryCachingStrategy(),
+});
 const cmsService = new CmsService({
   cmsApi,
   cachingStrategy: new InMemoryCachingStrategy(),


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/lsTOnS2s/1480-bug-homepage-sometimes-the-featured-tile-is-duplicated-in-the-middle-updates-list

> If this is an issue, do we have steps to reproduce?
No.

### Intent

> What changes are introduced by this PR that correspond to the above card?
- Codebase updated to find and remove largeUpdateTile content from the updates section on the homepage.

> Would this PR benefit from screenshots?
**Prior to fix:**
<img width="842" alt="Screenshot 2022-09-09 at 07 59 36" src="https://user-images.githubusercontent.com/104000682/189290919-1bed15d1-8bf4-475b-9b61-bfcf7e0020f4.png">

**After fix:**
<img width="856" alt="Screenshot 2022-09-09 at 08 02 07" src="https://user-images.githubusercontent.com/104000682/189291036-8d213acb-dc2c-41c2-9f37-ba6b3d107022.png">


### Considerations

> Is there any additional information that would help when reviewing this PR?
no.

> Are there any steps required when merging/deploying this PR?
no.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
