### PR TITLE
feature/add-lookups-to-cache

### DIFF
--- a/server/services/index.js
+++ b/server/services/index.js
@@ -33,8 +33,10 @@ const incentivesApiClient = new IncentivesApiClient({
   incentivesApi: config.incentivesApi,
   cachingStrategy: new InMemoryCachingStrategy(),
 });
-
-const cmsApi = new CmsApi(jsonApiClient);
+const cmsApi = new CmsApi({
+  jsonApiClient,
+  cachingStrategy: new InMemoryCachingStrategy(),
+});
 const cmsService = new CmsService({
   cmsApi,
   cachingStrategy: new InMemoryCachingStrategy(),


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/9juZktFE/1498-cache-drupal-router-requests-in-the-frontend

> If this is an issue, do we have steps to reproduce?
n/a

### Intent

> What changes are introduced by this PR that correspond to the above card?
Caching all lookups in the in memory cache

> Would this PR benefit from screenshots?
n/a

### Considerations

> Is there any additional information that would help when reviewing this PR?
This is a temporary measure to alleviate the drupal issues. This will be migrated to REDIS

> Are there any steps required when merging/deploying this PR?
n/a

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
