### PR TITLE
bug/1691-revert-jsona-to-v1.9.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "govuk-frontend": "^4.3.1",
         "helmet": "^5.1.1",
         "jquery": "^3.6.1",
-        "jsona": "^1.10.1",
+        "jsona": "^1.9.7",
         "jsonwebtoken": "^8.5.1",
         "mkdirp": "^1.0.4",
         "moment": "^2.29.4",
@@ -7819,9 +7819,9 @@
       }
     },
     "node_modules/jsona": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/jsona/-/jsona-1.10.1.tgz",
-      "integrity": "sha512-2czP2uLMkPynRexq/F+OLoJGvN7VSUa3pVayJscTXrxVMAdc67Wq/Fb9twjt0drpzbJ6+uz874LDkd8cQBq9xw=="
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/jsona/-/jsona-1.9.7.tgz",
+      "integrity": "sha512-GC3uTVJfYu0ovWrXmhAC+SqroKyv64dOI8iIWdVKYYn0ef7XNfXEkvkVcmdjfKdIjk6nZrf8VkYsZeSbPF3BGQ=="
     },
     "node_modules/jsonwebtoken": {
       "version": "8.5.1",
@@ -17367,9 +17367,9 @@
       "dev": true
     },
     "jsona": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/jsona/-/jsona-1.10.1.tgz",
-      "integrity": "sha512-2czP2uLMkPynRexq/F+OLoJGvN7VSUa3pVayJscTXrxVMAdc67Wq/Fb9twjt0drpzbJ6+uz874LDkd8cQBq9xw=="
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/jsona/-/jsona-1.9.7.tgz",
+      "integrity": "sha512-GC3uTVJfYu0ovWrXmhAC+SqroKyv64dOI8iIWdVKYYn0ef7XNfXEkvkVcmdjfKdIjk6nZrf8VkYsZeSbPF3BGQ=="
     },
     "jsonwebtoken": {
       "version": "8.5.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "govuk-frontend": "^4.3.1",
     "helmet": "^5.1.1",
     "jquery": "^3.6.1",
-    "jsona": "^1.10.1",
+    "jsona": "^1.9.7",
     "jsonwebtoken": "^8.5.1",
     "mkdirp": "^1.0.4",
     "moment": "^2.29.4",


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/5vCy4nnp/1691-npr-page-not-working

> If this is an issue, do we have steps to reproduce?
go to `/tags/785`

### Intent

> What changes are introduced by this PR that correspond to the above card?
Reverted jsona to version 1.9.7

> Would this PR benefit from screenshots?
no

### Considerations

> Is there any additional information that would help when reviewing this PR?
no

> Are there any steps required when merging/deploying this PR?
no

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
