### PR TITLE
Switch to new ingress controllers, with downtime.

### DIFF
--- a/helm_deploy/prisoner-content-hub-frontend/templates/ingress.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/templates/ingress.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- end}}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.ingress.allowed | quote }}
 spec:
+  ingressClassName: default
   tls:
   - hosts:
   {{- range .Values.ingress.hosts }}

--- a/helm_deploy/prisoner-content-hub-frontend/values-development.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values-development.yaml
@@ -11,11 +11,10 @@ application:
 
 ingress:
   annotations:
-    kubernetes.io/ingress.class: nginx
     external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-frontend-{{ .qualifier }}-prisoner-content-hub-development-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-  # These are legacy, prison specific hostnames we want to deprecate  
+  # These are legacy, prison specific hostnames we want to deprecate
   hosts:
     - pattern: "{{ .prison }}-prisoner-content-hub-development-{{ .qualifier }}.apps.live.cloud-platform.service.justice.gov.uk"
-  host: 
+  host:
       pattern: "prisoner-content-hub-development-{{ .qualifier }}.apps.live.cloud-platform.service.justice.gov.uk"

--- a/helm_deploy/prisoner-content-hub-frontend/values-production.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values-production.yaml
@@ -8,14 +8,13 @@ application:
 
 ingress:
   annotations:
-    kubernetes.io/ingress.class: nginx
     external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-frontend-prisoner-content-hub-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-  # These are legacy, prison specific hostnames we want to deprecate  
+  # These are legacy, prison specific hostnames we want to deprecate
   hosts:
     - pattern: "{{ .prison }}.content-hub.prisoner.service.justice.gov.uk"
       cert_secret: prisoner-content-hub-frontend-certificate
     - pattern: "{{ .prison }}-prisoner-content-hub-production.apps.live.cloud-platform.service.justice.gov.uk"
-  host: 
+  host:
       pattern: "content-hub.prisoner.service.justice.gov.uk"
       cert_secret: prisoner-content-hub-frontend-certificate

--- a/helm_deploy/prisoner-content-hub-frontend/values-staging.yaml
+++ b/helm_deploy/prisoner-content-hub-frontend/values-staging.yaml
@@ -8,11 +8,10 @@ application:
 
 ingress:
   annotations:
-    kubernetes.io/ingress.class: nginx
     external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-frontend-prisoner-content-hub-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-  # These are legacy, prison specific hostnames we want to deprecate  
+  # These are legacy, prison specific hostnames we want to deprecate
   hosts:
     - pattern: "{{ .prison }}-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk"
-  host: 
+  host:
       pattern: "prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk"


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/uFrdiYUP/1712-switch-to-new-ingress-controllers

### Intent

Switch to using new ingress controllers.  See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/Switch-ingress-to-v1-ingress-controller.htm

There was a previous PR https://github.com/ministryofjustice/prisoner-content-hub-frontend/pull/558 which did this but with 0 downtime.  However we couldn't get this to work (was unable to set the correct identifier for the dev environment).  So instead we are going with this option, which will incur some downtime.

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
