### PR TITLE
Update breadcrumb font size and content

### DIFF
--- a/assets/sass/_general.scss
+++ b/assets/sass/_general.scss
@@ -129,7 +129,7 @@
 
 .govuk-breadcrumbs li {
   @extend .govuk-body;
-  @include govuk-font(16);
+  @include govuk-font(19);
 }
 .govuk-breadcrumbs li a {
   @extend .govuk-link;

--- a/server/repositories/cmsQueries/__tests__/audioPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/audioPageQuery.spec.js
@@ -100,7 +100,6 @@ describe('Audio page query', () => {
         breadcrumbs: [
           { href: 'parent1Url', text: 'parent1' },
           { href: 'parent2Url', text: 'parent2' },
-          { href: '', text: 'Buddhist reflection: 29 July' },
         ],
         contentType: 'radio',
         created: '2020-01-03T01:02:30',

--- a/server/repositories/cmsQueries/__tests__/basicPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/basicPageQuery.spec.js
@@ -34,10 +34,7 @@ describe('Basic page query', () => {
         title: 'Novus',
         created: '2020-01-03T01:02:30',
         contentType: 'page',
-        breadcrumbs: [
-          { href: 'parent1Url', text: 'parent1' },
-          { href: '', text: 'Novus' },
-        ],
+        breadcrumbs: [{ href: 'parent1Url', text: 'parent1' }],
         description: 'Education content for prisoners',
         excludeFeedback: true,
         standFirst: 'Education',
@@ -68,10 +65,7 @@ describe('Basic page query', () => {
         created: '2020-01-03T01:02:30',
         title: 'Novus',
         contentType: 'page',
-        breadcrumbs: [
-          { href: 'parent1Url', text: 'parent1' },
-          { href: '', text: 'Novus' },
-        ],
+        breadcrumbs: [{ href: 'parent1Url', text: 'parent1' }],
         description: undefined,
         excludeFeedback: true,
         standFirst: 'Education',

--- a/server/repositories/cmsQueries/__tests__/categoryPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/categoryPageQuery.spec.js
@@ -104,7 +104,6 @@ describe('Category collection query', () => {
       { href: 'bread01/url', text: 'bread01' },
       { href: 'bread02/url', text: 'bread02' },
       { href: 'bread03/url', text: 'bread03' },
-      { href: '', text: 'Category' },
     ];
 
     beforeEach(() => {

--- a/server/repositories/cmsQueries/__tests__/seriesPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/seriesPageQuery.spec.js
@@ -68,10 +68,7 @@ describe('Series page query', () => {
       expect(query.transform(response, { next: 'URL' })).toStrictEqual({
         id: `100${UUID}`,
         contentType: 'series',
-        breadcrumbs: [
-          { href: 'parent1Url', text: 'parent1' },
-          { href: '', text: `name${UUID}` },
-        ],
+        breadcrumbs: [{ href: 'parent1Url', text: 'parent1' }],
         title: `name${UUID}`,
         summary: `description${UUID}`,
         image: {
@@ -101,10 +98,7 @@ describe('Series page query', () => {
       expect(query.transform(response, {})).toStrictEqual({
         id: `100${UUID}`,
         contentType: 'series',
-        breadcrumbs: [
-          { href: 'parent1Url', text: 'parent1' },
-          { href: '', text: `name${UUID}` },
-        ],
+        breadcrumbs: [{ href: 'parent1Url', text: 'parent1' }],
         title: `name${UUID}`,
         summary: `description${UUID}`,
         image: {

--- a/server/repositories/cmsQueries/__tests__/topicPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/topicPageQuery.spec.js
@@ -54,10 +54,7 @@ describe('Secondary Tag page query', () => {
         alt: `alt${id}`,
       },
       isNew: false,
-      breadcrumbs: [
-        { href: 'parent1Url', text: 'parent1' },
-        { href: '', text: `name${id}` },
-      ],
+      breadcrumbs: [{ href: 'parent1Url', text: 'parent1' }],
       displayUrl: undefined,
       excludeFeedback: true,
       externalContent: false,

--- a/server/repositories/cmsQueries/__tests__/videoPageQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/videoPageQuery.spec.js
@@ -92,10 +92,7 @@ describe('Video page query', () => {
           name: 'steve',
         },
         contentType: 'video',
-        breadcrumbs: [
-          { href: 'parent1Url', text: 'parent1' },
-          { href: '', text: 'Buddhist reflection: 29 July' },
-        ],
+        breadcrumbs: [{ href: 'parent1Url', text: 'parent1' }],
         description: 'Education content for prisoners',
         episodeId: 1036,
         excludeFeedback: undefined,

--- a/server/utils/jsonApi.js
+++ b/server/utils/jsonApi.js
@@ -143,16 +143,11 @@ const isBottomCategory = ({
   sub_series_count: subSeriesCount = 0,
 } = {}) => subCategoriesCount === 0 && subSeriesCount === 0;
 
-const mapBreadcrumbs = (rawBreadcrumbs = [], self = '') => {
-  const breadcrumbs = self
-    ? [...rawBreadcrumbs, { title: self }]
-    : rawBreadcrumbs;
-
-  return breadcrumbs.map(({ uri: href = '', title: text }) => ({
+const mapBreadcrumbs = (rawBreadcrumbs = []) =>
+  rawBreadcrumbs.map(({ uri: href = '', title: text }) => ({
     href,
     text,
   }));
-};
 
 module.exports = {
   getPagination,


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/0IXdWr6s/1793-increase-font-size-of-breadcrumb-to-19pt-remove-the-current-page

> If this is an issue, do we have steps to reproduce?
No.

### Intent

> What changes are introduced by this PR that correspond to the above card?
- Updated SASS to increase breadcrumb font size
- Removed current page/content from the breadcrumb
- Fixed failing unit tests caused by the changes made

> Would this PR benefit from screenshots?

**Before:**
<img width="1293" alt="Screenshot 2022-11-18 at 09 36 03" src="https://user-images.githubusercontent.com/104000682/202669973-ec514d62-72eb-4029-a9e7-43ad15aef885.png">

**After:**
<img width="1294" alt="Screenshot 2022-11-18 at 09 35 03" src="https://user-images.githubusercontent.com/104000682/202669794-48b09a5b-d924-4c7f-8cd1-febbf1272bfa.png">


### Considerations

> Is there any additional information that would help when reviewing this PR?
No.

> Are there any steps required when merging/deploying this PR?
No.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
