### PR TITLE
Remove establishment restriction for approved visitors list

### DIFF
--- a/server/routes/approvedVisitors.js
+++ b/server/routes/approvedVisitors.js
@@ -30,18 +30,15 @@ const createApprovedVisitorsRouter = ({ offenderService }) => {
 
   router.get(
     '/',
-    async ({ user, originalUrl: returnUrl, query, session }, res, next) => {
-      if (
-        config.features.approvedVisitorsFeatureEnabled &&
-        session.establishmentName === 'ranby'
-      ) {
+    async ({ user, originalUrl: returnUrl, query }, res, next) => {
+      if (config.features.approvedVisitorsFeatureEnabled) {
         try {
           const personalisation = user
             ? await getPersonalisation(user, query)
             : {};
 
           return res.render('pages/approvedVisitors', {
-            title: 'Your approved visitors',
+            title: 'Your approved visitors - social',
             content: false,
             header: false,
             postscript: true,

--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -93,8 +93,7 @@ const createProfileRouter = ({ offenderService }) => {
         data: { contentType: 'profile' },
         ...personalisation,
         displayApprovedVisitorsCard:
-          config.features.approvedVisitorsFeatureEnabled &&
-          req.session.establishmentName === 'ranby',
+          config.features.approvedVisitorsFeatureEnabled,
       });
     } catch (e) {
       return next(e);

--- a/server/views/pages/approvedVisitors.html
+++ b/server/views/pages/approvedVisitors.html
@@ -12,7 +12,7 @@
   {% else %}
   
   {% if error %}
-    <p class="govuk-body govuk-!-font-size-24 govuk-!-margin-bottom-9" data-test="approved-visitors-error">We can not list your approved visitors at this time, please <a href="{{ params.returnUrl }}" class="govuk-link">try again</a> or <a href="{{ knownPages.profile.visitorInfo }}" class="govuk-link">find out more about visits</a>.</p>
+    <p class="govuk-body govuk-!-font-size-24 govuk-!-margin-bottom-9" data-test="approved-visitors-error">We can not list your approved social visitors at this time, please <a href="{{ params.returnUrl }}" class="govuk-link">try again</a> or <a href="{{ knownPages.profile.visitorInfo }}" class="govuk-link">find out more about visits</a>.</p>
   {% else %}  
         {% if approvedVisitors.length > 0 %}
           <div class="govuk-!-margin-bottom-7">
@@ -35,7 +35,7 @@
         {% endif %}
       {% else %}
         <div class="govuk-!-margin-bottom-9">
-          <p class="govuk-heading-m" data-test="no-approved-visitors">You do not have any approved visitors.</p>
+          <p class="govuk-heading-m" data-test="no-approved-visitors">You do not have any approved social visitors.</p>
           <a href="{{ knownPages.profile.visitorInfo }}" class="govuk-link govuk-!-font-size-24">Find out more about visits</a>
         </div>
       {% endif %}

--- a/server/views/pages/profile.html
+++ b/server/views/pages/profile.html
@@ -174,7 +174,7 @@
               {%- endif %}
               {% if displayApprovedVisitorsCard %}
                 <li class="govuk-grid-column-one-quarter card-group__item">
-                  {{imageCard({ id: 'approvedVisitors', src: "/public/images/image_visitors.jpg", alt: "visitor picture", link: knownPages.profile.visitorsLink, description: "List of approved visitors" }) }}
+                  {{imageCard({ id: 'approvedVisitors', src: "/public/images/image_visitors.jpg", alt: "visitor picture", link: knownPages.profile.visitorsLink, description: "List of approved visitors - social" }) }}
                 </li>
               {%- endif %}
               <li class="govuk-grid-column-one-quarter card-group__item">


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/McnktIOG/1821-release-disable-the-approved-visitors-list-feature

> If this is an issue, do we have steps to reproduce?
No.

### Intent

> What changes are introduced by this PR that correspond to the above card?
- Removing the establishment restriction to open up the approved visitors list to all prisons
- Updating the My Profile page tile to read ‘List of approved visitors - social’
- Updating the approved visitors list page title to read ‘List of approved visitors - social’
- Updating the approved visitors list page - no approved visitors screen to have the title above and the content to read ‘You do not have any approved social visitors….’
- Updating the approved visitors list page - error screen to have the title above and the content to read ‘We can not list your approved social visitors at this time….’

> Would this PR benefit from screenshots?

### Considerations

> Is there any additional information that would help when reviewing this PR?
No.

> Are there any steps required when merging/deploying this PR?
No.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
