### PR TITLE
Add custom breadcrumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,36 @@ Can either run the tests headlessly:
 
 Or with the cypress user interface:
 `npm run test:e2e:ui`
+
+## Adding new breadcrumbs to none Drupal pages
+
+### breadcrumbs.json
+
+The server > content > breadcrumbs.json file lists the href and link text for breadcrumb navigation links that are displayed in sections of the site that do not use content from Drupal.
+
+### breadcrumbs.js
+
+The server > utils > breadcrumbs.js creates breadcrumbs structure for each path defined.
+
+When breadcrumbs are required for a path it should be added within the switch statement in this file.
+
+### Add breadcrumbs to the required routers
+
+Import the createBreadcrumbs function into the router
+
+```
+const { createBreadcrumbs } = require('../utils/breadcrumbs');
+```
+
+Pass the breadcrumb data into the view within res.render
+
+```
+return res.render('pages/approvedVisitors', {
+    ...
+    data: {
+        contentType: 'profile',
+        breadcrumbs: createBreadcrumbs(req)
+        },
+    ...
+});
+```

--- a/server/content/breadcrumbs.json
+++ b/server/content/breadcrumbs.json
@@ -1,0 +1,18 @@
+{
+  "home": {
+    "href": "/",
+    "text": "Home"
+  },
+  "profile": {
+    "href": "/profile",
+    "text": "My Profile"
+  },
+  "entertainment": {
+    "href": "/tags/1282",
+    "text": "Entertainment"
+  },
+  "games": {
+    "href": "/tags/647",
+    "text": "Games"
+  }
+}

--- a/server/routes/approvedVisitors.js
+++ b/server/routes/approvedVisitors.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const config = require('../config');
+const { createBreadcrumbs } = require('../utils/breadcrumbs');
 
 const createApprovedVisitorsRouter = ({ offenderService }) => {
   const router = express.Router();
@@ -28,33 +29,32 @@ const createApprovedVisitorsRouter = ({ offenderService }) => {
     };
   };
 
-  router.get(
-    '/',
-    async ({ user, originalUrl: returnUrl, query }, res, next) => {
-      if (config.features.approvedVisitorsFeatureEnabled) {
-        try {
-          const personalisation = user
-            ? await getPersonalisation(user, query)
-            : {};
+  router.get('/', async (req, res, next) => {
+    const { user, originalUrl: returnUrl, query } = req;
 
-          return res.render('pages/approvedVisitors', {
-            title: 'Your approved visitors - social',
-            content: false,
-            header: false,
-            postscript: true,
-            detailsType: 'small',
-            returnUrl,
-            ...personalisation,
-            data: { contentType: 'profile' },
-            displayImportantNotice: true,
-          });
-        } catch (e) {
-          return next(e);
-        }
+    if (config.features.approvedVisitorsFeatureEnabled) {
+      try {
+        const personalisation = user
+          ? await getPersonalisation(user, query)
+          : {};
+
+        return res.render('pages/approvedVisitors', {
+          title: 'Your approved visitors - social',
+          content: false,
+          header: false,
+          postscript: true,
+          detailsType: 'small',
+          returnUrl,
+          ...personalisation,
+          data: { contentType: 'profile', breadcrumbs: createBreadcrumbs(req) },
+          displayImportantNotice: true,
+        });
+      } catch (e) {
+        return next(e);
       }
-      return next();
-    },
-  );
+    }
+    return next();
+  });
 
   return router;
 };

--- a/server/routes/createAnagramicaRouter.js
+++ b/server/routes/createAnagramicaRouter.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const bodyParser = require('body-parser');
+const { createBreadcrumbs } = require('../utils/breadcrumbs');
 
 const { logger } = require('../utils/logger');
 const finder = require('../../assets/javascript/games/anagramica/lib/finder');
@@ -19,6 +20,7 @@ const createAnagramicaRouter = config => {
       res.render('pages/games/anagramica.html', {
         title: 'Anagramica',
         config: { ...config, detailsType: 'small' },
+        data: { breadcrumbs: createBreadcrumbs(req) },
       }),
     )
     .post((req, res) => {

--- a/server/routes/games.js
+++ b/server/routes/games.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { createAnagramicaRouter } = require('./createAnagramicaRouter');
+const { createBreadcrumbs } = require('../utils/breadcrumbs');
 
 const createGamesRouter = () => {
   const router = express.Router();
@@ -21,6 +22,7 @@ const createGamesRouter = () => {
     return res.render('pages/games/2048', {
       title: '2048',
       config,
+      data: { breadcrumbs: createBreadcrumbs(req) },
     });
   });
 
@@ -30,6 +32,7 @@ const createGamesRouter = () => {
     return res.render('pages/games/fadingsnake', {
       title: 'Fading Snake',
       config,
+      data: { breadcrumbs: createBreadcrumbs(req) },
     });
   });
 
@@ -39,6 +42,7 @@ const createGamesRouter = () => {
     return res.render('pages/games/sn4ke', {
       title: 'Sn4ke',
       config,
+      data: { breadcrumbs: createBreadcrumbs(req) },
     });
   });
 
@@ -50,6 +54,7 @@ const createGamesRouter = () => {
     return res.render('pages/games/chess', {
       title: 'Chess',
       config,
+      data: { breadcrumbs: createBreadcrumbs(req) },
     });
   });
 
@@ -59,6 +64,7 @@ const createGamesRouter = () => {
     return res.render('pages/games/sudoku', {
       title: 'Sudoku',
       config,
+      data: { breadcrumbs: createBreadcrumbs(req) },
     });
   });
 
@@ -68,6 +74,7 @@ const createGamesRouter = () => {
     return res.render('pages/games/neontroids', {
       title: 'Neontroids',
       config,
+      data: { breadcrumbs: createBreadcrumbs(req) },
     });
   });
 
@@ -77,6 +84,7 @@ const createGamesRouter = () => {
     return res.render('pages/games/mimstris', {
       title: 'Mimstris',
       config,
+      data: { breadcrumbs: createBreadcrumbs(req) },
     });
   });
 
@@ -86,6 +94,7 @@ const createGamesRouter = () => {
     return res.render('pages/games/invadersfromspace', {
       title: 'Invaders from Space',
       config,
+      data: { breadcrumbs: createBreadcrumbs(req) },
     });
   });
 
@@ -95,6 +104,7 @@ const createGamesRouter = () => {
     return res.render('pages/games/crossword', {
       title: 'Crossword',
       config,
+      data: { breadcrumbs: createBreadcrumbs(req) },
     });
   });
 
@@ -104,6 +114,7 @@ const createGamesRouter = () => {
     return res.render('pages/games/christmas-crossword', {
       title: 'Christmas Crossword',
       config,
+      data: { breadcrumbs: createBreadcrumbs(req) },
     });
   });
 
@@ -113,6 +124,7 @@ const createGamesRouter = () => {
     return res.render('pages/games/solitaire', {
       title: 'Solitaire',
       config,
+      data: { breadcrumbs: createBreadcrumbs(req) },
     });
   });
 
@@ -122,6 +134,7 @@ const createGamesRouter = () => {
     return res.render('pages/games/smashout', {
       title: 'Smashout',
       config,
+      data: { breadcrumbs: createBreadcrumbs(req) },
     });
   });
 

--- a/server/routes/money.js
+++ b/server/routes/money.js
@@ -6,6 +6,7 @@ const {
   createPendingTransactionsResponseFrom,
 } = require('./formatters');
 const { getDateSelection } = require('../utils/date');
+const { createBreadcrumbs } = require('../utils/breadcrumbs');
 
 const accountTypes = ['spends', 'private', 'savings'];
 
@@ -48,6 +49,7 @@ const createMoneyRouter = ({ prisonerInformationService }) => {
           postscript: true,
           detailsType: 'small',
         },
+        data: { breadcrumbs: createBreadcrumbs(req) },
       };
 
       if (res.locals.isSignedIn) {
@@ -80,6 +82,7 @@ const createMoneyRouter = ({ prisonerInformationService }) => {
             postscript: true,
             detailsType: 'small',
           },
+          data: { breadcrumbs: createBreadcrumbs(req) },
         };
 
         if (res.locals.isSignedIn) {
@@ -140,6 +143,7 @@ const createMoneyRouter = ({ prisonerInformationService }) => {
           postscript: true,
           detailsType: 'small',
         },
+        data: { breadcrumbs: createBreadcrumbs(req) },
       };
 
       if (res.locals.isSignedIn) {
@@ -199,6 +203,7 @@ const createMoneyRouter = ({ prisonerInformationService }) => {
           postscript: true,
           detailsType: 'small',
         },
+        data: { breadcrumbs: createBreadcrumbs(req) },
       };
 
       if (res.locals.isSignedIn) {

--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const config = require('../config');
+const { createBreadcrumbs } = require('../utils/breadcrumbs');
 
 const createProfileRouter = ({ offenderService }) => {
   const router = express.Router();
@@ -90,7 +91,7 @@ const createProfileRouter = ({ offenderService }) => {
         header: false,
         postscript: true,
         detailsType: 'small',
-        data: { contentType: 'profile' },
+        data: { contentType: 'profile', breadcrumbs: createBreadcrumbs(req) },
         ...personalisation,
         displayApprovedVisitorsCard:
           config.features.approvedVisitorsFeatureEnabled,

--- a/server/routes/timetable.js
+++ b/server/routes/timetable.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { format, addDays, subDays } = require('date-fns');
+const { createBreadcrumbs } = require('../utils/breadcrumbs');
 
 const createTimetableRouter = ({ offenderService }) => {
   const router = express.Router();
@@ -37,6 +38,7 @@ const createTimetableRouter = ({ offenderService }) => {
         title: 'Timetable',
         config,
         events,
+        data: { breadcrumbs: createBreadcrumbs(req) },
       });
     } catch (exception) {
       next(exception);
@@ -72,6 +74,7 @@ const createTimetableRouter = ({ offenderService }) => {
         title: 'Timetable',
         config,
         events,
+        data: { breadcrumbs: createBreadcrumbs(req) },
       });
     } catch (exception) {
       next(exception);
@@ -107,6 +110,7 @@ const createTimetableRouter = ({ offenderService }) => {
         title: 'Timetable',
         config,
         events,
+        data: { breadcrumbs: createBreadcrumbs(req) },
       });
     } catch (exception) {
       next(exception);

--- a/server/utils/__tests__/breadcrumbs.spec.js
+++ b/server/utils/__tests__/breadcrumbs.spec.js
@@ -1,0 +1,60 @@
+const breadcrumbs = require('../../content/breadcrumbs.json');
+const { createBreadcrumbs } = require('../breadcrumbs');
+
+describe('createBreadcrumbs', () => {
+  let req = {};
+  let homeBreadcrumb = [];
+  let myProfileBreadcrumb = [];
+  let gamesBreadcrumb = [];
+
+  beforeEach(() => {
+    homeBreadcrumb.push(breadcrumbs.home);
+
+    myProfileBreadcrumb.push(breadcrumbs.home, breadcrumbs.profile);
+
+    gamesBreadcrumb.push(
+      breadcrumbs.home,
+      breadcrumbs.entertainment,
+      breadcrumbs.games,
+    );
+  });
+
+  afterEach(() => {
+    req = {};
+    homeBreadcrumb = [];
+    myProfileBreadcrumb = [];
+    gamesBreadcrumb = [];
+  });
+
+  it('should return an empty array if originalUrl does not exist', () => {
+    expect(createBreadcrumbs(req)).toEqual([]);
+  });
+
+  it('should return the expected breadcrumbs for the /profile route', () => {
+    req = {
+      originalUrl: '/profile',
+    };
+
+    expect(createBreadcrumbs(req)).toEqual(homeBreadcrumb);
+  });
+
+  it('should return the expected breadcrumbs for the /approved-visitors route', () => {
+    req = {
+      originalUrl: '/approved-visitors',
+    };
+
+    expect(createBreadcrumbs(req)).toEqual(myProfileBreadcrumb);
+  });
+
+  it('should return the expected breadcrumbs for the /games route', () => {
+    req = {
+      originalUrl: '/games',
+    };
+
+    expect(createBreadcrumbs(req)).toEqual(gamesBreadcrumb);
+  });
+
+  it('should return an empty array if a matching route is not found', () => {
+    expect(createBreadcrumbs('/')).toEqual([]);
+  });
+});

--- a/server/utils/breadcrumbs.js
+++ b/server/utils/breadcrumbs.js
@@ -1,0 +1,27 @@
+const breadcrumbs = require('../content/breadcrumbs.json');
+
+const createBreadcrumbs = ({ originalUrl }) => {
+  if (!originalUrl) {
+    return [];
+  }
+
+  switch (originalUrl.match(/^\/[a-z,-]*/g)[0]) {
+    case '/profile':
+      return [breadcrumbs.home];
+
+    case '/timetable':
+    case '/money':
+    case '/approved-visitors':
+      return [breadcrumbs.home, breadcrumbs.profile];
+
+    case '/games':
+      return [breadcrumbs.home, breadcrumbs.entertainment, breadcrumbs.games];
+
+    default:
+      return [];
+  }
+};
+
+module.exports = {
+  createBreadcrumbs,
+};


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/zQ7Pu7He/1824-add-breadcrumb-navigation-to-the-my-profile-and-games-sections-of-the-hub

> If this is an issue, do we have steps to reproduce?
No.

### Intent

> What changes are introduced by this PR that correspond to the above card?
- Breadcrumbs added to the sections within My profile
- Breadcrumbs added to the Entertainment > games subpages 

> Would this PR benefit from screenshots?
<img width="1245" alt="Screenshot 2022-12-19 at 14 31 50" src="https://user-images.githubusercontent.com/104000682/208448973-4c5f2749-3798-4be6-9eac-280a7a7f109e.png">

<img width="1261" alt="Screenshot 2022-12-19 at 14 32 14" src="https://user-images.githubusercontent.com/104000682/208449054-0525277f-a4cd-4ec6-b370-dd5a5bd285a8.png">

<img width="1262" alt="Screenshot 2022-12-19 at 14 32 40" src="https://user-images.githubusercontent.com/104000682/208449140-ae2a403b-f89b-4b2e-a7f8-b884e1d7f3b7.png">

### Considerations

> Is there any additional information that would help when reviewing this PR?
No.

> Are there any steps required when merging/deploying this PR?
No.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
