### PR TITLE
Update establishment link styles

### DIFF
--- a/assets/sass/components/_topbar.scss
+++ b/assets/sass/components/_topbar.scss
@@ -28,6 +28,10 @@
       flex: 1 0 auto;
     }
 
+    & a:hover {
+      text-decoration: underline;
+    }
+
     & img {
       flex: 0 1 auto;
     }

--- a/server/views/components/top-bar/template.njk
+++ b/server/views/components/top-bar/template.njk
@@ -4,7 +4,7 @@
   <div class="govuk-width-container top-bar">
     <h1 class="govuk-heading-m">
       <img class="hub-logo" src="/public/images/icons/content-hub.png" alt="logo">
-      <a href="/" style="">Content Hub <span>{{ params.establishmentDisplayName }}</span></a>
+      <a href="/" class="govuk-link govuk-link--inverse">Content Hub <span>{{ params.establishmentDisplayName }}</span></a>
     </h1>
     {% if params.showSearch %}
       {{ hubSearch({ query: params.searchQuery, small: true }) }}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/obYzbUtl/1879-add-hover-press-state-to-content-hub-hmp-prison-name-text-next-to-logo-in-top-left-corner

> If this is an issue, do we have steps to reproduce?
No.

### Intent

> What changes are introduced by this PR that correspond to the above card?
- CSS styles added to the establishment link to provide GDS standard hover state and roll over state.

> Would this PR benefit from screenshots?

![1](https://user-images.githubusercontent.com/104000682/208672225-25a5cd6d-73fb-416c-9455-0f8546431627.png)

![2](https://user-images.githubusercontent.com/104000682/208672248-7112fd4c-05f6-45e3-9800-311fdd12af2b.png)

![3](https://user-images.githubusercontent.com/104000682/208672263-72cc8b11-d75e-4a32-9929-bb66fe1dc8f5.png)

![4](https://user-images.githubusercontent.com/104000682/208697167-3fb27754-0f8c-49c7-a916-208a11dc66eb.png)

### Considerations

> Is there any additional information that would help when reviewing this PR?
No.

> Are there any steps required when merging/deploying this PR?
No.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
