### PR TITLE
Revert jsona package version to 1.9.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "govuk-frontend": "^4.4.1",
         "helmet": "^5.1.1",
         "jquery": "^3.6.3",
-        "jsona": "~1.11.0",
+        "jsona": "~1.9.7",
         "jsonwebtoken": "^9.0.0",
         "mkdirp": "^1.0.4",
         "moment": "^2.29.4",
@@ -7327,17 +7327,9 @@
       }
     },
     "node_modules/jsona": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/jsona/-/jsona-1.11.0.tgz",
-      "integrity": "sha512-jH7f9TG+7aOFQ16BI2pCcoB2FNRz0Rny0icngddZLg8/It5gTDAlgfR6tvVNuor0yB1ZB60i3a/+TqKFgA+PdQ==",
-      "dependencies": {
-        "tslib": "^2.4.1"
-      }
-    },
-    "node_modules/jsona/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/jsona/-/jsona-1.9.7.tgz",
+      "integrity": "sha512-GC3uTVJfYu0ovWrXmhAC+SqroKyv64dOI8iIWdVKYYn0ef7XNfXEkvkVcmdjfKdIjk6nZrf8VkYsZeSbPF3BGQ=="
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.0",
@@ -15974,19 +15966,9 @@
       "dev": true
     },
     "jsona": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/jsona/-/jsona-1.11.0.tgz",
-      "integrity": "sha512-jH7f9TG+7aOFQ16BI2pCcoB2FNRz0Rny0icngddZLg8/It5gTDAlgfR6tvVNuor0yB1ZB60i3a/+TqKFgA+PdQ==",
-      "requires": {
-        "tslib": "^2.4.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
-        }
-      }
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/jsona/-/jsona-1.9.7.tgz",
+      "integrity": "sha512-GC3uTVJfYu0ovWrXmhAC+SqroKyv64dOI8iIWdVKYYn0ef7XNfXEkvkVcmdjfKdIjk6nZrf8VkYsZeSbPF3BGQ=="
     },
     "jsonwebtoken": {
       "version": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "govuk-frontend": "^4.4.1",
     "helmet": "^5.1.1",
     "jquery": "^3.6.3",
-    "jsona": "~1.11.0",
+    "jsona": "~1.9.7",
     "jsonwebtoken": "^9.0.0",
     "mkdirp": "^1.0.4",
     "moment": "^2.29.4",


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
No card needed, minor package version fix.

> If this is an issue, do we have steps to reproduce?
na

### Intent

> What changes are introduced by this PR that correspond to the above card?
Reverted jsona package back to 1.9.7 from 1.11.0

> Would this PR benefit from screenshots?
no

### Considerations

> Is there any additional information that would help when reviewing this PR?
no

> Are there any steps required when merging/deploying this PR?
no

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
