### PR TITLE
Add adjudications api call and data parsing

### DIFF
--- a/server/content/knownPages.json
+++ b/server/content/knownPages.json
@@ -13,6 +13,8 @@
     "moneyAndDebtInfo": "/tags/872",
     "visitorInfo": "/tags/1133",
     "visitorsLink": "/approved-visitors",
-    "learningAndSkills": "/tags/1341"
+    "learningAndSkills": "/tags/1341",
+    "adjudications": "/adjudications",
+    "adjudicationsInfo": "/content/4193"
   }
 }

--- a/server/repositories/__tests__/offenderRepository.spec.js
+++ b/server/repositories/__tests__/offenderRepository.spec.js
@@ -176,4 +176,20 @@ describe('offenderRepository', () => {
       expect(result).toBe('SOME_RESULT');
     });
   });
+
+  describe('getAdjudicationsFor', () => {
+    it('calls the adjudications endpoint for a given ID', async () => {
+      const client = {
+        get: jest.fn().mockResolvedValue('SOME_RESULT'),
+      };
+      const repository = offenderRepository(client);
+      const result = await repository.getAdjudicationsFor('FOO_ID');
+
+      expect(lastCall(client.get)[0]).toContain(
+        'offenders/FOO_ID/adjudications',
+      );
+
+      expect(result).toBe('SOME_RESULT');
+    });
+  });
 });

--- a/server/repositories/offender.js
+++ b/server/repositories/offender.js
@@ -74,6 +74,12 @@ function offenderRepository(prisonApiHttpClient, incentivesApiHttpClient) {
     return prisonApiHttpClient.get(`${endpoint}?${query.join('&')}`);
   }
 
+  function getAdjudicationsFor(offenderNo) {
+    return prisonApiHttpClient.get(
+      `${prisonApiBaseUrl}/offenders/${offenderNo}/adjudications`,
+    );
+  }
+
   return {
     getOffenderDetailsFor,
     getIncentivesSummaryFor,
@@ -85,6 +91,7 @@ function offenderRepository(prisonApiHttpClient, incentivesApiHttpClient) {
     sentenceDetailsFor,
     getCurrentEvents,
     getEventsFor,
+    getAdjudicationsFor,
   };
 }
 

--- a/server/routes/__tests__/profile.spec.js
+++ b/server/routes/__tests__/profile.spec.js
@@ -13,6 +13,7 @@ describe('GET /profile', () => {
     getVisitsFor: jest.fn().mockResolvedValue({}),
     getVisitsRemaining: jest.fn().mockResolvedValue({}),
     getBalancesFor: jest.fn().mockResolvedValue({}),
+    getAdjudicationsFor: jest.fn().mockResolvedValue({}),
   };
 
   let app;

--- a/server/routes/adjudications.js
+++ b/server/routes/adjudications.js
@@ -1,0 +1,47 @@
+const express = require('express');
+const config = require('../config');
+const { createBreadcrumbs } = require('../utils/breadcrumbs');
+
+const createAdjudicationsRouter = ({ offenderService }) => {
+  const router = express.Router();
+
+  const getPersonalisation = async user => {
+    const adjudications = await offenderService.getAdjudicationsFor(user);
+
+    return {
+      signedInUser: user.getFullName(),
+      adjudications,
+    };
+  };
+
+  router.get('/', async (req, res, next) => {
+    const { user, originalUrl: returnUrl } = req;
+
+    if (config.features.adjudicationsFeatureEnabled) {
+      try {
+        const personalisation = user ? await getPersonalisation(user) : {};
+
+        return res.render('pages/adjudications', {
+          title: 'My adjudications',
+          content: false,
+          header: false,
+          postscript: true,
+          detailsType: 'small',
+          returnUrl,
+          ...personalisation,
+          data: { contentType: 'profile', breadcrumbs: createBreadcrumbs(req) },
+          displayImportantNotice: true,
+        });
+      } catch (e) {
+        return next(e);
+      }
+    }
+    return next();
+  });
+
+  return router;
+};
+
+module.exports = {
+  createAdjudicationsRouter,
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -5,6 +5,7 @@ const { createTopicsRouter } = require('./topics');
 const { createTimetableRouter } = require('./timetable');
 const { createContentRouter } = require('./content');
 const { createMoneyRouter } = require('./money');
+const { createAdjudicationsRouter } = require('./adjudications');
 const { createApprovedVisitorsRouter } = require('./approvedVisitors');
 const { createProfileRouter } = require('./profile');
 const { createTagRouter } = require('./tags');
@@ -51,6 +52,7 @@ module.exports = (
       '^/search/?$',
       '/recently-added',
       '/updates',
+      '/adjudications',
     ],
     [
       createPrimaryNavigationMiddleware(cmsService),
@@ -100,6 +102,13 @@ module.exports = (
     createContentRouter({
       cmsService,
       analyticsService,
+    }),
+  );
+
+  router.use(
+    '/adjudications',
+    createAdjudicationsRouter({
+      offenderService,
     }),
   );
 

--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -12,12 +12,14 @@ const createProfileRouter = ({ offenderService }) => {
       visitsSummary,
       visitsBalances,
       moneySummary,
+      adjudications,
     ] = await Promise.all([
       offenderService.getEventsForToday(user),
       offenderService.getIncentivesSummaryFor(user),
       offenderService.getVisitsFor(user),
       offenderService.getVisitsRemaining(user),
       offenderService.getBalancesFor(user),
+      offenderService.getAdjudicationsFor(user),
     ]);
 
     const {
@@ -77,6 +79,7 @@ const createProfileRouter = ({ offenderService }) => {
         privateAccount,
         savings,
       },
+      hasAdjudications: adjudications.length > 0,
     };
   };
 
@@ -97,7 +100,8 @@ const createProfileRouter = ({ offenderService }) => {
           config.features.approvedVisitorsFeatureEnabled,
         displayAdjudicationsFeature:
           req.session.establishmentName === 'ranby' &&
-          config.features.adjudicationsFeatureEnabled,
+          config.features.adjudicationsFeatureEnabled &&
+          personalisation.hasAdjudications,
       });
     } catch (e) {
       return next(e);

--- a/server/services/__tests__/offenderService.spec.js
+++ b/server/services/__tests__/offenderService.spec.js
@@ -420,4 +420,29 @@ describe('Offender Service', () => {
       });
     });
   });
+
+  describe('getAdjudicationsFor', () => {
+    const mockNextVisit = jest.fn();
+    beforeAll(() => {
+      mockNextVisit.mockReturnValue(FORMATTED_RESPONSE);
+    });
+
+    it('returns formatted Adjudications data', async () => {
+      const repository = {
+        getAdjudicationsFor: jest.fn().mockResolvedValue(RAW_RESPONSE),
+      };
+
+      const service = createOffenderService(repository, {
+        Adjudications: mockAdapter,
+      });
+
+      const data = await service.getAdjudicationsFor(TEST_USER);
+
+      expect(repository.getAdjudicationsFor).toHaveBeenCalledWith(
+        TEST_USER.prisonerId,
+      );
+      expect(mockAdapter.from).toHaveBeenCalledWith(RAW_RESPONSE);
+      expect(data).toBe(FORMATTED_RESPONSE);
+    });
+  });
 });

--- a/server/services/offender/index.js
+++ b/server/services/offender/index.js
@@ -17,6 +17,7 @@ const createOffenderService = (
     ImportantDates,
     Timetable,
     TimetableEvent,
+    Adjudications,
   } = responses,
 ) => {
   async function getOffenderDetailsFor({ prisonerId }) {
@@ -254,6 +255,25 @@ const createOffenderService = (
     return Timetable.create({ startDate, endDate }).build();
   }
 
+  async function getAdjudicationsFor({ prisonerId }) {
+    try {
+      logger.info(
+        `OffenderService (getAdjudicationsFor) - User: ${prisonerId}`,
+      );
+
+      const response = await repository.getAdjudicationsFor(prisonerId);
+      return Adjudications.from(response).format();
+    } catch (e) {
+      logger.error(
+        `OffenderService (getAdjudicationsFor) - Failed: ${e.message} - User: ${prisonerId}`,
+      );
+      logger.debug(e.stack);
+      return {
+        error: true,
+      };
+    }
+  }
+
   return {
     getOffenderDetailsFor,
     getIncentivesSummaryFor,
@@ -267,6 +287,7 @@ const createOffenderService = (
     getEventsFor,
     getEventsForToday,
     getEmptyTimetable,
+    getAdjudicationsFor,
   };
 };
 

--- a/server/services/offender/responses/__tests__/adjudications.spec.js
+++ b/server/services/offender/responses/__tests__/adjudications.spec.js
@@ -1,0 +1,88 @@
+const { Adjudications } = require('../adjudications');
+const {
+  placeholders: { DEFAULT },
+} = require('../../../../utils/enums');
+
+describe('Adjudications', () => {
+  it('Should handle an empty response', () => {
+    const adjudications = Adjudications.from();
+
+    expect(adjudications.adjudications).not.toBeDefined();
+
+    const formatted = adjudications.format();
+
+    expect(formatted).toStrictEqual({});
+  });
+
+  it('should handle an incomplete response', () => {
+    const response = {
+      results: [
+        {
+          adjudicationNumber: 12345,
+        },
+        {
+          reportTime: '2016-05-08T14:16:00',
+        },
+        {},
+      ],
+    };
+
+    const formatted = Adjudications.from(response).format();
+
+    expect(formatted).toStrictEqual([
+      {
+        adjudicationNumber: 12345,
+        reportTime: DEFAULT,
+        numberOfCharges: 0,
+      },
+      {
+        adjudicationNumber: DEFAULT,
+        reportTime: '8 May 2016, 2.16pm',
+        numberOfCharges: 0,
+      },
+      {
+        adjudicationNumber: DEFAULT,
+        reportTime: DEFAULT,
+        numberOfCharges: 0,
+      },
+    ]);
+  });
+
+  it('should format data when passed', () => {
+    const response = {
+      results: [
+        {
+          adjudicationNumber: 1310574,
+          reportTime: '2016-05-08T14:16:00',
+          agencyIncidentId: 1291673,
+          agencyId: 'WMI',
+          partySeq: 1,
+          adjudicationCharges: [{}],
+        },
+        {
+          adjudicationNumber: 1310549,
+          reportTime: '2012-01-10T08:52:00',
+          agencyIncidentId: 1291652,
+          agencyId: 'WMI',
+          partySeq: 1,
+          adjudicationCharges: [{}, {}, {}, {}, {}],
+        },
+      ],
+    };
+
+    const formatted = Adjudications.from(response).format();
+
+    expect(formatted).toStrictEqual([
+      {
+        adjudicationNumber: 1310574,
+        reportTime: '8 May 2016, 2.16pm',
+        numberOfCharges: 1,
+      },
+      {
+        adjudicationNumber: 1310549,
+        reportTime: '10 January 2012, 8.52am',
+        numberOfCharges: 5,
+      },
+    ]);
+  });
+});

--- a/server/services/offender/responses/adjudications.js
+++ b/server/services/offender/responses/adjudications.js
@@ -1,0 +1,37 @@
+const {
+  placeholders: { DEFAULT },
+  dateFormats: { GDS_PRETTY_DATE_TIME },
+} = require('../../../utils/enums');
+
+const { formatDateOrDefault } = require('../../../utils/date');
+
+const formatAdjudication = adjudication => ({
+  adjudicationNumber: adjudication.adjudicationNumber || DEFAULT,
+  reportTime: formatDateOrDefault(
+    DEFAULT,
+    GDS_PRETTY_DATE_TIME,
+    adjudication.reportTime,
+  ),
+  numberOfCharges: adjudication.adjudicationCharges?.length || 0,
+});
+
+class Adjudications {
+  constructor(options = {}) {
+    const { results } = options;
+    this.adjudications = results;
+  }
+
+  format() {
+    return this.adjudications?.length > 0
+      ? this.adjudications.map(formatAdjudication)
+      : {};
+  }
+
+  static from(response = {}) {
+    return new Adjudications(response);
+  }
+}
+
+module.exports = {
+  Adjudications,
+};

--- a/server/services/offender/responses/index.js
+++ b/server/services/offender/responses/index.js
@@ -7,6 +7,7 @@ const nextVisit = require('./nextVisit');
 const { ImportantDates } = require('./importantDates');
 const { Timetable } = require('./timetable');
 const { TimetableEvent } = require('./timetableEvent');
+const { Adjudications } = require('./adjudications');
 
 module.exports = {
   IncentivesSummary,
@@ -18,4 +19,5 @@ module.exports = {
   ImportantDates,
   Timetable,
   TimetableEvent,
+  Adjudications,
 };

--- a/server/utils/__tests__/date.spec.js
+++ b/server/utils/__tests__/date.spec.js
@@ -37,6 +37,15 @@ describe('DateUtils', () => {
       );
       expect(formatted).toBe('PLACEHOLDER');
     });
+
+    it('should return a valid date in the expected GDS date format', () => {
+      const formatted = formatDateOrDefault(
+        'PLACEHOLDER',
+        'd MMMM yyyy, h.mmaaa',
+        '2016-05-08T14:16:00',
+      );
+      expect(formatted).toBe('8 May 2016, 2.16pm');
+    });
   });
 
   describe('formatTimeBetweenOrDefault', () => {

--- a/server/utils/breadcrumbs.js
+++ b/server/utils/breadcrumbs.js
@@ -12,6 +12,7 @@ const createBreadcrumbs = ({ originalUrl }) => {
     case '/timetable':
     case '/money':
     case '/approved-visitors':
+    case '/adjudications':
       return [breadcrumbs.home, breadcrumbs.profile];
 
     case '/games':

--- a/server/utils/enums.js
+++ b/server/utils/enums.js
@@ -3,6 +3,7 @@ module.exports = {
     DEFAULT: 'Unavailable',
   },
   dateFormats: {
+    GDS_PRETTY_DATE_TIME: 'd MMMM yyyy, h.mmaaa',
     LONG_PRETTY_DATE: 'EEEE d MMMM',
     PRETTY_DATE: 'EEEE d MMMM yyyy',
     PRETTY_DAY: 'EEEE',

--- a/server/views/pages/adjudications.html
+++ b/server/views/pages/adjudications.html
@@ -1,0 +1,51 @@
+{% extends "../components/basicTemplate.njk" %}
+
+{% block content %}
+  {% if not isSignedIn %}
+      <h2 class="govuk-heading-m">You are signed out</h2>
+      <p class="govuk-!-font-size-24" data-test="signin-prompt">
+        <a href="/auth/sign-in?returnUrl={{ returnUrl }}" class="govuk-link">Sign in</a> to see your personal information.
+      </p>
+  {% else %}
+  
+  {% if error %}
+    <p class="govuk-body govuk-!-font-size-24 govuk-!-margin-bottom-9" data-test="approved-visitors-error">We can not list your adjudications at this time, please <a href="{{ params.returnUrl }}" class="govuk-link">try again</a> or <a href="{{ knownPages.profile.adjudicationsInfo }}" class="govuk-link">read more about adjudications</a>.</p>
+  {% else %}  
+
+      <div class="govuk-!-margin-bottom-7">
+        <a href="{{ knownPages.profile.adjudicationsInfo }}" class="govuk-link govuk-!-font-size-24">Read more about adjudications</a>
+      </div>  
+
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Adjudication number</th>
+            <th scope="col" class="govuk-table__header">Report date and time</th>
+            <th scope="col" class="govuk-table__header">Number of charges</th>
+            <th scope="col" class="govuk-table__header"></th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          {% for adjudication in adjudications %}
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">{{ adjudication.adjudicationNumber }}</td>
+            <td class="govuk-table__cell">{{ adjudication.reportTime }}</td>
+            <td class="govuk-table__cell">{{ adjudication.numberOfCharges }}</td>
+            <td class="govuk-table__cell">[VIEW]</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+
+  {% endif %}
+  {% endif %}
+{% endblock %}
+
+{% block bodyEnd %}
+  <script src="/public/all.js"></script>
+  <script>
+    window
+      .GOVUKFrontend
+      .initAll();
+  </script>
+{% endblock %}

--- a/server/views/pages/profile.html
+++ b/server/views/pages/profile.html
@@ -198,7 +198,7 @@
                   {{imageCard({ id: 'adjudications', src: "/public/images/image_visitors.jpg", alt: "visitor picture", link: knownPages.profile.adjudications, description: "View my adjudications" }) }}
                 </li>
               </ul>
-              <a href='#' class="govuk-!-font-size-24 card-title govuk-link govuk-!-font-weight-regular govuk-link--no-visited-state" data-test="adjudicationsLink">
+              <a href='{{ knownPages.profile.adjudicationsInfo }}' class="govuk-!-font-size-24 card-title govuk-link govuk-!-font-weight-regular govuk-link--no-visited-state" data-test="adjudicationsLink">
                 <span>Read more about adjudications</span>
               </a>
             {% endif %}


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/jvrT7FkA/1997-adjudications-3-add-prison-api-call-and-show-hide-logic-to-my-profile

> If this is an issue, do we have steps to reproduce?
no

### Intent

> What changes are introduced by this PR that correspond to the above card?
- Add API call to prison api - adjudications end point
- Add adjudications section to the My profile page with conditional display
- Add /adjudications route
- Add place holder adjudications list view - to be updated when designs finalised
- Add text link to read more about adjudications
- Add supporting unit tests

> Would this PR benefit from screenshots?

![Screenshot 2023-02-16 at 11 47 18](https://user-images.githubusercontent.com/104000682/219356942-53787ff2-d9f7-4083-b1e2-7a1ddb771436.png)

![Screenshot 2023-02-16 at 11 47 26](https://user-images.githubusercontent.com/104000682/219356981-1c584a95-3ae3-4174-aaa2-f2c1a1aef093.png)


### Considerations

> Is there any additional information that would help when reviewing this PR?
The feature is currently restricted to HMP Ranby.

> Are there any steps required when merging/deploying this PR?
no

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
