### PR TITLE
add links to adjudication detail page in list table

### DIFF
--- a/server/auth/middleware.js
+++ b/server/auth/middleware.js
@@ -59,7 +59,7 @@ const createMockSignIn = ({ offenderService }) =>
   async function mockSignIn(req, res, next) {
     try {
       const user = new User({
-        prisonerId: 'G6046GQ',
+        prisonerId: 'G2311GO',
         firstName: 'Test',
         lastName: 'User',
       });

--- a/server/clients/prisonApiClient.js
+++ b/server/clients/prisonApiClient.js
@@ -72,7 +72,7 @@ class PrisonApiClient {
     return token;
   }
 
-  async get(url) {
+  async get(url, additionalHeaders) {
     logger.debug(`PrisonApiClient (GET) - ${url}`);
 
     let token = await this.cache.get(PRISON_API_TOKEN_KEY);
@@ -81,13 +81,16 @@ class PrisonApiClient {
       token = await this.requestNewAccessToken();
     }
 
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+      ...additionalHeaders,
+    };
+
     const response = await this.client({
       method: 'GET',
       url,
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/json',
-      },
+      headers,
     });
 
     return response.data;

--- a/server/config.js
+++ b/server/config.js
@@ -55,6 +55,10 @@ module.exports = {
       authUrl: `${hmppsAuthBaseUrl}/oauth/token?grant_type=client_credentials`,
     },
     baseUrl: getRequiredEnv('PRISON_API_BASE_URL', 'https://api.nomis'),
+    adjudications: {
+      pageLimit: 50,
+      maxAdjudicationsPerPage: 10,
+    },
   },
   prisonerContactRegistryApi: {
     auth: {

--- a/server/repositories/offender.js
+++ b/server/repositories/offender.js
@@ -77,6 +77,9 @@ function offenderRepository(prisonApiHttpClient, incentivesApiHttpClient) {
   function getAdjudicationsFor(offenderNo) {
     return prisonApiHttpClient.get(
       `${prisonApiBaseUrl}/offenders/${offenderNo}/adjudications`,
+      {
+        'Page-Limit': config.prisonApi.adjudications.pageLimit,
+      },
     );
   }
 

--- a/server/routes/adjudications.js
+++ b/server/routes/adjudications.js
@@ -1,25 +1,35 @@
 const express = require('express');
 const config = require('../config');
 const { createBreadcrumbs } = require('../utils/breadcrumbs');
+const { createPagination } = require('../utils/pagination');
 
 const createAdjudicationsRouter = ({ offenderService }) => {
   const router = express.Router();
 
-  const getPersonalisation = async user => {
+  const getPersonalisation = async (user, query) => {
     const adjudications = await offenderService.getAdjudicationsFor(user);
+
+    const { paginatedData, pageData } = createPagination({
+      data: adjudications,
+      maxItemsPerPage: config.prisonApi.adjudications.maxAdjudicationsPerPage,
+      query,
+    });
 
     return {
       signedInUser: user.getFullName(),
-      adjudications,
+      paginatedData,
+      pageData,
     };
   };
 
   router.get('/', async (req, res, next) => {
-    const { user, originalUrl: returnUrl } = req;
+    const { user, originalUrl: returnUrl, query } = req;
 
     if (config.features.adjudicationsFeatureEnabled) {
       try {
-        const personalisation = user ? await getPersonalisation(user) : {};
+        const personalisation = user
+          ? await getPersonalisation(user, query)
+          : {};
 
         return res.render('pages/adjudications', {
           title: 'My adjudications',

--- a/server/utils/__tests__/pagination.js
+++ b/server/utils/__tests__/pagination.js
@@ -1,0 +1,126 @@
+const { createPagination } = require('../pagination');
+
+describe('Pagination', () => {
+  let data;
+  let maxItemsPerPage;
+  let query;
+
+  beforeEach(() => {
+    data = [
+      {
+        adjudicationNumber: 1111111,
+        reportTime: '19 March 2017, 10.10am',
+        numberOfCharges: 1,
+      },
+      {
+        adjudicationNumber: 2222222,
+        reportTime: '15 March 2017, 4.07pm',
+        numberOfCharges: 1,
+      },
+      {
+        adjudicationNumber: 3333333,
+        reportTime: '14 March 2017, 1.51pm',
+        numberOfCharges: 1,
+      },
+      {
+        adjudicationNumber: 4444444,
+        reportTime: '12 March 2017, 10.10am',
+        numberOfCharges: 1,
+      },
+      {
+        adjudicationNumber: 5555555,
+        reportTime: '10 March 2017, 7.07pm',
+        numberOfCharges: 1,
+      },
+      {
+        adjudicationNumber: 6666666,
+        reportTime: '10 March 2017, 3.47pm',
+        numberOfCharges: 1,
+      },
+      {
+        adjudicationNumber: 7777777,
+        reportTime: '9 March 2017, 10.10am',
+        numberOfCharges: 1,
+      },
+      {
+        adjudicationNumber: 8888888,
+        reportTime: '9 March 2017, 4.07pm',
+        numberOfCharges: 1,
+      },
+      {
+        adjudicationNumber: 9999999,
+        reportTime: '8 March 2017, 2.10pm',
+        numberOfCharges: 1,
+      },
+      {
+        adjudicationNumber: 1010101,
+        reportTime: '7 March 2017, 11.11am',
+        numberOfCharges: 1,
+      },
+      {
+        adjudicationNumber: 1121121,
+        reportTime: '7 March 2017, 4.07pm',
+        numberOfCharges: 1,
+      },
+      {
+        adjudicationNumber: 1212121,
+        reportTime: '4 March 2017, 1.51pm',
+        numberOfCharges: 1,
+      },
+    ];
+    maxItemsPerPage = 10;
+    query = {};
+  });
+
+  afterEach(() => {
+    data = [];
+    maxItemsPerPage = 10;
+    query = {};
+  });
+
+  it('should return the expected values when data, maxItemsPerPage, query values are not provided', () => {
+    const { paginatedData, pageData } = createPagination({});
+    expect(paginatedData).toEqual([]);
+    expect(pageData).toEqual({});
+  });
+
+  it('should return paginated adjudications data', () => {
+    const { paginatedData } = createPagination({
+      data,
+      maxItemsPerPage,
+      query,
+    });
+
+    expect(paginatedData).toHaveLength(maxItemsPerPage);
+    expect(paginatedData).toEqual(data.slice(0, 10));
+  });
+
+  it('should return the expected number of remaining paginated adjudication items', () => {
+    const { paginatedData } = createPagination({
+      data,
+      maxItemsPerPage,
+      query: {
+        page: 2,
+      },
+    });
+
+    expect(paginatedData).toHaveLength(2);
+    expect(paginatedData).toEqual(data.slice(-2));
+  });
+
+  it('should return the expected pageData values', () => {
+    const { pageData } = createPagination({
+      data,
+      maxItemsPerPage,
+      query,
+    });
+
+    expect(pageData).toEqual({
+      page: 1,
+      totalPages: 2,
+      min: 1,
+      max: 10,
+      totalCount: 12,
+    });
+  });
+});

--- a/server/utils/pagination.js
+++ b/server/utils/pagination.js
@@ -1,0 +1,28 @@
+const createPagination = ({ data, maxItemsPerPage, query }) => {
+  let paginatedData = [];
+  let pageData = {};
+
+  if (!data || !maxItemsPerPage || !query)
+    return {
+      paginatedData,
+      pageData,
+    };
+
+  const totalCount = data.length;
+  const totalPages = Math.ceil(totalCount / maxItemsPerPage);
+  const pageNumber = Math.round(query.page) || 1;
+  const page = pageNumber > 0 && pageNumber <= totalPages ? pageNumber : 1;
+  const max = Math.min(page * maxItemsPerPage, totalCount);
+  const min = (page - 1) * maxItemsPerPage + 1;
+  pageData = { page, totalPages, min, max, totalCount };
+  paginatedData = data.slice(min - 1, max);
+
+  return {
+    paginatedData,
+    pageData,
+  };
+};
+
+module.exports = {
+  createPagination,
+};

--- a/server/views/pages/adjudications.html
+++ b/server/views/pages/adjudications.html
@@ -1,4 +1,5 @@
 {% extends "../components/basicTemplate.njk" %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
 
 {% block content %}
   {% if not isSignedIn %}
@@ -13,29 +14,34 @@
   {% else %}  
 
       <div class="govuk-!-margin-bottom-7">
+        <p class="govuk-body govuk-!-font-size-24">Up to 50 adjudications are shown here, in date order, with the newest first.</p>
         <a href="{{ knownPages.profile.adjudicationsInfo }}" class="govuk-link govuk-!-font-size-24">Read more about adjudications</a>
       </div>  
 
       <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Adjudication number</th>
+            <th scope="col" class="govuk-table__header">Report number</th>
             <th scope="col" class="govuk-table__header">Report date and time</th>
-            <th scope="col" class="govuk-table__header">Number of charges</th>
             <th scope="col" class="govuk-table__header"></th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">
-          {% for adjudication in adjudications %}
+          {% for adjudication in paginatedData %}
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell">{{ adjudication.adjudicationNumber }}</td>
+            <td class="govuk-table__cell"><a href="/adjudications/{{adjudication.adjudicationNumber}}" class="govuk-link">{{ adjudication.adjudicationNumber }}</a></td>
             <td class="govuk-table__cell">{{ adjudication.reportTime }}</td>
-            <td class="govuk-table__cell">{{ adjudication.numberOfCharges }}</td>
-            <td class="govuk-table__cell">[VIEW]</td>
+            <td class="govuk-table__cell"><a href="/adjudications/{{adjudication.adjudicationNumber}}" class="govuk-link">View</a></td>
           </tr>
           {% endfor %}
         </tbody>
       </table>
+
+      {% if pageData.totalPages > 1 %}
+        <div class="govuk-!-margin-bottom-9">
+          {{ govukPagination( pageData | toPagination(rawQuery) ) }}
+        </div>
+      {% endif %}
 
   {% endif %}
   {% endif %}
@@ -43,6 +49,8 @@
 
 {% block bodyEnd %}
   <script src="/public/all.js"></script>
+  <script src="/public/javascript/showMore.js"></script>
+  <script>setUpShowMore($('.show-more-tiles'), $('.small-tiles'))</script>
   <script>
     window
       .GOVUKFrontend


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/yT7QImZG/2030-adjudications-4-adjudications-list-page

> If this is an issue, do we have steps to reproduce?
no.

### Intent

> What changes are introduced by this PR that correspond to the above card?

- Add Page-Limit header to adjudications prison api call
- Add details text to list page
- Refactor pagination 
- Add unit tests to for createPagination

> Would this PR benefit from screenshots?

![Screenshot 2023-02-22 at 15 21 12](https://user-images.githubusercontent.com/104000682/220667668-f966a53b-6844-4f9f-b30d-09b476280fb5.png)


### Considerations

> Is there any additional information that would help when reviewing this PR?
no

> Are there any steps required when merging/deploying this PR?
no

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
