### PR TITLE
Add remaining establishment names to adjudications feature enabled at…

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -91,7 +91,23 @@ module.exports = {
       getEnv('APPROVED_VISITORS_FEATURE_ENABLED', 'false') === 'true',
     adjudicationsFeatureEnabled:
       getEnv('ADJUDICATIONS_FEATURE_ENABLED', 'false') === 'true',
-    adjudicationsFeatureEnabledAt: ['lindholme'],
+    adjudicationsFeatureEnabledAt: [
+      'cookhamwood',
+      'erlestoke',
+      'felthama',
+      'felthamb',
+      'garth',
+      'lindholme',
+      'newhall',
+      'ranby',
+      'stokeheath',
+      'styal',
+      'swaleside',
+      'themount',
+      'wayland',
+      'werrington',
+      'wetherby',
+    ],
   },
   analytics: {
     endpoint: getEnv(


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/Un7hH18P/2050-adjudication-on-prisoner-profile-wider-rollout-to-all-sites

> If this is an issue, do we have steps to reproduce?
No

### Intent

> What changes are introduced by this PR that correspond to the above card?
- Add remaining establishment names to feature enabled at array.

> Would this PR benefit from screenshots?
No.

### Considerations

> Is there any additional information that would help when reviewing this PR?
The adjudications feature will appear for any prisoner with adjudications in any of the following establishments:

- cookhamwood
- erlestoke
- felthama
- felthamb
- garth
- lindholme
- newhall
- ranby
- stokeheath
- styal
- swaleside
- themount
- wayland
- werrington
- wetherby

> Are there any steps required when merging/deploying this PR?
No.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
