### PR TITLE
Remove max-height property

### DIFF
--- a/assets/sass/components/_update-items.scss
+++ b/assets/sass/components/_update-items.scss
@@ -19,7 +19,6 @@
         & p {
           width: 100%;
           margin: 0;
-          max-height: 50px;
           text-decoration: underline;
           overflow: hidden;
           text-overflow: ellipsis;


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/4lVtHfZm/2062-implement-frontend-updates-based-on-accessibility-audit-findings-suggestions - point 21

> If this is an issue, do we have steps to reproduce?
no

### Intent

> What changes are introduced by this PR that correspond to the above card?
- Update to CSS to fix hidden text when the browser text size is set to large / extra large

> Would this PR benefit from screenshots?

Before:
![image](https://user-images.githubusercontent.com/104000682/226892172-a304ecaa-1be6-4495-bc5d-ca00291b1953.png)


After:
![Screenshot 2023-03-22 at 11 35 27](https://user-images.githubusercontent.com/104000682/226892539-59962f07-d732-4d16-a721-633c3b30b396.png)


### Considerations

> Is there any additional information that would help when reviewing this PR?
no

> Are there any steps required when merging/deploying this PR?
no

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
