### PR TITLE
Update key-info tile styles

### DIFF
--- a/assets/sass/components/_key-info-items.scss
+++ b/assets/sass/components/_key-info-items.scss
@@ -41,9 +41,7 @@
 
 .govuk-hub-key-info-item > a {
   display: flex;
-  height: 90px;
   background-color: $real-dark-grey;
-  overflow: hidden;
   text-decoration: none;
   box-sizing: border-box;
 
@@ -53,9 +51,9 @@
   }
 
   > img {
-    min-width: 50%;
-    max-width: 50%;
-    height: 90px;
+    min-width: 40%;
+    max-width: 40%;
+    max-height: 90px;
     object-fit: cover;
     object-position: 50% 50%;
   }


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/u8emcFnD/2094-accessibility-fix-29-key-info-tile-text-at-large-very-large

> If this is an issue, do we have steps to reproduce?
Change the browser appearance setting to use large / very large font sizes

### Intent

> What changes are introduced by this PR that correspond to the above card?
- updated related CSS to ensure the key-info tile text is readable when then browser font-size setting is set to large or very large.

> Would this PR benefit from screenshots?

Before the updates:
<img width="363" alt="Screenshot 2023-03-24 at 09 58 15" src="https://user-images.githubusercontent.com/104000682/227490084-810ed6ac-a814-4193-9fff-192aa489bccb.png">


After the updates:

- medium (recommended) font size
<img width="310" alt="Screenshot 2023-03-24 at 09 15 50" src="https://user-images.githubusercontent.com/104000682/227489571-2c5e8be5-7a02-42ad-b7ed-0d1ccde34631.png">

- large font size
<img width="317" alt="Screenshot 2023-03-24 at 09 15 39" src="https://user-images.githubusercontent.com/104000682/227489700-4c7ae9cf-b196-4f69-81fb-138d0135fdf5.png">

- very large font size
<img width="294" alt="Screenshot 2023-03-24 at 09 15 25" src="https://user-images.githubusercontent.com/104000682/227489774-0d74bd34-cdbc-4ae2-9fd6-13342ac6cefd.png">


### Considerations

> Is there any additional information that would help when reviewing this PR?
No.

> Are there any steps required when merging/deploying this PR?
No.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
