### PR TITLE
Reposition NEW tag

### DIFF
--- a/server/views/components/content-tile-small/template.njk
+++ b/server/views/components/content-tile-small/template.njk
@@ -1,7 +1,9 @@
 {% if params.id %}
   <a data-featured-tile-id="{{params.id}}" data-featured-id="{{params.id}}" data-featured-title="{{ params.title }}" href="{{params.contentUrl}}" {% if params.externalContent %}target="_blank"{% endif %}>
     <div class="tile-top">
-      {% if params.contentType === "series" %}
+      {% if params.isNew %}
+        <strong class="govuk-tag govuk-tag--green">NEW</strong>
+      {% elif params.contentType === "series" %}
         <strong class="govuk-tag govuk-tag--purple">SERIES</strong>
       {% endif %}
       {% if params.image.url %}
@@ -12,24 +14,19 @@
       <h3 class="govuk-heading-m" style="">{{params.title}}</h3>
     </div>
     <div class="govuk-grid-column-full govuk-hub-contentTileSmall">
-    <div>
-      {% if params.contentType === "video" %}
-        <p class="content-link--video">Watch</p>
-      {% elif params.contentType === "radio" %}
-        <p class="content-link--audio">Listen</p>
-      {% elif params.contentType === "external_link" %}
-        <p class="content-link--external">{{ params.displayUrl }}</p>
-      {% elif params.contentType === "internal_link" %}
-      <p class="content-link--internal"></p>
-      {% elif params.contentType === "category" %}
-      {% elif params.contentType !== "series" and params.contentType !== "category_bottom" %}
-        <p class="content-link--article">Read</p>
-      {% endif %}
-    </div>
       <div>
-        {% if params.isNew %}
-          <strong class="govuk-tag govuk-tag--green">NEW</strong>
-        {% endif %} 
+        {% if params.contentType === "video" %}
+          <p class="content-link--video">Watch</p>
+        {% elif params.contentType === "radio" %}
+          <p class="content-link--audio">Listen</p>
+        {% elif params.contentType === "external_link" %}
+          <p class="content-link--external">{{ params.displayUrl }}</p>
+        {% elif params.contentType === "internal_link" %}
+        <p class="content-link--internal"></p>
+        {% elif params.contentType === "category" %}
+        {% elif params.contentType !== "series" and params.contentType !== "category_bottom" %}
+          <p class="content-link--article">Read</p>
+        {% endif %}
       </div>
     </div>
   </a>


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/RlBYeHtI/2102-reposition-the-new-tag

> If this is an issue, do we have steps to reproduce?
N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?
- Reposition the 'NEW' tag on the small content tile

> Would this PR benefit from screenshots?

**Before the change:**
![Screenshot 2023-03-28 at 14 57 36](https://user-images.githubusercontent.com/104000682/228276646-074ce4ea-6982-4793-aeb6-04e2ea79b2aa.png)

**After the change:** 
<img width="310" alt="Screenshot 2023-03-28 at 15 47 02" src="https://user-images.githubusercontent.com/104000682/228276724-2d841c9a-5f82-4250-9373-79cc0d85878c.png">

### Considerations

> Is there any additional information that would help when reviewing this PR?
No.

> Are there any steps required when merging/deploying this PR?
No.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
