### PR TITLE
Add lazy loading to key info tiles

### DIFF
--- a/server/views/components/key-info-items/template.njk
+++ b/server/views/components/key-info-items/template.njk
@@ -9,11 +9,9 @@
         class="govuk-link govuk-link--no-visited-state govuk-link--no-underline govuk-!-margin-bottom-2">
 
         {% if item.image.url %}
-          <img src="{{item.image.url}}" 
-              alt="">
+          <img src="{{item.image.url}}" alt="" loading="lazy">
         {% else %}
-          <img src="/public/images/default_key_info_item_hub_logo.png"
-              alt="logo">
+          <img src="/public/images/default_key_info_item_hub_logo.png" alt="logo" loading="lazy">
         {% endif %}
           <h3 class="govuk-heading-s govuk-!-margin-0">{{item.title}}</h3>
 


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/D9Rs1jcv/870-introduce-image-lazy-loading

> If this is an issue, do we have steps to reproduce?

### Intent

> What changes are introduced by this PR that correspond to the above card?

Added `loading="lazy"` to key info tiles.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [X] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
