### PR TITLE
Remove reported by data from view

### DIFF
--- a/server/views/pages/adjudication.html
+++ b/server/views/pages/adjudication.html
@@ -49,14 +49,6 @@
             },
             {
               key: {
-                text: "Reported by"
-              },
-              value: {
-                text: data.adjudication.reportedBy
-              }
-            },
-            {
-              key: {
                 text: "Report date and time"
               },
               value: {


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/5eSk2ts7/2114-update-remove-reported-by-values-from-the-adjudication-detail-view

> If this is an issue, do we have steps to reproduce?
N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?
- Removed 'Reported by' data from the adjudication detail view

> Would this PR benefit from screenshots?

**Prior to the update:**

![Screenshot 2023-04-18 at 09 44 29](https://user-images.githubusercontent.com/104000682/232723590-e9b96ce3-c647-4d14-82ac-c24dc45c5e72.png)

**After the update:**

![Screenshot 2023-04-18 at 09 44 38](https://user-images.githubusercontent.com/104000682/232723652-2b1da869-07be-4b46-a3e0-4e6ffea04fc5.png)


### Considerations

> Is there any additional information that would help when reviewing this PR?
No.

> Are there any steps required when merging/deploying this PR?
No.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
