### PR TITLE
Fix/2125 missing prisonerid on adjudications

### DIFF
--- a/server/routes/adjudications.js
+++ b/server/routes/adjudications.js
@@ -69,7 +69,7 @@ const createAdjudicationsRouter = ({ offenderService }) => {
     ) {
       try {
         const adjudication = await offenderService.getAdjudicationFor(
-          user,
+          user?.prisonerId,
           adjudicationId,
         );
 

--- a/server/services/__tests__/offenderService.spec.js
+++ b/server/services/__tests__/offenderService.spec.js
@@ -471,7 +471,10 @@ describe('Offender Service', () => {
         Adjudication: mockAdapter,
       });
 
-      const data = await service.getAdjudicationFor(TEST_USER, adjudicationId);
+      const data = await service.getAdjudicationFor(
+        TEST_USER.prisonerId,
+        adjudicationId,
+      );
 
       expect(repository.getAdjudicationFor).toHaveBeenCalledWith(
         TEST_USER.prisonerId,

--- a/server/services/offender/index.js
+++ b/server/services/offender/index.js
@@ -275,7 +275,7 @@ const createOffenderService = (
     }
   }
 
-  async function getAdjudicationFor({ prisonerId }, adjudicationId) {
+  async function getAdjudicationFor(prisonerId, adjudicationId) {
     try {
       logger.info(
         `OffenderService (getAdjudicationFor) - User: ${prisonerId}, Adjudication: ${adjudicationId}`,


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/rb7181rg/2125-fix-missing-user-object-when-deconstructing-prisonerid-on-adjudication-detail-route

> If this is an issue, do we have steps to reproduce?
na

### Intent

> What changes are introduced by this PR that correspond to the above card?

- remove deconstruction of user object
- update supporting unit test

> Would this PR benefit from screenshots?
no

### Considerations

> Is there any additional information that would help when reviewing this PR?
no

> Are there any steps required when merging/deploying this PR?
no

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
