### PR TITLE
add drupal wysiwyg specific alignment styles

### DIFF
--- a/assets/sass/components/_drupal-wysiwyg-editor.scss
+++ b/assets/sass/components/_drupal-wysiwyg-editor.scss
@@ -1,0 +1,30 @@
+.gov-uk-dynamic-content {
+  .align-right {
+    float: right;
+    margin-left: 1em;
+
+    &:after {
+      content: '';
+      display: block;
+      clear: right;
+    }
+  }
+
+  .align-left {
+    float: left;
+    margin-right: 1em;
+
+    &:after {
+      content: '';
+      display: block;
+      clear: left;
+    }
+  }
+
+  .align-center {
+    display: block;
+    margin-right: auto;
+    margin-left: auto;
+    margin-bottom: 1em;
+  }
+}

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -45,6 +45,7 @@ $real-dark-grey: #232425;
 @import 'components/related-topics';
 @import 'components/urgent-banner';
 @import 'components/adjudication';
+@import 'components/drupal-wysiwyg-editor';
 
 @import 'pages/flat-content';
 @import 'pages/step-by-step';


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/8P6DzI0H/2126-add-drupal-wysiwyg-editor-css-styles-into-the-frontend-application

> If this is an issue, do we have steps to reproduce?
na

### Intent

> What changes are introduced by this PR that correspond to the above card?
- Add align right, align left, align centre classes to reflect those within the Drupal WYSIWYG editor output.

> Would this PR benefit from screenshots?
![image](https://user-images.githubusercontent.com/104000682/235928220-97cd8b7a-ca8b-4236-86a0-44f1623e1997.png)
![image](https://user-images.githubusercontent.com/104000682/235928255-9e126dfb-b00a-4861-a232-b577fefd7c89.png)


### Considerations

> Is there any additional information that would help when reviewing this PR?
no

> Are there any steps required when merging/deploying this PR?
no

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
