### PR TITLE
Add GA4 code block to basicTemplate.njk

### DIFF
--- a/server/views/components/basicTemplate.njk
+++ b/server/views/components/basicTemplate.njk
@@ -39,6 +39,16 @@
       gtag('js', new Date());
       gtag('config', 'UA-152065860-4');
     </script>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-H1MT63QRLQ"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-H1MT63QRLQ');
+    </script>
   </head>
   <body class="govuk-template__body {{ bodyClasses }}">
     <script>


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/b1cIq1Tk/2150-add-ga4-code-block-into-basictemplatenjk-for-testing-establishment-access-to-ga4-urls

> If this is an issue, do we have steps to reproduce?
N/A

### Intent

> What changes are introduced by this PR that correspond to the above card?
- Added GA4 code block to the basicTemplate.njk file that is used throughout the frontend application for the purpose of testing allow listing of the GA4 URLs from the establishments, by monitoring the GA4 production property realtime dashboard for activity post deployment to production.

> Would this PR benefit from screenshots?
No.

### Considerations

> Is there any additional information that would help when reviewing this PR?
No.

> Are there any steps required when merging/deploying this PR?
No.

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
