### PR TITLE
Change readiness to UP from OK

### DIFF
--- a/e2e/cypress/features/health.feature.js
+++ b/e2e/cypress/features/health.feature.js
@@ -13,7 +13,7 @@ describe('Healthcheck', () => {
     });
 
     it('Health/readiness is visible and UP', () => {
-      cy.request('/health/readiness').its('body.status').should('equal', 'OK');
+      cy.request('/health/readiness').its('body.status').should('equal', 'UP');
     });
   });
 });

--- a/server/routes/__tests__/health.spec.js
+++ b/server/routes/__tests__/health.spec.js
@@ -44,7 +44,7 @@ describe('GET healthchecks', () => {
       .expect('Content-Type', /json/)
       .then(res => {
         expect(res.body).toStrictEqual({
-          status: 'OK',
+          status: 'UP',
         });
       }));
 });

--- a/server/routes/health.js
+++ b/server/routes/health.js
@@ -4,7 +4,7 @@ const createHealthRouter = () => {
   const router = express.Router();
 
   router.get('/', (_, res) => res.json(addAppInfo({ healthy: true })));
-  router.get('/readiness', (_, res) => res.json({ status: 'OK' }));
+  router.get('/readiness', (_, res) => res.json({ status: 'UP' }));
 
   return router;
 };


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

No

> If this is an issue, do we have steps to reproduce?

Current `/health/readiness` endpoint returns `OK`, it needs to return `UP`

### Intent

> What changes are introduced by this PR that correspond to the above ticket?

> Would this PR benefit from screenshots?

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above ticket
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
