### PR TITLE
Disable capturing of inproc dependencies in app insights

### DIFF
--- a/server/utils/__tests__/azureInsights.spec.js
+++ b/server/utils/__tests__/azureInsights.spec.js
@@ -2,6 +2,7 @@ const { Contracts } = require('applicationinsights');
 const {
   addEstablishmentProcessor,
   ignoreStaticAssetsProcessor,
+  ignoreInProcDependencies,
 } = require('../azureAppInsights');
 
 describe('azureAppInsights', () => {
@@ -107,6 +108,48 @@ describe('azureAppInsights', () => {
       );
 
       const result = ignoreStaticAssetsProcessor(envelope, context);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('ignoreInProcDependencies', () => {
+    const context = {};
+
+    const createRemoteDependencyData = type => {
+      const baseData = new Contracts.RemoteDependencyData();
+      baseData.name = 'name';
+      baseData.type = type;
+      return baseData;
+    };
+
+    const createEnvelope = baseData => ({
+      data: {
+        baseType: 'RemoteDependencyData',
+        baseData,
+      },
+    });
+
+    it('processes when missing request data', () => {
+      const envelope = createEnvelope(null);
+
+      const result = ignoreInProcDependencies(envelope, context);
+
+      expect(result).toBe(true);
+    });
+
+    it('processes when unknown baseType', () => {
+      const envelope = createEnvelope(createRemoteDependencyData('HTTP'));
+
+      const result = ignoreInProcDependencies(envelope, context);
+
+      expect(result).toBe(true);
+    });
+
+    it('does not InProc dependencies', () => {
+      const envelope = createEnvelope(createRemoteDependencyData('InProc'));
+
+      const result = ignoreInProcDependencies(envelope, context);
 
       expect(result).toBe(false);
     });

--- a/server/utils/azureAppInsights.js
+++ b/server/utils/azureAppInsights.js
@@ -20,6 +20,13 @@ function ignoreStaticAssetsProcessor(envelope) {
   return true;
 }
 
+function ignoreInProcDependencies(envelope) {
+  if (envelope.data.baseType === Contracts.TelemetryTypeString.Dependency) {
+    return envelope.data.baseData?.type !== 'InProc';
+  }
+  return true;
+}
+
 function addEstablishmentProcessor(envelope, contextObjects) {
   if (envelope.data.baseType === Contracts.TelemetryTypeString.Request) {
     const establishmentName =
@@ -49,11 +56,13 @@ function initialiseAppInsights() {
   client.context.tags['ai.application.ver'] = version();
   client.addTelemetryProcessor(addEstablishmentProcessor);
   client.addTelemetryProcessor(ignoreStaticAssetsProcessor);
+  client.addTelemetryProcessor(ignoreInProcDependencies);
   return client;
 }
 
 module.exports = {
   ignoreStaticAssetsProcessor,
+  ignoreInProcDependencies,
   addEstablishmentProcessor,
   initialiseAppInsights,
 };


### PR DESCRIPTION
Sentry was registering extra events against app insights.
