### PR TITLE
LNP-1122: 💄  fix focus styles in header.

### DIFF
--- a/assets/sass/components/_topbar.scss
+++ b/assets/sass/components/_topbar.scss
@@ -5,7 +5,6 @@
 .top-bar {
   @include govuk-font(24, 'regular');
   display: flex;
-  color: govuk-colour('white');
   align-items: center;
   padding: govuk-spacing(1) 0;
 
@@ -24,10 +23,6 @@
   & a {
     text-decoration: none;
     margin-bottom: 0;
-  }
-
-  & a.govuk-link {
-    color: govuk-colour('white');
   }
 
   & a:hover {
@@ -87,10 +82,6 @@
             &:hover,
             &.active {
               text-decoration: underline;
-            }
-
-            &:visited {
-              color: white;
             }
           }
         }

--- a/server/views/components/top-bar/template.njk
+++ b/server/views/components/top-bar/template.njk
@@ -21,7 +21,7 @@
                 <a
                   href="{{ translation.href }}"
                   lang="{{ translation.lang }}"
-                  class="{% if translation.lang == params.currentLng %}active{% endif %} govuk-link">
+                  class="govuk-link govuk-link--inverse {% if translation.lang == params.currentLng %}active{% endif %} govuk-link">
                   {{ translation.text }}
                 </a>
               </div>


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-1122

> If this is an issue, do we have steps to reproduce?

Open the content hub front end and tab to focus on the Content Hub title or the language switcher (only The Studio has the language switcher configured at present). These display in white text rather than black when focused:

![image](https://github.com/user-attachments/assets/c7a4917c-00e2-4a4d-8a32-d82bbdd026bb)

![image](https://github.com/user-attachments/assets/9a8dc60e-605f-4b03-8921-3f1eda9d0cef)


### Intent

> What changes are introduced by this PR that correspond to the above ticket?

Removes the explicit setting of topbar links to white in CSS - instead applies the correct existing styles to those links.

> Would this PR benefit from screenshots?

Yes, have some:

<img width="1238" alt="image" src="https://github.com/user-attachments/assets/47b607a6-3bee-4360-ad50-6b794426ccea" />

<img width="1241" alt="image" src="https://github.com/user-attachments/assets/4a3b0ea4-9319-4357-b739-74beff2906ab" />


### Considerations

> Is there any additional information that would help when reviewing this PR?

You can read https://design-system.service.gov.uk/get-started/focus-states/

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above ticket
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
