### PR TITLE
LNP-1091: 🔧  remove profile from remaining sites except Cardiff and Bullingdon

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -1,9 +1,6 @@
 const { getEnv, getRequiredEnv, isProduction } = require('../utils/index');
 
-const hubEndpoint = getRequiredEnv(
-  'HUB_API_ENDPOINT',
-  'http://localhost:11001',
-);
+const hubEndpoint = getRequiredEnv('HUB_API_ENDPOINT', 'http://localhost:9090');
 const hmppsAuthBaseUrl = getRequiredEnv(
   'HMPPS_AUTH_BASE_URL',
   'https://api.nomis',

--- a/server/config.js
+++ b/server/config.js
@@ -1,6 +1,9 @@
 const { getEnv, getRequiredEnv, isProduction } = require('../utils/index');
 
-const hubEndpoint = getRequiredEnv('HUB_API_ENDPOINT', 'http://localhost:9090');
+const hubEndpoint = getRequiredEnv(
+  'HUB_API_ENDPOINT',
+  'http://localhost:11001',
+);
 const hmppsAuthBaseUrl = getRequiredEnv(
   'HMPPS_AUTH_BASE_URL',
   'https://api.nomis',
@@ -128,13 +131,13 @@ module.exports = {
       languages: ['en'],
     },
     chelmsford: {
-      enabled: true,
-      features: ['incentives', 'money', 'timetable', 'visits'],
+      enabled: false,
+      features: [],
       languages: ['en'],
     },
     cookhamwood: {
-      enabled: true,
-      features: ['adjudications', 'incentives', 'money', 'timetable', 'visits'],
+      enabled: false,
+      features: [],
       languages: ['en'],
     },
     erlestoke: {
@@ -157,13 +160,13 @@ module.exports = {
       languages: ['en'],
     },
     garth: {
-      enabled: true,
-      features: ['adjudications', 'incentives', 'money', 'timetable', 'visits'],
+      enabled: false,
+      features: [],
       languages: ['en'],
     },
     lindholme: {
-      enabled: true,
-      features: ['adjudications', 'incentives', 'money', 'timetable', 'visits'],
+      enabled: false,
+      features: [],
       languages: ['en'],
     },
     newhall: {
@@ -172,13 +175,13 @@ module.exports = {
       languages: ['en'],
     },
     ranby: {
-      enabled: true,
-      features: ['adjudications', 'incentives', 'money', 'timetable', 'visits'],
+      enabled: false,
+      features: [],
       languages: ['en'],
     },
     stokeheath: {
-      enabled: true,
-      features: ['adjudications', 'incentives', 'money', 'timetable', 'visits'],
+      enabled: false,
+      features: [],
       languages: ['en'],
     },
     styal: {
@@ -187,23 +190,23 @@ module.exports = {
       languages: ['en'],
     },
     swaleside: {
-      enabled: true,
-      features: ['adjudications', 'incentives', 'money', 'timetable', 'visits'],
+      enabled: false,
+      features: [],
       languages: ['en'],
     },
     themount: {
-      enabled: true,
-      features: ['adjudications', 'incentives', 'money', 'timetable', 'visits'],
+      enabled: false,
+      features: [],
       languages: ['en'],
     },
     thestudio: {
-      enabled: true,
-      features: ['adjudications', 'incentives', 'money', 'timetable', 'visits'],
+      enabled: false,
+      features: [],
       languages: ['en', 'cy'],
     },
     wayland: {
-      enabled: true,
-      features: ['adjudications', 'incentives', 'money', 'timetable', 'visits'],
+      enabled: false,
+      features: [],
       languages: ['en'],
     },
     werrington: {
@@ -217,8 +220,8 @@ module.exports = {
       languages: ['en'],
     },
     woodhill: {
-      enabled: true,
-      features: ['incentives', 'money', 'timetable', 'visits'],
+      enabled: false,
+      features: [],
       languages: ['en'],
     },
   },


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-1091

> If this is an issue, do we have steps to reproduce?

N/A

### Intent

> What changes are introduced by this PR that correspond to the above ticket?

Changes configuration so that Profile is not available for all remaining prisons except Cardiff, Bullingdon (and etwow, which isn't real).

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

This should be preceded by https://dsdmoj.atlassian.net/browse/LNP-1092, so that there is no longer a broken link to the profile in Drupal.

### Checklist

- [x] This PR contains **only** changes related to the above ticket
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development
