### PR TITLE
Stop fetching events when timetable disabled

### DIFF
--- a/server/routes/homepage.js
+++ b/server/routes/homepage.js
@@ -23,9 +23,14 @@ const createHomepageRouter = ({ cmsService, offenderService }) => {
         cmsService.getExploreContent(establishmentName),
         cmsService.getUpdatesContent(establishmentName),
       ]);
-      const currentEvents = res.locals.isSignedIn
-        ? await offenderService.getCurrentEvents(req.user)
-        : {};
+      const displayTimetable = checkFeatureEnabledAtSite(
+        req.session.establishmentName,
+        'timetable',
+      );
+      const currentEvents =
+        res.locals.isSignedIn && displayTimetable
+          ? await offenderService.getCurrentEvents(req.user)
+          : {};
       const useLargeUpdateTile = Boolean(largeUpdateTileSpecified?.contentUrl);
 
       const largeUpdateTile = useLargeUpdateTile
@@ -58,10 +63,7 @@ const createHomepageRouter = ({ cmsService, offenderService }) => {
         largeUpdateTile,
         exploreContent,
         currentEvents,
-        displayTimetable: checkFeatureEnabledAtSite(
-          req.session.establishmentName,
-          'timetable',
-        ),
+        displayTimetable,
       });
     } catch (error) {
       next(error);


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

No

> If this is an issue, do we have steps to reproduce?

Check logs for `06:41:56.238Z  INFO Prisoner Content Hub Frontend: OffenderService (getCurrentEvents) - User: ???????`

### Intent

> What changes are introduced by this PR that correspond to the above ticket?

> Would this PR benefit from screenshots?

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above ticket
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
