### PR TITLE
LNP-1138: ⚡️  round the timestamp for the JSON:API request for update…

### DIFF
--- a/server/repositories/cmsQueries/homepageUpdatesContentQuery.js
+++ b/server/repositories/cmsQueries/homepageUpdatesContentQuery.js
@@ -55,7 +55,7 @@ class HomepageUpdatesContentQuery {
       )
       .addFilter(
         'published_at',
-        getOffsetUnixTime(90),
+        getOffsetUnixTime(90, new Date().setHours(0, 0, 0, 0)),
         '>=',
         'categories_group',
       )


### PR DESCRIPTION
…s. This makes the query the same all day and hence cacheable.

### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-1138

> If this is an issue, do we have steps to reproduce?

Load a prison homepage  or /updates page. Monitor the http header X-Drupal-Cache and observe it repeatedly miss.

### Intent

> What changes are introduced by this PR that correspond to the above ticket?

Rounds the date filter down to the beginning of the current day. This makes repeated requests on the same day use the same date filter rather than the nearest second. Because the date filter is part of the cache key, subsequent responses on the same day will be cached.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above ticket
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
