### PR TITLE
LNP-1167: fix topics page and make recently added page translatable.

### DIFF
--- a/server/repositories/cmsQueries/__tests__/recentlyAddedContentQuery.spec.js
+++ b/server/repositories/cmsQueries/__tests__/recentlyAddedContentQuery.spec.js
@@ -6,13 +6,19 @@ describe('Recently Added Content page query', () => {
   let query;
 
   beforeEach(() => {
-    query = new RecentlyAddedContentQuery(ESTABLISHMENTNAME, 1, 40, TIMESTAMP);
+    query = new RecentlyAddedContentQuery(
+      ESTABLISHMENTNAME,
+      1,
+      40,
+      TIMESTAMP,
+      'en',
+    );
   });
 
   describe('path', () => {
     it('should return correct path', () => {
       expect(query.path()).toStrictEqual(
-        `/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Btype.meta.drupal_internal__target_id%5D%5Bcondition%5D%5Bpath%5D=type.meta.drupal_internal__target_id&filter%5Btype.meta.drupal_internal__target_id%5D%5Bcondition%5D%5Bvalue%5D%5B0%5D=page&filter%5Btype.meta.drupal_internal__target_id%5D%5Bcondition%5D%5Bvalue%5D%5B1%5D=moj_video_item&filter%5Btype.meta.drupal_internal__target_id%5D%5Bcondition%5D%5Bvalue%5D%5B2%5D=moj_radio_item&filter%5Btype.meta.drupal_internal__target_id%5D%5Bcondition%5D%5Bvalue%5D%5B3%5D=moj_pdf_item&filter%5Btype.meta.drupal_internal__target_id%5D%5Bcondition%5D%5Boperator%5D=IN&filter%5Bcreated%5D%5Bvalue%5D=1651737416&filter%5Bcreated%5D%5Boperator%5D=%3E%3D&include=field_moj_thumbnail_image&sort=-published_at%2Ccreated&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_thumbnail_image%2Cfield_summary%2Cfield_moj_series%2Cpath%2Ctype.meta.drupal_internal__target_id%2Cpublished_at&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_thumbnail_image%2Cfield_summary%2Cfield_moj_series%2Cpath%2Ctype.meta.drupal_internal__target_id%2Cpublished_at&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_thumbnail_image%2Cfield_summary%2Cfield_moj_series%2Cpath%2Ctype.meta.drupal_internal__target_id%2Cpublished_at&fields%5Bnode--moj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_thumbnail_image%2Cfield_summary%2Cfield_moj_series%2Cpath%2Ctype.meta.drupal_internal__target_id%2Cpublished_at&fields%5Bfile--file%5D=drupal_internal__fid%2Cid%2Cimage_style_uri&page%5Boffset%5D=0&page%5Blimit%5D=40`,
+        `/en/jsonapi/prison/${ESTABLISHMENTNAME}/node?filter%5Btype.meta.drupal_internal__target_id%5D%5Bcondition%5D%5Bpath%5D=type.meta.drupal_internal__target_id&filter%5Btype.meta.drupal_internal__target_id%5D%5Bcondition%5D%5Bvalue%5D%5B0%5D=page&filter%5Btype.meta.drupal_internal__target_id%5D%5Bcondition%5D%5Bvalue%5D%5B1%5D=moj_video_item&filter%5Btype.meta.drupal_internal__target_id%5D%5Bcondition%5D%5Bvalue%5D%5B2%5D=moj_radio_item&filter%5Btype.meta.drupal_internal__target_id%5D%5Bcondition%5D%5Bvalue%5D%5B3%5D=moj_pdf_item&filter%5Btype.meta.drupal_internal__target_id%5D%5Bcondition%5D%5Boperator%5D=IN&filter%5Bcreated%5D%5Bvalue%5D=1651737416&filter%5Bcreated%5D%5Boperator%5D=%3E%3D&include=field_moj_thumbnail_image&sort=-published_at%2Ccreated&fields%5Bnode--page%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_thumbnail_image%2Cfield_summary%2Cfield_moj_series%2Cpath%2Ctype.meta.drupal_internal__target_id%2Cpublished_at&fields%5Bnode--moj_video_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_thumbnail_image%2Cfield_summary%2Cfield_moj_series%2Cpath%2Ctype.meta.drupal_internal__target_id%2Cpublished_at&fields%5Bnode--moj_radio_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_thumbnail_image%2Cfield_summary%2Cfield_moj_series%2Cpath%2Ctype.meta.drupal_internal__target_id%2Cpublished_at&fields%5Bnode--moj_pdf_item%5D=drupal_internal__nid%2Ctitle%2Cfield_moj_thumbnail_image%2Cfield_summary%2Cfield_moj_series%2Cpath%2Ctype.meta.drupal_internal__target_id%2Cpublished_at&fields%5Bfile--file%5D=drupal_internal__fid%2Cid%2Cimage_style_uri&page%5Boffset%5D=0&page%5Blimit%5D=40`,
       );
     });
   });

--- a/server/repositories/cmsQueries/recentlyAddedContentQuery.js
+++ b/server/repositories/cmsQueries/recentlyAddedContentQuery.js
@@ -14,10 +14,12 @@ class RecentlyAddedContentQuery {
     'published_at',
   ];
 
-  constructor(establishmentName, page, pageLimit, timeStamp) {
+  constructor(establishmentName, page, pageLimit, timeStamp, language) {
     this.establishmentName = establishmentName;
     this.page = page;
     this.limit = pageLimit;
+    this.language = language;
+
     const queryWithoutOffset = new Query()
       .addFields('node--page', RecentlyAddedContentQuery.#TILE_FIELDS)
       .addFields('node--moj_video_item', RecentlyAddedContentQuery.#TILE_FIELDS)
@@ -53,6 +55,7 @@ class RecentlyAddedContentQuery {
       this.establishmentName,
       `limit:${this.limit}`,
       `page:${this.page}`,
+      this.language,
     );
   }
 
@@ -61,7 +64,7 @@ class RecentlyAddedContentQuery {
   }
 
   path() {
-    return `/jsonapi/prison/${this.establishmentName}/node?${this.query}`;
+    return `/${this.language}/jsonapi/prison/${this.establishmentName}/node?${this.query}`;
   }
 
   transform(deserializedResponse, links) {

--- a/server/routes/recentlyAdded.js
+++ b/server/routes/recentlyAdded.js
@@ -5,7 +5,7 @@ const express = require('express');
 const createRecentlyAddedContentRouter = ({ cmsService }) => {
   const router = express.Router();
 
-  const getMostRecentContent = req => {
+  const getMostRecentContent = (req, language) => {
     const { establishmentName } = req.session;
 
     if (!establishmentName) {
@@ -14,23 +14,28 @@ const createRecentlyAddedContentRouter = ({ cmsService }) => {
 
     const { page } = req.query;
 
-    return cmsService.getRecentlyAddedContent(establishmentName, page, 40);
+    return cmsService.getRecentlyAddedContent(
+      establishmentName,
+      language,
+      page,
+      40,
+    );
   };
 
   router.get('/', async (req, res, next) => {
     try {
-      const hubContentData = await getMostRecentContent(req);
+      const { currentLng } = res.locals;
 
-      const language = req.language || i18next.language;
+      const hubContentData = await getMostRecentContent(req, currentLng);
 
       res.render('pages/collections', {
         config: {
           content: true,
         },
-        title: i18next.t('recentlyAdded.title', { lng: language }),
+        title: i18next.t('recentlyAdded.title', { lng: currentLng }),
         data: {
           hubContentData,
-          summary: i18next.t('recentlyAdded.summary', { lng: language }),
+          summary: i18next.t('recentlyAdded.summary', { lng: currentLng }),
           breadcrumbs: [
             { href: '/', text: 'Home' },
             { href: '', text: 'Recently added' },

--- a/server/routes/recentlyAdded.js
+++ b/server/routes/recentlyAdded.js
@@ -37,8 +37,14 @@ const createRecentlyAddedContentRouter = ({ cmsService }) => {
           hubContentData,
           summary: i18next.t('recentlyAdded.summary', { lng: currentLng }),
           breadcrumbs: [
-            { href: '/', text: 'Home' },
-            { href: '', text: 'Recently added' },
+            {
+              href: '/',
+              text: i18next.t('pageNavigation.home', { lng: currentLng }),
+            },
+            {
+              href: '',
+              text: i18next.t('recentlyAdded.title', { lng: currentLng }),
+            },
           ],
         },
       });

--- a/server/routes/topics.js
+++ b/server/routes/topics.js
@@ -13,9 +13,9 @@ const createTopicsRouter = ({ cmsService }) => {
         throw new Error('Could not determine establishment!');
       }
 
-      const language = req.language || i18next.language;
+      const { currentLng } = res.locals;
 
-      const topics = await cmsService.getTopics(establishmentName, language);
+      const topics = await cmsService.getTopics(establishmentName, currentLng);
       // We have to sort the results even though we specified a sort order in
       // the JSON:API request.
       // See https://www.drupal.org/project/drupal/issues/3186834.
@@ -30,7 +30,7 @@ const createTopicsRouter = ({ cmsService }) => {
       });
 
       res.render('pages/topics', {
-        title: i18next.t('home.browseAllTopics', { lng: language }),
+        title: i18next.t('home.browseAllTopics', { lng: currentLng }),
         topics: groupBy(topics, item => item.linkText.charAt(0).toUpperCase()),
         config: {
           content: false,

--- a/server/services/__tests__/cmsService.spec.js
+++ b/server/services/__tests__/cmsService.spec.js
@@ -923,6 +923,7 @@ describe('cms Service', () => {
       jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
       result = await cmsService.getRecentlyAddedContent(
         ESTABLISHMENT_NAME,
+        'en',
         1,
         40,
       );
@@ -943,6 +944,7 @@ describe('cms Service', () => {
           1,
           40,
           getOffsetUnixTime(14),
+          'en',
         ),
       );
     });

--- a/server/services/cms.js
+++ b/server/services/cms.js
@@ -316,7 +316,12 @@ class CmsService {
     return primaryNavigation;
   }
 
-  async getRecentlyAddedContent(establishmentName, page = 1, pageLimit = 4) {
+  async getRecentlyAddedContent(
+    establishmentName,
+    language,
+    page = 1,
+    pageLimit = 4,
+  ) {
     const timeStamp = getOffsetUnixTime(14);
 
     const recentlyAddedContent = await this.#cmsApi.getCache(
@@ -325,6 +330,7 @@ class CmsService {
         page,
         pageLimit,
         timeStamp,
+        language,
       ),
     );
 


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-1167

> If this is an issue, do we have steps to reproduce?

Visit the topics page. It will error.
Visit the recently added page for Cardiff. Switch language to Welsh. The page will remain stubbornly English.

### Intent

> What changes are introduced by this PR that correspond to the above ticket?

Fix language determination for topics and recently added, making it uniform with other routes.
Pass language parameters where appropriate for recently added functionality.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above ticket
- [x] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
