### PR TITLE
LNP-1167: 🐛  fix ajax call for Show More button on Recently Added page.

### DIFF
--- a/server/routes/recentlyAdded.js
+++ b/server/routes/recentlyAdded.js
@@ -56,7 +56,9 @@ const createRecentlyAddedContentRouter = ({ cmsService }) => {
 
   router.get('/json', async (req, res, next) => {
     try {
-      const hubContentData = await getMostRecentContent(req);
+      const { currentLng } = res.locals;
+
+      const hubContentData = await getMostRecentContent(req, currentLng);
 
       res.json(hubContentData);
     } catch (e) {


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

[LNP-1167](https://dsdmoj.atlassian.net/browse/LNP-1167)

> If this is an issue, do we have steps to reproduce?

Navigate to the Recently Added Page.
Scroll to the bottom of the content and click the _Show more_ button.
No more content shall be shown.

Note this is not an issue on production - this is a follow up to the previous LNP-1167 PR which has not yet been deployed. Thus this can only be observed on staging.

### Intent

> What changes are introduced by this PR that correspond to the above ticket?

Adds a language parameter when getting content in response to the AJAX call for the _Show more_ button on this page.

> Would this PR benefit from screenshots?

No.

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above ticket
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [x] Tested in Development


[LNP-1167]: https://dsdmoj.atlassian.net/browse/LNP-1167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ