### PR TITLE
LNP-1217: Add validation to feedback id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
         "pg": "^8.16.3",
         "ramda": "^0.31.3",
         "redis": "^4.7.1",
-        "video.js": "^8.23.3"
+        "video.js": "^8.23.3",
+        "zod": "^4.0.17"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.28.0",
@@ -11908,6 +11909,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.17.tgz",
+      "integrity": "sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "pg": "^8.16.3",
     "ramda": "^0.31.3",
     "redis": "^4.7.1",
-    "video.js": "^8.23.3"
+    "video.js": "^8.23.3",
+    "zod": "^4.0.17"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.28.0",

--- a/server/routes/feedback.js
+++ b/server/routes/feedback.js
@@ -1,28 +1,34 @@
 const express = require('express');
+const z = require('zod');
 const { logger } = require('../utils/logger');
 
 const createFeedbackRouter = ({ feedbackService }) => {
   const router = express.Router();
 
   router.post('/:feedbackId', (req, res) => {
-    const {
-      body,
-      params: { feedbackId } = {},
-      session: { id: sessionId } = {},
-      user,
-    } = req;
+    const { body, session: { id: sessionId } = {}, user } = req;
+
+    const schema = z.object({
+      feedbackId: z.uuid(),
+    });
+
+    const params = schema.safeParse(req.params);
+
+    if (!params.success) {
+      return res.status(400).send();
+    }
 
     logger.info(
       `Prisoner '${
         user?.prisonerId || 'anon'
-      }' leaving feedback: ${feedbackId}`,
+      }' leaving feedback: ${params.data.feedbackId}`,
     );
 
     feedbackService.sendFeedback({
       title: body?.title,
       url: body?.url,
       contentType: body?.contentType,
-      feedbackId,
+      feedbackId: params.data.feedbackId,
       series: body?.series,
       categories: body?.categories,
       topics: body?.topics,


### PR DESCRIPTION
### Context

JIRA ticket: LNP-1217

### Intent

The ID in the `/feedback/:feedbackId` route is now validated, ensuring it is a valid UUID. This stops anything other than UUIDs from being logged/stored.

### Considerations

N/A

### Checklist

- [x] This PR contains **only** changes related to the above ticket
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
