### PR TITLE
LNP-1219: Add CSP rules

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -81,7 +81,7 @@ const createApp = services => {
           defaultSrc: ["'self'"],
           scriptSrc: ["'self'", "'unsafe-inline'", 'www.googletagmanager.com'],
           imgSrc: ["'self'", '*.amazonaws.com'],
-          connectSrc: ['*.google-analytics.com'],
+          connectSrc: ["'self'", '*.google-analytics.com'],
           styleSrc: ["'self'", "'unsafe-inline'"],
         },
       },

--- a/server/app.js
+++ b/server/app.js
@@ -75,7 +75,16 @@ const createApp = services => {
 
   app.use(
     helmet({
-      contentSecurityPolicy: false,
+      contentSecurityPolicy: {
+        useDefaults: false,
+        directives: {
+          defaultSrc: ["'self'"],
+          scriptSrc: ["'self'", "'unsafe-inline'", 'www.googletagmanager.com'],
+          imgSrc: ["'self'", '*.amazonaws.com'],
+          connectSrc: ['*.google-analytics.com'],
+          styleSrc: ["'self'", "'unsafe-inline'"],
+        },
+      },
       crossOriginEmbedderPolicy: false,
       referrerPolicy: { policy: ['no-referrer', 'same-origin'] },
     }),


### PR DESCRIPTION
### Context

LNP-1219: Helmet config missing CSP config - highlighted by Github scan

### Intent

Added a loose content security policy to give some basic protection and fix the issue github code scanning is reporting.

### Considerations

We ideally would want to have a more strict CSP and not allow `unsafe-inline` scripts. However this would require more work such as adding randomly generated nonces to inline scripts and styles.

Question is - do we want to do this now and expand the scope beyond just fixing the scan warning, or do we want to add a new item to the backlog for enhancing the CSP beyond what's covered here?

### Checklist

- [x] This PR contains **only** changes related to the above ticket
- [x] Tests have been added/updated to cover the change (N/A - config change so tested manually)
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
