### PR TITLE
LNP-1222: Updated solitaire - DOM text reinterpreted as HTML

### DIFF
--- a/assets/javascript/games/solitaire/main.js
+++ b/assets/javascript/games/solitaire/main.js
@@ -517,9 +517,9 @@ function bindClick(selectors, double) {
       var dataValue = dataParts[1].replace(replaceNonAlpha, '');
 
       if (dataName === 'played') {
-        $(actualSelector.toString()).each(function() {
+        $(actualSelector).each(function() {
           if ($(this).data(dataName) === dataValue) {
-            $(selector.toString()).on(eventType, select);
+            $(selector).on(eventType, select);
             doBind = false;
             return false;
           }
@@ -527,7 +527,7 @@ function bindClick(selectors, double) {
       }
     }
     if (doBind) {
-      $(selector.toString()).on(eventType, select);
+      $(selector).on(eventType, select);
     }
   });
 }
@@ -585,12 +585,19 @@ function select(event) {
     lastEventTime = time; // cache timestamp
   }
 
+  var suits = ['spade', 'heart', 'diamond', 'club'];
+
   // get variables
   var $e = $(this);
   var rank = $e.attr('data-rank');//e.dataset.rank; // get rank attribute
-  var suit = $e.attr('data-suit');//e.dataset.suit; // get suit attribute
+  var suit = String($e.attr('data-suit'));//e.dataset.suit; // get suit attribute
   var pile = $e.attr('data-pile');//e.dataset.pile; // get pile attribute
   var action = $e.attr('data-action');//e.dataset.action; // get action attribute
+
+  // ensure suit is valid
+  if (!suits.includes(suit)) {
+    return false;
+  }
 
   // create card array
   if (rank && suit) var card = [rank, suit];

--- a/assets/javascript/games/solitaire/main.js
+++ b/assets/javascript/games/solitaire/main.js
@@ -585,19 +585,19 @@ function select(event) {
     lastEventTime = time; // cache timestamp
   }
 
-  var suits = ['spade', 'heart', 'diamond', 'club'];
+  var suits = {
+    spade: 'spade',
+    heart: 'heart',
+    diamond: 'diamond',
+    club: 'club',
+  };
 
   // get variables
   var $e = $(this);
   var rank = $e.attr('data-rank');//e.dataset.rank; // get rank attribute
-  var suit = String($e.attr('data-suit'));//e.dataset.suit; // get suit attribute
+  var suit = suits[$e.attr('data-suit')];//e.dataset.suit; // get suit attribute
   var pile = $e.attr('data-pile');//e.dataset.pile; // get pile attribute
   var action = $e.attr('data-action');//e.dataset.action; // get action attribute
-
-  // ensure suit is valid
-  if (!suits.includes(suit)) {
-    return false;
-  }
 
   // create card array
   if (rank && suit) var card = [rank, suit];

--- a/assets/javascript/games/solitaire/main.js
+++ b/assets/javascript/games/solitaire/main.js
@@ -517,9 +517,9 @@ function bindClick(selectors, double) {
       var dataValue = dataParts[1].replace(replaceNonAlpha, '');
 
       if (dataName === 'played') {
-        $(actualSelector).each(function() {
+        $(actualSelector.toString()).each(function() {
           if ($(this).data(dataName) === dataValue) {
-            $(selector).on(eventType, select);
+            $(selector.toString()).on(eventType, select);
             doBind = false;
             return false;
           }
@@ -527,7 +527,7 @@ function bindClick(selectors, double) {
       }
     }
     if (doBind) {
-      $(selector).on(eventType, select);
+      $(selector.toString()).on(eventType, select);
     }
   });
 }


### PR DESCRIPTION
### Context

LNP-1222 - Github scan warning for DOM text reinterpreted as HTML

### Intent

Updated code to avoid using HTML attributes directly. Fixes scan warning

### Considerations

It took a couple of attempts to find a solution the code scan was happy with but the latest commit is showing the issue as fixed

### Checklist

- [x] This PR contains **only** changes related to the above ticket
- [x] Tests have been added/updated to cover the change (N/A - game code)
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
