### PR TITLE
LNP-1221: Sudoku - Unsafe HTML constructed from library input

### DIFF
--- a/assets/javascript/games/sudoku/sudokuJS.js
+++ b/assets/javascript/games/sudoku/sudokuJS.js
@@ -311,12 +311,11 @@
 		/* buildCandidatesString
 		 * -----------------------------------------------------------------*/
 		var buildCandidatesString = function(candidatesList){
-			var s="";
+			var s = "";
 			for(var i=1; i<boardSize+1; i++){
-				if(contains(candidatesList,i))
-					s+= "<div>"+i+"</div> ";
-				else
-					s+= "<div>&nbsp;</div> ";
+        var div = document.createElement("div");
+        div.textContent = contains(candidatesList,i) ? i : '&nbsp;';
+				s+= div.outerHTML;
 			}
 			return s;
 		};


### PR DESCRIPTION
### Context

LNP-1221: Unsafe HTML constructed from library input

### Intent

Using `.textContent` to ensure rendered HTML is safe as per guidance here:

https://cheatsheetseries.owasp.org/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.html#rule-7-fixing-dom-cross-site-scripting-vulnerabilities

### Considerations

N/A

### Checklist

- [x] This PR contains **only** changes related to the above ticket
- [x] Tests have been added/updated to cover the change (N/A - game code)
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
