### PR TITLE
LNP-1277: 📌  pin jsona to 1.9.7 exact version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "i18next-fs-backend": "^2.6.0",
         "i18next-http-middleware": "^3.8.0",
         "jquery": "^3.7.1",
-        "jsona": "~1.10.1",
+        "jsona": "1.9.7",
         "jsonwebtoken": "^9.0.2",
         "knex": "^3.1.0",
         "mkdirp": "^3.0.1",
@@ -7902,9 +7902,9 @@
       }
     },
     "node_modules/jsona": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/jsona/-/jsona-1.10.1.tgz",
-      "integrity": "sha512-2czP2uLMkPynRexq/F+OLoJGvN7VSUa3pVayJscTXrxVMAdc67Wq/Fb9twjt0drpzbJ6+uz874LDkd8cQBq9xw==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/jsona/-/jsona-1.9.7.tgz",
+      "integrity": "sha512-GC3uTVJfYu0ovWrXmhAC+SqroKyv64dOI8iIWdVKYYn0ef7XNfXEkvkVcmdjfKdIjk6nZrf8VkYsZeSbPF3BGQ==",
       "license": "MIT"
     },
     "node_modules/jsonwebtoken": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "i18next-fs-backend": "^2.6.0",
     "i18next-http-middleware": "^3.8.0",
     "jquery": "^3.7.1",
-    "jsona": "~1.10.1",
+    "jsona": "1.9.7",
     "jsonwebtoken": "^9.0.2",
     "knex": "^3.1.0",
     "mkdirp": "^3.0.1",


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-1277

> If this is an issue, do we have steps to reproduce?

Visit /tags/785
Site will error.
Maximum call stack size exceeded will be logged

### Intent

> What changes are introduced by this PR that correspond to the above ticket?

Revert jsona to known working old version.

> Would this PR benefit from screenshots?

No

### Considerations

> Is there any additional information that would help when reviewing this PR?

No

> Are there any steps required when merging/deploying this PR?

No

### Checklist

- [x] This PR contains **only** changes related to the above ticket
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
