### PR TITLE
LNP-1590: add /info endpoint showing active agencies

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -25,6 +25,7 @@ const routes = require('./routes');
 const { NotFound } = require('./repositories/apiError');
 const setCurrentUser = require('./middleware/setCurrentUser');
 const setReturnUrl = require('./middleware/setReturnUrl');
+const { createInfoRouter } = require('./routes/info');
 
 i18next
   .use(middleware.LanguageDetector)
@@ -181,6 +182,9 @@ const createApp = services => {
 
   // Health end point
   app.use('/health', createHealthRouter(config));
+
+  // info end point
+  app.use('/info', createInfoRouter(establishmentData));
 
   app.use(getEstablishmentFromUrl);
   app.use(configureEstablishment);

--- a/server/content/establishmentData.json
+++ b/server/content/establishmentData.json
@@ -3,145 +3,169 @@
     "name": "bedford",
     "displayName": "HMP Bedford",
     "youth": false,
-    "agencyId": "BFI"
+    "agencyId": "BFI",
+    "active": true
   },
   "792": {
     "name": "berwyn",
     "displayName": "HMP Berwyn",
     "youth": false,
-    "agencyId": "BWI"
+    "agencyId": "BWI",
+    "active": true
   },
   "2428": {
     "name": "bristol",
     "displayName": "HMP Bristol",
     "youth": false,
-    "agencyId": "BLI"
+    "agencyId": "BLI",
+    "active": true
   },
   "2010": {
     "name": "bullingdon",
     "displayName": "HMP Bullingdon",
     "youth": false,
-    "agencyId": "BNI"
+    "agencyId": "BNI",
+    "active": true
   },
   "2095": {
     "name": "cardiff",
     "displayName": "HMP Cardiff",
     "youth": false,
-    "agencyId": "CFI"
+    "agencyId": "CFI",
+    "active": true
   },
   "2001": {
     "name": "chelmsford",
     "displayName": "HMP Chelmsford",
     "youth": false,
-    "agencyId": "CDI"
+    "agencyId": "CDI",
+    "active": true
   },
   "959": {
     "name": "cookhamwood",
     "displayName": "HMP Cookham Wood",
     "youth": false,
-    "agencyId": "CKI"
+    "agencyId": "CKI",
+    "active": true
   },
   "1": {
     "name": "etwoe",
     "displayName": "HMP etwoe",
     "youth": false,
-    "agencyId": "EEE"
+    "agencyId": "EEE",
+    "active": true
   },
   "1074": {
     "name": "erlestoke",
     "displayName": "HMP Erlestoke",
     "youth": false,
-    "agencyId": "EEI"
+    "agencyId": "EEI",
+    "active": true
   },
   "1083": {
     "name": "felthama",
     "displayName": "HMYOI Feltham A",
     "youth": true,
-    "agencyId": "FYI"
+    "agencyId": "FYI",
+    "active": true
   },
   "1084": {
     "name": "felthamb",
     "displayName": "HMYOI Feltham B",
     "youth": true,
-    "agencyId": "FMI"
+    "agencyId": "FMI",
+    "active": true
   },
   "1075": {
     "name": "garth",
     "displayName": "HMP Garth",
     "youth": false,
-    "agencyId": "GHI"
+    "agencyId": "GHI",
+    "active": true
   },
   "1076": {
     "name": "lindholme",
     "displayName": "HMP Lindholme",
     "youth": false,
-    "agencyId": "LHI"
+    "agencyId": "LHI",
+    "active": true
   },
   "1077": {
     "name": "newhall",
     "displayName": "HMPYOI New Hall",
     "youth": false,
-    "agencyId": "NHI"
+    "agencyId": "NHI",
+    "active": true
   },
   "1078": {
     "name": "ranby",
     "displayName": "HMP Ranby",
     "youth": false,
-    "agencyId": "RNI"
+    "agencyId": "RNI",
+    "active": true
   },
   "1079": {
     "name": "stokeheath",
     "displayName": "HMPYOI Stoke Heath",
     "youth": false,
-    "agencyId": "SHI"
+    "agencyId": "SHI",
+    "active": true
   },
   "1080": {
     "name": "styal",
     "displayName": "HMPYOI Styal",
     "youth": false,
-    "agencyId": "STI"
+    "agencyId": "STI",
+    "active": true
   },
   "1081": {
     "name": "swaleside",
     "displayName": "HMP Swaleside",
     "youth": false,
-    "agencyId": "SLI"
+    "agencyId": "SLI",
+    "active": true
   },
   "1082": {
     "name": "themount",
     "displayName": "HMP The Mount",
     "youth": false,
-    "agencyId": "MTI"
+    "agencyId": "MTI",
+    "active": true
   },
   "1603": {
     "name": "thestudio",
     "displayName": "HMPPS The Studio",
-    "agencyId": ""
+    "agencyId": "",
+    "active": true
   },
   "793": {
     "name": "wayland",
     "displayName": "HMP Wayland",
     "youth": false,
-    "agencyId": "WLI"
+    "agencyId": "WLI",
+    "active": true
   },
   "1085": {
     "name": "werrington",
     "displayName": "HMYOI Werrington",
     "youth": false,
-    "agencyId": "WNI"
+    "agencyId": "WNI",
+    "active": true
   },
   "1086": {
     "name": "wetherby",
     "formattedName": "Wetherby",
     "displayName": "HMYOI Wetherby",
     "youth": true,
-    "agencyId": "WYI"
+    "agencyId": "WYI",
+    "active": true
   },
   "1915": {
     "name": "woodhill",
     "formattedName": "Woodhill",
     "displayName": "HMP Woodhill",
     "youth": false,
-    "agencyId": "WHI"
+    "agencyId": "WHI",
+    "active": true
   }
 }

--- a/server/routes/__tests__/info.spec.js
+++ b/server/routes/__tests__/info.spec.js
@@ -1,0 +1,71 @@
+const request = require('supertest');
+const express = require('express');
+
+const { createInfoRouter } = require('../info');
+
+const mockActiveAgency = {
+  "2343": {
+    "name": "bedford",
+    "displayName": "HMP Bedford",
+    "youth": false,
+    "agencyId": "BFI",
+    "active": true
+  },
+}
+
+const mockNoActiveAgencies = {
+    "2343": {
+    "name": "bedford",
+    "displayName": "HMP Bedford",
+    "youth": false,
+    "agencyId": "BFI",
+    "active": false
+  },
+}
+
+
+describe('GET info', () => {
+  let app;
+  beforeEach(() => {
+    app = express();
+  });
+
+  it('returns active agencies on /info', () => {
+    app.use('/info', createInfoRouter(mockActiveAgency));
+    request(app)
+      .get('/info')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .then(res => {
+        expect(res.body).toStrictEqual({
+          activeAgencies: ['BFI']
+        });
+      })
+  });
+
+  it('returns an empty array on /info when there are no active agencies', () => {
+    app.use('/info', createInfoRouter(mockNoActiveAgencies));
+    request(app)
+      .get('/info')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .then(res => {
+        expect(res.body).toStrictEqual({
+          activeAgencies: []
+        });
+      })
+  });
+
+  it('returns an empty array when no establishment data is present', () => {
+    app.use('/info', createInfoRouter({}));
+    request(app)
+      .get('/info')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .then(res => {
+        expect(res.body).toStrictEqual({
+          activeAgencies: []
+        });
+      })
+  });
+});

--- a/server/routes/info.js
+++ b/server/routes/info.js
@@ -1,0 +1,17 @@
+const express = require('express');
+
+const createInfoRouter = (establishmentData) => {
+  const router = express.Router();
+
+  router.get('/', (_, res) => res.json(displayActiveAgencies(establishmentData)));
+  return router;
+};
+
+function displayActiveAgencies(establishmentData) {
+  const activeAgencies = Object.values(establishmentData).filter(establishment => establishment.active).map(establishment => establishment.agencyId)
+  return { activeAgencies };
+}
+
+module.exports = {
+  createInfoRouter,
+};


### PR DESCRIPTION
### Context

> Does this issue have a Jira ticket?

https://dsdmoj.atlassian.net/browse/LNP-1590

### Intent

> What changes are introduced by this PR that correspond to the above card?

This p.r adds an /info endpoint which displays active agencies.

The motivation for using /info instead of /health is that Launchpad defaults to using the /info endpoint to establish which agencies are active for a given service.  Given this codebase will be deprecated - I opted to add an /info endpoint here rather than add code to launchpad that would need to be removed 

> Would this PR benefit from screenshots?

Dev screenshot

<img width="1199" height="719" alt="Screenshot 2026-08-03 at 15 29 18" src="https://github.com/user-attachments/assets/f369884a-108a-4e4f-b3dc-8abade23f0d0" />

### Considerations

> Is there any additional information that would help when reviewing this PR?

**Testing instructions:** go to /info and observe activeAgencies (should be all)

> Are there any steps required when merging/deploying this PR?
N/A
### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development

